### PR TITLE
Add tests for invalid array entries

### DIFF
--- a/test/browser/toys.convertArrayToKeyValueObject.test.js
+++ b/test/browser/toys.convertArrayToKeyValueObject.test.js
@@ -6,12 +6,12 @@ describe('convertArrayToKeyValueObject', () => {
     const input = [
       { key: 'name', value: 'John' },
       { key: 'age', value: 30 },
-      { key: 'city', value: 'New York' }
+      { key: 'city', value: 'New York' },
     ];
     const expected = {
       name: 'John',
       age: 30,
-      city: 'New York'
+      city: 'New York',
     };
     expect(convertArrayToKeyValueObject(input)).toEqual(expected);
   });
@@ -20,12 +20,12 @@ describe('convertArrayToKeyValueObject', () => {
     const input = [
       { key: 'name', value: 'John' },
       { key: 'age', value: null },
-      { key: 'city' } // value is undefined
+      { key: 'city' }, // value is undefined
     ];
     const expected = {
       name: 'John',
       age: '',
-      city: ''
+      city: '',
     };
     expect(convertArrayToKeyValueObject(input)).toEqual(expected);
   });
@@ -35,11 +35,26 @@ describe('convertArrayToKeyValueObject', () => {
       { key: 'name', value: 'John' },
       { value: 'should be skipped' },
       { key: 'city', value: 'New York' },
-      { notKey: 'test', value: 'should be skipped' }
+      { notKey: 'test', value: 'should be skipped' },
     ];
     const expected = {
       name: 'John',
-      city: 'New York'
+      city: 'New York',
+    };
+    expect(convertArrayToKeyValueObject(input)).toEqual(expected);
+  });
+
+  it('should ignore non-object entries in the input array', () => {
+    const input = [
+      { key: 'name', value: 'John' },
+      null,
+      undefined,
+      'string',
+      { key: 'city', value: 'NY' },
+    ];
+    const expected = {
+      name: 'John',
+      city: 'NY',
     };
     expect(convertArrayToKeyValueObject(input)).toEqual(expected);
   });

--- a/test/browser/toys.parseExistingRows.test.js
+++ b/test/browser/toys.parseExistingRows.test.js
@@ -8,7 +8,7 @@ describe('parseExistingRows', () => {
 
   beforeEach(() => {
     mockDom = {
-      getValue: jest.fn()
+      getValue: jest.fn(),
     };
     mockInputElement = {};
   });
@@ -37,7 +37,7 @@ describe('parseExistingRows', () => {
   it('should convert an array of key-value pairs to an object', () => {
     const testArray = [
       { key: 'name', value: 'John' },
-      { key: 'age', value: 30 }
+      { key: 'age', value: 30 },
     ];
     mockDom.getValue.mockReturnValue(JSON.stringify(testArray));
 
@@ -45,7 +45,7 @@ describe('parseExistingRows', () => {
 
     expect(result).toEqual({
       name: 'John',
-      age: 30
+      age: 30,
     });
   });
 
@@ -53,7 +53,7 @@ describe('parseExistingRows', () => {
     const testArray = [
       { key: 'name', value: 'John' },
       { key: 'age', value: null },
-      { key: 'city' } // value is undefined
+      { key: 'city' }, // value is undefined
     ];
     mockDom.getValue.mockReturnValue(JSON.stringify(testArray));
 
@@ -62,7 +62,7 @@ describe('parseExistingRows', () => {
     expect(result).toEqual({
       name: 'John',
       age: '',
-      city: ''
+      city: '',
     });
   });
 
@@ -71,7 +71,7 @@ describe('parseExistingRows', () => {
       { key: 'name', value: 'John' },
       { value: 'should be skipped' },
       { key: 'age', value: 30 },
-      { notKey: 'test', value: 'should be skipped' }
+      { notKey: 'test', value: 'should be skipped' },
     ];
     mockDom.getValue.mockReturnValue(JSON.stringify(testArray));
 
@@ -79,7 +79,25 @@ describe('parseExistingRows', () => {
 
     expect(result).toEqual({
       name: 'John',
-      age: 30
+      age: 30,
+    });
+  });
+
+  it('should ignore non-object items in array input', () => {
+    const testArray = [
+      { key: 'name', value: 'John' },
+      null,
+      undefined,
+      'string',
+      { key: 'age', value: 30 },
+    ];
+    mockDom.getValue.mockReturnValue(JSON.stringify(testArray));
+
+    const result = parseExistingRows(mockDom, mockInputElement);
+
+    expect(result).toEqual({
+      name: 'John',
+      age: 30,
     });
   });
 


### PR DESCRIPTION
## Summary
- extend tests for convertArrayToKeyValueObject to cover non-object entries
- extend parseExistingRows tests for arrays containing null, undefined and other invalid items

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684028971f60832e8d08613b7c6e6212