### PR TITLE
Add test for setData error message

### DIFF
--- a/test/browser/data.test.js
+++ b/test/browser/data.test.js
@@ -351,6 +351,21 @@ describe('getData, setData, and getDeepStateCopy', () => {
     );
   });
 
+  it("setData throws an error with the expected message when 'temporary' is missing", () => {
+    const state = { blog: { title: 'preserved' } };
+    const logFn = jest.fn();
+    const errorFn = jest.fn();
+    const invalidState = { foo: 1 };
+    expect(() =>
+      setData(
+        { desired: invalidState, current: state },
+        { logInfo: logFn, logError: errorFn }
+      )
+    ).toThrow(
+      "setData requires an object with at least a 'temporary' property."
+    );
+  });
+
   it('setData throws and logs error if incoming state is null', () => {
     const state = { blog: { title: 'preserved' } };
     const logFn = jest.fn();


### PR DESCRIPTION
## Summary
- add a test verifying the specific error message from `setData` when the `temporary` property is missing

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68408873352c832ea92e0bb3239390b9