### PR TITLE
Extend unit tests for mutation survivor

### DIFF
--- a/test/browser/tags.test.js
+++ b/test/browser/tags.test.js
@@ -105,3 +105,24 @@ describe('makeHandleHideSpan', () => {
     expect(result).toBeUndefined();
   });
 });
+
+describe('makeHandleClassName integration', () => {
+  it('uses DOM helpers when the click handler is triggered', () => {
+    let storedHandler;
+    const dom = {
+      addEventListener: (_link, _event, handler) => {
+        storedHandler = handler;
+      },
+      stopDefault: jest.fn(),
+      hasNextSiblingClass: jest.fn(() => true),
+      removeNextSibling: jest.fn(),
+      createHideSpan: jest.fn(),
+    };
+    const link = { parentNode: {} };
+    const handler = makeHandleClassName(dom, link);
+    handler('tag-test');
+    storedHandler('evt');
+    expect(dom.stopDefault).toHaveBeenCalledWith('evt');
+    expect(dom.removeNextSibling).toHaveBeenCalledWith(link);
+  });
+});


### PR DESCRIPTION
## Summary
- test DOM helper usage in makeHandleClassName

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68403e6fdafc832e8ce351fbb2de7af8