### PR TITLE
Add test to kill convertArrayToKeyValueObject mutant

### DIFF
--- a/test/browser/toys.convertArrayToKeyValueObject.test.js
+++ b/test/browser/toys.convertArrayToKeyValueObject.test.js
@@ -59,6 +59,19 @@ describe('convertArrayToKeyValueObject', () => {
     expect(convertArrayToKeyValueObject(input)).toEqual(expected);
   });
 
+  it('should skip null entries in the input array', () => {
+    const input = [
+      { key: 'name', value: 'John' },
+      null,
+      { key: 'age', value: 30 },
+    ];
+    const expected = {
+      name: 'John',
+      age: 30,
+    };
+    expect(convertArrayToKeyValueObject(input)).toEqual(expected);
+  });
+
   it('should return an empty object for an empty array', () => {
     expect(convertArrayToKeyValueObject([])).toEqual({});
   });


### PR DESCRIPTION
## Summary
- add a new unit test ensuring `convertArrayToKeyValueObject` skips null entries

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684086f81164832e8d8102b9d5717e78