### PR TITLE
Add test for audio timeupdate listener

### DIFF
--- a/test/browser/audio-controls.test.js
+++ b/test/browser/audio-controls.test.js
@@ -409,4 +409,16 @@ describe('setupAudio', () => {
     // Then
     expect(createElement).toHaveBeenCalledWith('div');
   });
+
+  it('registers a timeupdate listener on the audio element', () => {
+    // When
+    setupAudio(dom);
+
+    // Then
+    expect(dom.addEventListener).toHaveBeenCalledWith(
+      audioElement,
+      'timeupdate',
+      expect.any(Function)
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- extend audio controls tests to verify the `timeupdate` listener is added

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684018f62520832ea2b20082d20e1abe