### PR TITLE
Add test for audio control spacing

### DIFF
--- a/test/browser/audio-controls.test.js
+++ b/test/browser/audio-controls.test.js
@@ -470,6 +470,17 @@ describe('setupAudio', () => {
     expect(createElement).toHaveBeenCalledWith('div');
   });
 
+  it('inserts spacing between the control buttons', () => {
+    // When
+    setupAudio(dom);
+
+    // Then
+    expect(dom.createTextNode).toHaveBeenCalledTimes(3);
+    dom.createTextNode.mock.calls.forEach(call => {
+      expect(call[0]).toBe(' ');
+    });
+  });
+
   it('wires up event listeners and button hrefs correctly', () => {
     // When
     setupAudio(dom);


### PR DESCRIPTION
## Summary
- check that `setupAudio` adds spacing text nodes between controls

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68403e559a5c832e9c064ec392c15421