### PR TITLE
Add test covering blog state restoration in setData

### DIFF
--- a/test/browser/data.test.js
+++ b/test/browser/data.test.js
@@ -294,6 +294,33 @@ describe('getData, setData, and getDeepStateCopy', () => {
     expect(state.blog).toEqual({ title: 'preserved' });
   });
 
+  it('setData restores existing blog fields when incoming state provides new ones', () => {
+    const fetchPromise = Promise.resolve();
+    const errorObj = new Error('old');
+    state.blogStatus = 'loaded';
+    state.blogError = errorObj;
+    state.blogFetchPromise = fetchPromise;
+    state.blog = { title: 'existing' };
+
+    const incomingState = {
+      temporary: true,
+      blogStatus: 'idle',
+      blogError: new Error('new'),
+      blogFetchPromise: Promise.resolve(),
+      blog: { title: 'incoming' },
+    };
+
+    setData(
+      { desired: incomingState, current: state },
+      { logInfo: logFn, logError: errorFn }
+    );
+
+    expect(state.blogStatus).toBe('loaded');
+    expect(state.blogError).toBe(errorObj);
+    expect(state.blogFetchPromise).toBe(fetchPromise);
+    expect(state.blog).toEqual({ title: 'existing' });
+  });
+
   it('setData logs specific error message when blog is missing', () => {
     expect(() =>
       setData(

--- a/test/generator/html.test.js
+++ b/test/generator/html.test.js
@@ -1,12 +1,28 @@
 import { describe, test, expect } from '@jest/globals';
-import { createOpeningTag, createTag } from '../../src/generator/html.js';
+import {
+  createOpeningTag,
+  createTag,
+  escapeHtml,
+} from '../../src/generator/html.js';
 
 describe('html utilities', () => {
   test('createOpeningTag omits space when no attributes', () => {
-    expect(createOpeningTag('div', '')).toBe('<div>');
+    expect(createOpeningTag('div')).toBe('<div>');
+  });
+
+  test('createOpeningTag adds space when attributes are provided', () => {
+    expect(createOpeningTag('div', 'class="c"')).toBe('<div class="c">');
   });
 
   test('createTag handles empty attributes', () => {
     expect(createTag('span', '', 'x')).toBe('<span>x</span>');
+  });
+
+  test('createTag includes attributes when provided', () => {
+    expect(createTag('p', 'id="a"', 't')).toBe('<p id="a">t</p>');
+  });
+
+  test('escapeHtml replaces special characters', () => {
+    expect(escapeHtml('<div>&"')).toBe('&lt;div&gt;&amp;&quot;');
   });
 });


### PR DESCRIPTION
## Summary
- extend `setData` tests to verify blog fields are restored when incoming state provides its own blog values
- add additional html utilities tests for attribute handling and escaping

## Testing
- `npm run lint` *(passes with warnings)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68403e5a1308832e96386ee6c265eb50