### PR TITLE
Add missing test for audio control button elements

### DIFF
--- a/test/browser/audio-controls.test.js
+++ b/test/browser/audio-controls.test.js
@@ -470,6 +470,16 @@ describe('setupAudio', () => {
     expect(createElement).toHaveBeenCalledWith('div');
   });
 
+  it('creates anchor elements for control buttons', () => {
+    // When
+    setupAudio(dom);
+
+    // Then
+    expect(createElement).toHaveBeenNthCalledWith(3, 'a');
+    expect(createElement).toHaveBeenNthCalledWith(4, 'a');
+    expect(createElement).toHaveBeenNthCalledWith(5, 'a');
+  });
+
   it('inserts spacing between the control buttons', () => {
     // When
     setupAudio(dom);

--- a/test/browser/tags.test.js
+++ b/test/browser/tags.test.js
@@ -1,13 +1,18 @@
 import { jest } from '@jest/globals';
-import { hideArticlesByClass, toggleHideLink, makeHandleClassName, makeHandleLink, makeHandleHideSpan } from '../../src/browser/tags.js';
-
+import {
+  hideArticlesByClass,
+  toggleHideLink,
+  makeHandleClassName,
+  makeHandleLink,
+  makeHandleHideSpan,
+} from '../../src/browser/tags.js';
 
 describe('hideArticlesByClass', () => {
   it('does not throw when given a class and no matching elements', () => {
     const dom = {
       getElementsByTagName: () => [],
       hasClass: () => false,
-      hide: () => {}
+      hide: () => {},
     };
 
     expect(() => {
@@ -22,8 +27,9 @@ describe('hideArticlesByClass', () => {
 
     const dom = {
       getElementsByTagName: () => articles,
-      hasClass: (el, className) => el === article1 && className === 'target-class',
-      hide: jest.fn()
+      hasClass: (el, className) =>
+        el === article1 && className === 'target-class',
+      hide: jest.fn(),
     };
 
     hideArticlesByClass('target-class', dom);
@@ -39,7 +45,7 @@ describe('toggleHideLink', () => {
     const dom = {
       hasNextSiblingClass: () => true,
       removeNextSibling: jest.fn(),
-      createHideSpan: jest.fn()
+      createHideSpan: jest.fn(),
     };
 
     toggleHideLink(link, 'some-class', dom);
@@ -53,7 +59,7 @@ describe('toggleHideLink', () => {
     const dom = {
       hasNextSiblingClass: () => false,
       removeNextSibling: jest.fn(),
-      createHideSpan: jest.fn()
+      createHideSpan: jest.fn(),
     };
 
     toggleHideLink(link, 'some-class', dom);
@@ -76,7 +82,27 @@ describe('makeHandleClassName', () => {
     const link = {};
     const handler = makeHandleClassName(dom, link);
     handler('tag-sample');
-    expect(addEventListener).toHaveBeenCalledWith(link, 'click', expect.any(Function));
+    expect(addEventListener).toHaveBeenCalledWith(
+      link,
+      'click',
+      expect.any(Function)
+    );
+  });
+  it('triggers the stored handler without errors', () => {
+    let storedHandler;
+    const dom = {
+      addEventListener: (_l, _e, h) => {
+        storedHandler = h;
+      },
+      stopDefault: jest.fn(),
+      hasNextSiblingClass: jest.fn(() => true),
+      removeNextSibling: jest.fn(),
+    };
+    const link = { parentNode: {} };
+    const handler = makeHandleClassName(dom, link);
+    handler('tag-fire');
+    expect(() => storedHandler('evt')).not.toThrow();
+    expect(dom.stopDefault).toHaveBeenCalledWith('evt');
   });
 });
 
@@ -148,7 +174,11 @@ describe('makeHandleHideSpan', () => {
     expect(appendChild).toHaveBeenCalledWith(span, hideLink);
     expect(createTextNode).toHaveBeenCalledWith(')');
     expect(appendChild).toHaveBeenCalledWith(span, textNodeClose);
-    expect(insertBefore).toHaveBeenCalledWith(link.parentNode, span, link.nextSibling);
+    expect(insertBefore).toHaveBeenCalledWith(
+      link.parentNode,
+      span,
+      link.nextSibling
+    );
   });
 });
 

--- a/test/utils/index.test.js
+++ b/test/utils/index.test.js
@@ -57,4 +57,17 @@ describe('utils/index', () => {
     expect(utils.HTML_TAGS.PARAGRAPH).toBe('p');
     expect(utils.HTML_TAGS.BLOCKQUOTE).toBe('blockquote');
   });
+
+  test('remaining default options are correct', () => {
+    expect(utils.DEFAULT_OPTIONS.breaks).toBe(false);
+    expect(utils.DEFAULT_OPTIONS.pedantic).toBe(false);
+    expect(utils.DEFAULT_OPTIONS.sanitize).toBe(false);
+    expect(utils.DEFAULT_OPTIONS.smartLists).toBe(true);
+    expect(utils.DEFAULT_OPTIONS.smartypants).toBe(false);
+    expect(utils.DEFAULT_OPTIONS.xhtml).toBe(false);
+    expect(utils.DEFAULT_OPTIONS.langPrefix).toBe('language-');
+    expect(utils.DEFAULT_OPTIONS.headerIds).toBe(true);
+    expect(utils.DEFAULT_OPTIONS.headerPrefix).toBe('');
+    expect(utils.DEFAULT_OPTIONS.mangle).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- verify that remaining markdown defaults are exported correctly
- ensure tag handlers use stored DOM listeners without errors

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684087033a94832ea23e417f4fb656f1