### PR TITLE
Add test to cover ensureNumberInput insertion

### DIFF
--- a/test/browser/toys.ensureNumberInput.test.js
+++ b/test/browser/toys.ensureNumberInput.test.js
@@ -8,7 +8,7 @@ describe('ensureNumberInput', () => {
     const mockDom = {
       querySelector: jest.fn(() => mockNumberInput),
       getTargetValue: jest.fn(),
-      setValue: jest.fn()
+      setValue: jest.fn(),
     };
     const mockContainer = {};
 
@@ -16,6 +16,40 @@ describe('ensureNumberInput', () => {
     const result = ensureNumberInput(mockContainer, { value: '42' }, mockDom);
 
     // Assert
+    expect(mockDom.querySelector).toHaveBeenCalledWith(
+      mockContainer,
+      'input[type="number"]'
+    );
     expect(result).toBe(mockNumberInput);
+  });
+
+  test('creates and inserts a number input when one does not exist', () => {
+    // Arrange
+    const nextSibling = {};
+    const createdInput = {};
+    const mockContainer = { insertBefore: jest.fn() };
+    const mockDom = {
+      querySelector: jest.fn(() => null),
+      createElement: jest.fn(() => createdInput),
+      setType: jest.fn(),
+      setValue: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      getNextSibling: jest.fn(() => nextSibling),
+    };
+    const textInput = { value: '42' };
+
+    // Act
+    const result = ensureNumberInput(mockContainer, textInput, mockDom);
+
+    // Assert
+    expect(mockDom.createElement).toHaveBeenCalledWith('input');
+    expect(mockDom.setType).toHaveBeenCalledWith(createdInput, 'number');
+    expect(mockDom.getNextSibling).toHaveBeenCalledWith(textInput);
+    expect(mockContainer.insertBefore).toHaveBeenCalledWith(
+      createdInput,
+      nextSibling
+    );
+    expect(result).toBe(createdInput);
   });
 });


### PR DESCRIPTION
## Summary
- extend `ensureNumberInput` tests to verify selector usage
- add coverage for insertion of new number input

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684086f43390832eb3f50c8832abdd87