### PR TITLE
Add test to handle whitespace input in get()

### DIFF
--- a/test/toys/2025-03-29/get.test.js
+++ b/test/toys/2025-03-29/get.test.js
@@ -115,6 +115,12 @@ describe('get function with path traversal', () => {
     expect(mockGetData).toHaveBeenCalledTimes(1);
   });
 
+  test('should treat whitespace-only input as empty', () => {
+    mockGetData.mockReturnValue(testData);
+    expect(get('   ', env)).toBe(JSON.stringify(testData));
+    expect(mockGetData).toHaveBeenCalledTimes(1);
+  });
+
   test('should handle numeric string keys in object', () => {
     const objWithNumericKeys = { "2025": { value: "future" } };
     mockGetData.mockReturnValue(objWithNumericKeys);


### PR DESCRIPTION
## Summary
- add unit test for `get` to handle whitespace-only input

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68408fe71e80832ea0a51593b2e6b960