### PR TITLE
Add test for deepMerge primitive replacement

### DIFF
--- a/test/browser/data.test.js
+++ b/test/browser/data.test.js
@@ -47,6 +47,13 @@ describe('deepMerge', () => {
     const merged = deepMerge(target, source);
     expect(merged).toEqual({ a: { x: 3 } });
   });
+
+  it('replaces an object value when the source provides a primitive', () => {
+    const target = { a: { x: 1 } };
+    const source = { a: 5 };
+    const merged = deepMerge(target, source);
+    expect(merged).toEqual({ a: 5 });
+  });
 });
 
 describe('fetchAndCacheBlogData', () => {


### PR DESCRIPTION
## Summary
- add regression test for replacing an object value with a primitive in `deepMerge`

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684018f41474832e8c159b3d2a2539ce