### PR TITLE
Add test for dropdown article id

### DIFF
--- a/test/browser/toys.test.js
+++ b/test/browser/toys.test.js
@@ -196,6 +196,35 @@ describe('toys', () => {
 
       expect(parent.child.textContent).toBe('');
     });
+
+    it('uses the closest article id to look up and display output', () => {
+      const parent = { child: null, querySelector: jest.fn() };
+      parent.querySelector.mockReturnValue(parent);
+      const dropdown = {
+        value: 'text',
+        closest: jest.fn(() => ({ id: 'post-42' })),
+        parentNode: parent,
+      };
+      const getData = jest.fn(() => ({ output: { 'post-42': 'answer' } }));
+      const dom = {
+        querySelector: (el, selector) => el.querySelector(selector),
+        removeAllChildren: jest.fn(p => {
+          p.child = null;
+        }),
+        appendChild: jest.fn((p, c) => {
+          p.child = c;
+        }),
+        createElement: jest.fn(() => ({ textContent: '' })),
+        setTextContent: jest.fn((el, txt) => {
+          el.textContent = txt;
+        }),
+      };
+
+      handleDropdownChange(dropdown, getData, dom);
+
+      expect(dropdown.closest).toHaveBeenCalledWith('article.entry');
+      expect(parent.child.textContent).toBe('answer');
+    });
   });
 
   let entry;


### PR DESCRIPTION
## Summary
- extend `handleDropdownChange` tests to verify article id lookup

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68408fe61d2c832e9367e88d5f10aece