### PR TITLE
Fix extra space in HTML tag opening

### DIFF
--- a/src/generator/html.js
+++ b/src/generator/html.js
@@ -53,7 +53,10 @@ export const QUOTE = '"';
  * @returns {Array<string>} - Array of tag parts
  */
 export function getOpeningTagParts(name, attributes) {
-  return [TAG_OPEN, name, SPACE, attributes, TAG_CLOSE];
+  if (attributes) {
+    return [TAG_OPEN, name, SPACE, attributes, TAG_CLOSE];
+  }
+  return [TAG_OPEN, name, TAG_CLOSE];
 }
 
 /**
@@ -62,7 +65,7 @@ export function getOpeningTagParts(name, attributes) {
  * @param {string} attributes - The HTML attributes as a string
  * @returns {string} - The opening HTML tag
  */
-export function createOpeningTag(tagName, attributes) {
+export function createOpeningTag(tagName, attributes = '') {
   const tagParts = getOpeningTagParts(tagName, attributes);
   return join(tagParts);
 }

--- a/test/generator/html.test.js
+++ b/test/generator/html.test.js
@@ -1,0 +1,12 @@
+import { describe, test, expect } from '@jest/globals';
+import { createOpeningTag, createTag } from '../../src/generator/html.js';
+
+describe('html utilities', () => {
+  test('createOpeningTag omits space when no attributes', () => {
+    expect(createOpeningTag('div', '')).toBe('<div>');
+  });
+
+  test('createTag handles empty attributes', () => {
+    expect(createTag('span', '', 'x')).toBe('<span>x</span>');
+  });
+});


### PR DESCRIPTION
## Summary
- avoid adding an extra space when building opening HTML tags with no attributes
- add regression tests for html utils

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_683f40ffc624832ea9469824d8681b02