### PR TITLE
Add test to kill mutation in audio controls

### DIFF
--- a/test/browser/audio-controls.test.js
+++ b/test/browser/audio-controls.test.js
@@ -508,4 +508,18 @@ describe('setupAudio', () => {
       expect.any(Function)
     );
   });
+
+  it('creates play, pause and stop buttons as anchor elements', () => {
+    // When
+    setupAudio(dom);
+
+    // Then
+    const playButton = createdElements.find(el => el.textContent === 'PLAY');
+    const pauseButton = createdElements.find(el => el.textContent === 'PAUSE');
+    const stopButton = createdElements.find(el => el.textContent === 'STOP');
+
+    expect(playButton.tagName).toBe('a');
+    expect(pauseButton.tagName).toBe('a');
+    expect(stopButton.tagName).toBe('a');
+  });
 });


### PR DESCRIPTION
## Summary
- extend `audio-controls` tests to verify button elements are anchors

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68403e2e48ac832e86a0d489945876af