### PR TITLE
Add test to kill handleDropdownChange mutant

### DIFF
--- a/test/browser/toys.test.js
+++ b/test/browser/toys.test.js
@@ -197,6 +197,34 @@ describe('toys', () => {
       expect(parent.child.textContent).toBe('');
     });
 
+    it('handles when output property is missing', () => {
+      const parent = { child: null, querySelector: jest.fn() };
+      parent.querySelector.mockReturnValue(parent);
+      const dropdown = {
+        value: 'text',
+        closest: jest.fn(() => ({ id: 'post-3' })),
+        parentNode: parent,
+      };
+      const getData = jest.fn(() => ({}));
+      const dom = {
+        querySelector: (el, selector) => el.querySelector(selector),
+        removeAllChildren: jest.fn(p => {
+          p.child = null;
+        }),
+        appendChild: jest.fn((p, c) => {
+          p.child = c;
+        }),
+        createElement: jest.fn(() => ({ textContent: '' })),
+        setTextContent: jest.fn((el, txt) => {
+          el.textContent = txt;
+        }),
+      };
+
+      handleDropdownChange(dropdown, getData, dom);
+
+      expect(parent.child.textContent).toBe('');
+    });
+
     it('uses the closest article id to look up and display output', () => {
       const parent = { child: null, querySelector: jest.fn() };
       parent.querySelector.mockReturnValue(parent);


### PR DESCRIPTION
## Summary
- extend `handleDropdownChange` tests to cover missing `output`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68409696f3c0832e8d8ba7b127fcfe3c