### PR TITLE
Add hide-span coverage

### DIFF
--- a/test/browser/tags.makeHandleHideSpan.test.js
+++ b/test/browser/tags.makeHandleHideSpan.test.js
@@ -9,8 +9,12 @@ describe('makeHandleHideSpan', () => {
     const textNode2 = {};
     const dom = {
       createElement: jest.fn(tag => {
-        if (tag === 'span') {return spanEl;}
-        if (tag === 'a') {return hideLinkEl;}
+        if (tag === 'span') {
+          return spanEl;
+        }
+        if (tag === 'a') {
+          return hideLinkEl;
+        }
         return {};
       }),
       addClass: jest.fn(),
@@ -32,10 +36,15 @@ describe('makeHandleHideSpan', () => {
       'click',
       expect.any(Function)
     );
+    expect(dom.createTextNode).toHaveBeenCalledWith(' (');
+    expect(dom.appendChild).toHaveBeenCalledWith(spanEl, textNode1);
     expect(dom.insertBefore).toHaveBeenCalledWith(
       link.parentNode,
       spanEl,
       link.nextSibling
     );
+    expect(dom.createTextNode).toHaveBeenCalledWith(')');
+    expect(dom.appendChild).toHaveBeenCalledWith(spanEl, hideLinkEl);
+    expect(dom.appendChild).toHaveBeenCalledWith(spanEl, textNode2);
   });
 });


### PR DESCRIPTION
## Summary
- expand tests for `makeHandleHideSpan` to assert DOM text nodes and append calls

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68408873c0dc832e87c4fb4e908fbd17