### PR TITLE
Add coverage for markdown default options

### DIFF
--- a/test/utils/index.test.js
+++ b/test/utils/index.test.js
@@ -58,4 +58,20 @@ describe('utils/index', () => {
     expect(utils.HTML_TAGS.PARAGRAPH).toBe('p');
     expect(utils.HTML_TAGS.BLOCKQUOTE).toBe('blockquote');
   });
+
+  test('additional default option values are correct', () => {
+    expect(utils.DEFAULT_OPTIONS.breaks).toBe(false);
+    expect(utils.DEFAULT_OPTIONS.pedantic).toBe(false);
+    expect(utils.DEFAULT_OPTIONS.sanitize).toBe(false);
+    expect(utils.DEFAULT_OPTIONS.smartLists).toBe(true);
+    expect(utils.DEFAULT_OPTIONS.smartypants).toBe(false);
+    expect(utils.DEFAULT_OPTIONS.xhtml).toBe(false);
+    expect(utils.DEFAULT_OPTIONS.headerIds).toBe(true);
+    expect(utils.DEFAULT_OPTIONS.headerPrefix).toBe('');
+    expect(utils.DEFAULT_OPTIONS.mangle).toBe(true);
+    expect(utils.DEFAULT_OPTIONS.highlight).toBeNull();
+    expect(utils.DEFAULT_OPTIONS.baseUrl).toBeNull();
+    expect(utils.DEFAULT_OPTIONS.linkTarget).toBeNull();
+    expect(utils.DEFAULT_OPTIONS.renderer).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- improve utils tests to assert markdown parsing option defaults

## Testing
- `npm install`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68408fe99014832e82c21a57cc0f2e94