### PR TITLE
Improve markdown constants test coverage

### DIFF
--- a/test/utils/index.test.js
+++ b/test/utils/index.test.js
@@ -28,5 +28,8 @@ describe('utils/index', () => {
     expect(utils.HTML_TAGS.EMPHASIS).toBe('em');
     expect(utils.CSS_CLASSES.CONTAINER).toBe('markdown-container');
     expect(utils.DEFAULT_OPTIONS.gfm).toBe(true);
+    expect(utils.HTML_TAGS.LINK).toBe('a');
+    expect(utils.CSS_CLASSES.LINK).toBe('markdown-link');
+    expect(utils.DEFAULT_OPTIONS.tables).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- add tests covering `HTML_TAGS.LINK`, `CSS_CLASSES.LINK`, and `DEFAULT_OPTIONS.tables`

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6840289b96f4832ebef081b49733c19e