### PR TITLE
Add test for setData error message

### DIFF
--- a/test/browser/data.test.js
+++ b/test/browser/data.test.js
@@ -334,6 +334,15 @@ describe('getData, setData, and getDeepStateCopy', () => {
     );
   });
 
+  it("setData throws a descriptive error when blog data is missing", () => {
+    expect(() =>
+      setData(
+        { desired: {}, current: state },
+        { logInfo: logFn, logError: errorFn }
+      )
+    ).toThrow("setData requires an object with at least a 'temporary' property.");
+  });
+
   it('setData throws and logs error if incoming state is object but lacks temporary property', () => {
     const state = { blog: { title: 'preserved' } };
     const logFn = jest.fn();


### PR DESCRIPTION
## Summary
- check that setData throws the documented message when blog data is missing

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68408875b418832e96293a40b536b47b