### PR TITLE
Kill surviving mutant in toys.parseExistingRows

### DIFF
--- a/test/browser/toys.parseExistingRows.test.js
+++ b/test/browser/toys.parseExistingRows.test.js
@@ -19,9 +19,12 @@ describe('parseExistingRows', () => {
 
   it('should parse an empty input as an empty object', () => {
     mockDom.getValue.mockReturnValue('');
+    const parseSpy = jest.spyOn(JSON, 'parse');
     const result = parseExistingRows(mockDom, mockInputElement);
     expect(result).toEqual({});
     expect(mockDom.getValue).toHaveBeenCalledWith(mockInputElement);
+    expect(parseSpy).toHaveBeenCalledWith('{}');
+    parseSpy.mockRestore();
   });
 
   it('should parse a valid JSON object', () => {


### PR DESCRIPTION
## Summary
- improve tests for `parseExistingRows` to ensure empty input uses `'{}'` as fallback

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6840839447c8832ebbdc084d04f9b3f4