### PR TITLE
Add tests for markdown constants

### DIFF
--- a/test/utils/index.test.js
+++ b/test/utils/index.test.js
@@ -22,4 +22,11 @@ describe('utils/index', () => {
     expect(utils.CSS_CLASSES).toBeDefined();
     expect(utils.DEFAULT_OPTIONS).toBeDefined();
   });
+
+  test('markdown constants values are correct', () => {
+    expect(utils.MARKDOWN_MARKERS.ASTERISK).toBe('*');
+    expect(utils.HTML_TAGS.EMPHASIS).toBe('em');
+    expect(utils.CSS_CLASSES.CONTAINER).toBe('markdown-container');
+    expect(utils.DEFAULT_OPTIONS.gfm).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- extend utils/index tests to verify markdown constant values

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684018f00e88832ea1c1d6eafd30f7cf