### PR TITLE
Add test for markdown options

### DIFF
--- a/test/utils/index.test.js
+++ b/test/utils/index.test.js
@@ -31,6 +31,7 @@ describe('utils/index', () => {
     expect(utils.HTML_TAGS.LINK).toBe('a');
     expect(utils.CSS_CLASSES.LINK).toBe('markdown-link');
     expect(utils.DEFAULT_OPTIONS.tables).toBe(true);
+    expect(utils.DEFAULT_OPTIONS.langPrefix).toBe('language-');
   });
 
   test('markdown marker characters are correct', () => {


### PR DESCRIPTION
## Summary
- increase test coverage for markdown constants

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68408b45ac00832ea258145d3f221c43