### PR TITLE
Add basic assertions to existing unit tests

### DIFF
--- a/test/browser/toys.createRenderer.test.js
+++ b/test/browser/toys.createRenderer.test.js
@@ -24,14 +24,22 @@ describe('createRenderer', () => {
       setDataAttribute,
       addEventListener,
       setTextContent,
-      appendChild
+      appendChild,
     };
     const disposers = [];
     const container = undefined;
     const rows = { foo: 'bar' };
     const textInput = undefined;
     const syncHiddenField = jest.fn();
-    const render = createRenderer(dom, disposers, container, rows, textInput, syncHiddenField);
+    const render = createRenderer(
+      dom,
+      disposers,
+      container,
+      rows,
+      textInput,
+      syncHiddenField
+    );
     render();
+    expect(syncHiddenField).toHaveBeenCalled();
   });
 });

--- a/test/browser/toys.getFetchErrorHandler.test.js
+++ b/test/browser/toys.getFetchErrorHandler.test.js
@@ -14,13 +14,18 @@ describe('getFetchErrorHandler', () => {
       createElement,
       setTextContent,
       appendChild,
-      addWarning
+      addWarning,
     };
 
     const presenterKey = 'text';
     const errorFn = jest.fn();
-    const errorHandler = getFetchErrorHandler({ dom, errorFn }, null, presenterKey);
+    const errorHandler = getFetchErrorHandler(
+      { dom, errorFn },
+      null,
+      presenterKey
+    );
     const error = {};
     errorHandler(error);
+    expect(errorFn).toHaveBeenCalled();
   });
 });

--- a/test/browser/toys.processInputAndSetOutput.test.js
+++ b/test/browser/toys.processInputAndSetOutput.test.js
@@ -26,10 +26,16 @@ describe('processInputAndSetOutput', () => {
     const createElement = jest.fn();
     const setTextContent = jest.fn();
     const appendChild = jest.fn();
-    const dom = { removeAllChildren, createElement, setTextContent, appendChild };
+    const dom = {
+      removeAllChildren,
+      createElement,
+      setTextContent,
+      appendChild,
+    };
     const env = { createEnv, dom, fetchFn };
 
     // Call with all required arguments
     processInputAndSetOutput(elements, processingFunction, env);
+    expect(processingFunction).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- improve several unit tests that previously had no assertions

## Testing
- `npm test` *(fails: Cannot find module 'jest')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683f4b50554c832eae4260de5b7242ba