### PR TITLE
Add test for dropdown output id

### DIFF
--- a/test/browser/toys.test.js
+++ b/test/browser/toys.test.js
@@ -196,6 +196,35 @@ describe('toys', () => {
 
       expect(parent.child.textContent).toBe('');
     });
+
+    it('uses the article id to set the correct output text', () => {
+      const parent = { child: null, querySelector: jest.fn() };
+      parent.querySelector.mockReturnValue(parent);
+      const dropdown = {
+        value: 'text',
+        closest: jest.fn(() => ({ id: 'post-99' })),
+        parentNode: parent,
+      };
+      const getData = jest.fn(() => ({ output: { 'post-99': 'result' } }));
+      const dom = {
+        querySelector: (el, selector) => el.querySelector(selector),
+        removeAllChildren: jest.fn(p => {
+          p.child = null;
+        }),
+        appendChild: jest.fn((p, c) => {
+          p.child = c;
+        }),
+        createElement: jest.fn(() => ({ textContent: '' })),
+        setTextContent: jest.fn((el, txt) => {
+          el.textContent = txt;
+        }),
+      };
+
+      handleDropdownChange(dropdown, getData, dom);
+
+      expect(dropdown.closest).toHaveBeenCalledWith('article.entry');
+      expect(parent.child.textContent).toBe('result');
+    });
   });
 
   let entry;

--- a/test/toys/2025-05-11/battleshipSolitaireClues.test.js
+++ b/test/toys/2025-05-11/battleshipSolitaireClues.test.js
@@ -6,7 +6,7 @@ import { generateClues } from '../../../src/toys/2025-05-11/battleshipSolitaireC
 describe('generateClues', () => {
   it('returns an error for invalid JSON', () => {
     const output = JSON.parse(generateClues('not json'));
-    expect(output).toHaveProperty('error');
+    expect(output).toHaveProperty('error', 'Invalid input JSON');
   });
 
   it('returns an error for an invalid fleet structure', () => {
@@ -20,8 +20,8 @@ describe('generateClues', () => {
       width: 5,
       height: 5,
       ships: [
-        { start: { x: 1, y: 2 }, length: 3, direction: 'H' } // cells (1,2), (2,2), (3,2)
-      ]
+        { start: { x: 1, y: 2 }, length: 3, direction: 'H' }, // cells (1,2), (2,2), (3,2)
+      ],
     };
     const expectedRow = [0, 0, 3, 0, 0];
     const expectedCol = [0, 1, 1, 1, 0];
@@ -37,8 +37,8 @@ describe('generateClues', () => {
       height: 4,
       ships: [
         { start: { x: 0, y: 0 }, length: 4, direction: 'V' }, // (0,0)–(0,3)
-        { start: { x: 1, y: 1 }, length: 2, direction: 'H' } // (1,1), (2,1)
-      ]
+        { start: { x: 1, y: 1 }, length: 2, direction: 'H' }, // (1,1), (2,1)
+      ],
     };
     const expectedRow = [1, 3, 1, 1]; // rows 0–3
     const expectedCol = [4, 1, 1, 0]; // cols 0–3
@@ -53,11 +53,27 @@ describe('generateClues', () => {
       width: 3,
       height: 3,
       ships: [
-        { start: { x: 2, y: 2 }, length: 2, direction: 'H' } // (2,2) in, (3,2) out
-      ]
+        { start: { x: 2, y: 2 }, length: 2, direction: 'H' }, // (2,2) in, (3,2) out
+      ],
     };
     const expectedRow = [0, 0, 1];
     const expectedCol = [0, 0, 1];
+
+    const output = JSON.parse(generateClues(JSON.stringify(fleet)));
+    expect(output.rowClues).toEqual(expectedRow);
+    expect(output.colClues).toEqual(expectedCol);
+  });
+
+  it('ignores vertical ship cells that exceed board height', () => {
+    const fleet = {
+      width: 3,
+      height: 3,
+      ships: [
+        { start: { x: 1, y: 2 }, length: 2, direction: 'V' }, // (1,2) in, (1,3) out
+      ],
+    };
+    const expectedRow = [0, 0, 1];
+    const expectedCol = [0, 1, 0];
 
     const output = JSON.parse(generateClues(JSON.stringify(fleet)));
     expect(output.rowClues).toEqual(expectedRow);


### PR DESCRIPTION
## Summary
- ensure toys.handleDropdownChange uses the dropdown article id when setting text
- verify generateClues returns specific error for bad JSON and ignore vertical overflow

## Testing
- `npm run lint` *(warns: 66 warnings)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68408c1607d8832ea959e1be23a821c0