### PR TITLE
Add test for battleship no-touching edge case

### DIFF
--- a/test/toys/2025-05-08/battleshipSolitaireFleet.test.js
+++ b/test/toys/2025-05-08/battleshipSolitaireFleet.test.js
@@ -122,4 +122,10 @@ describe('generateFleet', () => {
     expect(fleet).toHaveProperty('height', 10);
     expect(Array.isArray(fleet.ships)).toBe(true);
   });
+
+  test('noTouching prevents vertical adjacency on narrow board', () => {
+    const cfg = { width: 1, height: 3, ships: [1, 1], noTouching: true };
+    const result = generateFleet(JSON.stringify(cfg), env);
+    expect(JSON.parse(result)).toEqual({ error: 'Failed to generate fleet after max retries' });
+  });
 });


### PR DESCRIPTION
## Summary
- add unit test covering narrow board placement when `noTouching` is true

## Testing
- `npm test` *(fails: cannot find module 'jest')*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684014c07ac4832ea140cfb6f616131f