### PR TITLE
Add test for undefined output in handleDropdownChange

### DIFF
--- a/test/browser/toys.test.js
+++ b/test/browser/toys.test.js
@@ -197,6 +197,33 @@ describe('toys', () => {
       expect(parent.child.textContent).toBe('');
     });
 
+    it('defaults to empty text when output is undefined', () => {
+      const parent = { child: null, querySelector: jest.fn() };
+      parent.querySelector.mockReturnValue(parent);
+      const dropdown = {
+        value: 'text',
+        closest: jest.fn(() => ({ id: 'post-undef' })),
+        parentNode: parent,
+      };
+      const getData = jest.fn(() => ({}));
+      const dom = {
+        querySelector: (el, selector) => el.querySelector(selector),
+        removeAllChildren: jest.fn(p => {
+          p.child = null;
+        }),
+        appendChild: jest.fn((p, c) => {
+          p.child = c;
+        }),
+        createElement: jest.fn(() => ({ textContent: '' })),
+        setTextContent: jest.fn((el, txt) => {
+          el.textContent = txt;
+        }),
+      };
+
+      expect(() => handleDropdownChange(dropdown, getData, dom)).not.toThrow();
+      expect(parent.child.textContent).toBe('');
+    });
+
     it('uses the closest article id to look up and display output', () => {
       const parent = { child: null, querySelector: jest.fn() };
       parent.querySelector.mockReturnValue(parent);


### PR DESCRIPTION
## Summary
- extend `handleDropdownChange` tests to handle undefined output

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6840969a078c832e83bbbc7f669627f0