### PR TITLE
Add test for non-string pre element input

### DIFF
--- a/test/presenters/pre.test.js
+++ b/test/presenters/pre.test.js
@@ -26,6 +26,7 @@ describe('createPreElement', () => {
     ['', ''],
     ['[a', '[a'],
     ['a]', 'a]'],
+    [42, 42],
   ])(
     'given %p when creating the element then it sets %p as text',
     (input, expected) => {


### PR DESCRIPTION
## Summary
- extend `createPreElement` tests to handle non-string inputs

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684099543c1c832ea918f2ea7222bfbf