### PR TITLE
Add test for restoreBlogState

### DIFF
--- a/test/browser/data.restoreBlogState.test.js
+++ b/test/browser/data.restoreBlogState.test.js
@@ -1,0 +1,33 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { setData } from '../../src/browser/data.js';
+
+describe('restoreBlogState via setData', () => {
+  it('restores blog fetch fields when incoming state provides them', () => {
+    const oldError = new Error('old');
+    const oldPromise = Promise.resolve('old');
+    const state = {
+      blogStatus: 'loaded',
+      blogError: oldError,
+      blogFetchPromise: oldPromise,
+      blog: { title: 'existing' },
+    };
+
+    const incomingState = {
+      temporary: true,
+      blogStatus: 'idle',
+      blogError: new Error('new'),
+      blogFetchPromise: Promise.resolve('new'),
+      blog: { title: 'incoming' },
+    };
+
+    setData(
+      { desired: incomingState, current: state },
+      { logInfo: jest.fn(), logError: jest.fn() }
+    );
+
+    expect(state.blogStatus).toBe('loaded');
+    expect(state.blogError).toBe(oldError);
+    expect(state.blogFetchPromise).toBe(oldPromise);
+    expect(state.blog).toEqual({ title: 'existing' });
+  });
+});


### PR DESCRIPTION
## Summary
- add regression test covering restoreBlogState via `setData`

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68408b3a4184832ea22117a5d93f6e39