### PR TITLE
Add test for play/pause/stop button elements

### DIFF
--- a/test/browser/audio-controls.test.js
+++ b/test/browser/audio-controls.test.js
@@ -520,6 +520,20 @@ describe('setupAudio', () => {
     );
   });
 
+  it('creates play, pause and stop buttons as anchor elements', () => {
+    // When
+    setupAudio(dom);
+
+    // Then
+    const playButton = createdElements.find(el => el.textContent === 'PLAY');
+    const pauseButton = createdElements.find(el => el.textContent === 'PAUSE');
+    const stopButton = createdElements.find(el => el.textContent === 'STOP');
+
+    expect(playButton.tagName).toBe('a');
+    expect(pauseButton.tagName).toBe('a');
+    expect(stopButton.tagName).toBe('a');
+  });
+
   it('inserts spaces between control buttons', () => {
     // When
     setupAudio(dom);

--- a/test/browser/tags.test.js
+++ b/test/browser/tags.test.js
@@ -31,6 +31,19 @@ describe('hideArticlesByClass', () => {
     expect(dom.hide).toHaveBeenCalledTimes(1);
     expect(dom.hide).toHaveBeenCalledWith(article1);
   });
+
+  it('calls getElementsByTagName with "article"', () => {
+    const getElementsByTagName = jest.fn(() => []);
+    const dom = {
+      getElementsByTagName,
+      hasClass: () => false,
+      hide: jest.fn(),
+    };
+
+    hideArticlesByClass('any-class', dom);
+
+    expect(getElementsByTagName).toHaveBeenCalledWith('article');
+  });
 });
 
 describe('toggleHideLink', () => {


### PR DESCRIPTION
## Summary
- verify the play, pause and stop buttons created by `setupAudio` are `<a>` elements
- ensure `hideArticlesByClass` calls `getElementsByTagName` with `article`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68408700a988832e8cfdf4b48f0fd8a0