### PR TITLE
Fix surviving mutant in handleDropdownChange

### DIFF
--- a/test/browser/toys.test.js
+++ b/test/browser/toys.test.js
@@ -78,6 +78,27 @@ describe('toys', () => {
       handleDropdownChange(mockDropdown, mockGetData, dom);
     });
 
+    it('gets the enclosing article using the correct selector', () => {
+      const mockArticle = { id: 'article-1' };
+      const dropdown = {
+        value: 'text',
+        parentNode: { querySelector: () => ({}) },
+        closest: jest.fn(() => mockArticle),
+      };
+      const getData = jest.fn(() => ({ output: {} }));
+      const dom = {
+        querySelector: jest.fn(() => ({})),
+        setTextContent: jest.fn(),
+        removeAllChildren: jest.fn(),
+        appendChild: jest.fn(),
+        createElement: jest.fn(() => ({})),
+      };
+
+      handleDropdownChange(dropdown, getData, dom);
+
+      expect(dropdown.closest).toHaveBeenCalledWith('article.entry');
+    });
+
     it('handles dropdown change with empty output data', () => {
       // Mock dropdown with required methods
       const dropdown = {


### PR DESCRIPTION
## Summary
- extend tests for `handleDropdownChange` to verify the selector used for `closest`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6840839c2f7c832eacf4eb5d3fca331f