### PR TITLE
Improve makeHandleHideSpan tests

### DIFF
--- a/test/browser/tags.test.js
+++ b/test/browser/tags.test.js
@@ -104,4 +104,50 @@ describe('makeHandleHideSpan', () => {
     const result = createHideSpan({}, 'some-class');
     expect(result).toBeUndefined();
   });
+
+  it('creates a hide link span and inserts it after the link', () => {
+    const span = {};
+    const hideLink = {};
+    const textNodeOpen = {};
+    const textNodeClose = {};
+    const createElement = jest.fn(tag => (tag === 'span' ? span : hideLink));
+    const addClass = jest.fn();
+    const appendChild = jest.fn();
+    const createTextNode = jest.fn(text =>
+      text === ' (' ? textNodeOpen : textNodeClose
+    );
+    const setTextContent = jest.fn();
+    const addEventListener = jest.fn();
+    const insertBefore = jest.fn();
+
+    const dom = {
+      createElement,
+      addClass,
+      appendChild,
+      createTextNode,
+      setTextContent,
+      addEventListener,
+      insertBefore,
+    };
+
+    const link = { parentNode: {}, nextSibling: {} };
+    const createHideSpan = makeHandleHideSpan(dom);
+    createHideSpan(link, 'tag-test');
+
+    expect(createElement).toHaveBeenCalledWith('span');
+    expect(addClass).toHaveBeenCalledWith(span, 'hide-span');
+    expect(createTextNode).toHaveBeenCalledWith(' (');
+    expect(appendChild).toHaveBeenCalledWith(span, textNodeOpen);
+    expect(createElement).toHaveBeenCalledWith('a');
+    expect(setTextContent).toHaveBeenCalledWith(hideLink, 'hide');
+    expect(addEventListener).toHaveBeenCalledWith(
+      hideLink,
+      'click',
+      expect.any(Function)
+    );
+    expect(appendChild).toHaveBeenCalledWith(span, hideLink);
+    expect(createTextNode).toHaveBeenCalledWith(')');
+    expect(appendChild).toHaveBeenCalledWith(span, textNodeClose);
+    expect(insertBefore).toHaveBeenCalledWith(link.parentNode, span, link.nextSibling);
+  });
 });


### PR DESCRIPTION
## Summary
- cover makeHandleHideSpan DOM operations to kill surviving mutants

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68403e19c87c832e9e97e0e9751b1b24