### PR TITLE
Add tests to kill audio-controls mutants

### DIFF
--- a/test/browser/audio-controls.test.js
+++ b/test/browser/audio-controls.test.js
@@ -402,6 +402,27 @@ describe('setupAudio', () => {
     expect(timeElements[0].textContent).toBe('0:00');
   });
 
+  it('uses a span element for the time display', () => {
+    // When
+    setupAudio(dom);
+
+    // Then
+    const timeElement = createdElements.find(el => el.className === 'audio-time');
+    expect(timeElement.tagName).toBe('span');
+  });
+
+  it('attaches a timeupdate listener to the audio element', () => {
+    // When
+    setupAudio(dom);
+
+    // Then
+    expect(dom.addEventListener).toHaveBeenCalledWith(
+      audioElement,
+      'timeupdate',
+      expect.any(Function)
+    );
+  });
+
   it('creates a div container for the controls', () => {
     // When
     setupAudio(dom);


### PR DESCRIPTION
## Summary
- enhance `setupAudio` tests with checks for time display span and timeupdate listener

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684018f1b5a0832ea868c0dd9e5b7b34