### PR TITLE
Improve data validation test coverage

### DIFF
--- a/test/browser/data.test.js
+++ b/test/browser/data.test.js
@@ -327,7 +327,7 @@ describe('getData, setData, and getDeepStateCopy', () => {
         { desired: {}, current: state },
         { logInfo: logFn, logError: errorFn }
       )
-    ).toThrow();
+    ).toThrow("setData requires an object with at least a 'temporary' property.");
     expect(errorFn).toHaveBeenCalledWith(
       'setData received invalid data structure:',
       {}


### PR DESCRIPTION
## Summary
- extend `setData` validation test to assert the thrown error message

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684088749e70832ea802caddf0dd6afb