### PR TITLE
Improve test coverage for initialization

### DIFF
--- a/test/browser/toys.test.js
+++ b/test/browser/toys.test.js
@@ -644,6 +644,44 @@ describe('toys', () => {
       );
     });
 
+    it('disables input and submit button during initialization', () => {
+      const globalState = {};
+      const createEnvFn = () => ({});
+      const errorFn = jest.fn();
+      const fetchFn = jest.fn();
+      const dom = {
+        removeAllChildren: jest.fn(),
+        createElement: jest.fn(() => ({ textContent: '' })),
+        stopDefault: jest.fn(),
+        addWarning: jest.fn(),
+        addWarningFn: jest.fn(),
+        addEventListener: jest.fn(),
+        removeChild: jest.fn(),
+        appendChild: jest.fn(),
+        querySelector,
+        setTextContent: jest.fn(),
+        removeWarning: jest.fn(),
+        enable: jest.fn(),
+        contains: () => true,
+      };
+      const processingFunction = jest.fn();
+      const config = {
+        globalState,
+        createEnvFn,
+        errorFn,
+        fetchFn,
+        dom,
+        loggers: {
+          logInfo: jest.fn(),
+          logError: jest.fn(),
+          logWarning: jest.fn(),
+        },
+      };
+      initializeInteractiveComponent(article, processingFunction, config);
+      expect(inputElement.disabled).toBe(true);
+      expect(submitButton.disabled).toBe(true);
+    });
+
     it('does not call handleSubmit when a non-Enter key is pressed', () => {
       const inputElement = { value: 'test', disabled: false };
       const submitButton = { disabled: false };


### PR DESCRIPTION
## Summary
- add regression test ensuring initializeInteractiveComponent disables input and submit button

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68408ff22a48832ea20aa50bc2a54bdb