### PR TITLE
Add missing output test

### DIFF
--- a/test/browser/toys.test.js
+++ b/test/browser/toys.test.js
@@ -197,6 +197,33 @@ describe('toys', () => {
       expect(parent.child.textContent).toBe('');
     });
 
+    it('handles missing output property without throwing', () => {
+      const parent = { child: null, querySelector: jest.fn() };
+      parent.querySelector.mockReturnValue(parent);
+      const dropdown = {
+        value: 'text',
+        closest: jest.fn(() => ({ id: 'post-3' })),
+        parentNode: parent,
+      };
+      const getData = jest.fn(() => ({}));
+      const dom = {
+        querySelector: (el, selector) => el.querySelector(selector),
+        removeAllChildren: jest.fn(p => {
+          p.child = null;
+        }),
+        appendChild: jest.fn((p, c) => {
+          p.child = c;
+        }),
+        createElement: jest.fn(() => ({ textContent: '' })),
+        setTextContent: jest.fn((el, txt) => {
+          el.textContent = txt;
+        }),
+      };
+
+      expect(() => handleDropdownChange(dropdown, getData, dom)).not.toThrow();
+      expect(parent.child.textContent).toBe('');
+    });
+
     it('uses the closest article id to look up and display output', () => {
       const parent = { child: null, querySelector: jest.fn() };
       parent.querySelector.mockReturnValue(parent);


### PR DESCRIPTION
## Summary
- extend `handleDropdownChange` tests to cover missing `output` property

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684096916694832e91122a3591b4c46a