### PR TITLE
Add test for missing output handling

### DIFF
--- a/test/browser/toys.test.js
+++ b/test/browser/toys.test.js
@@ -279,6 +279,34 @@ describe('toys', () => {
       expect(() => handleDropdownChange(dropdown, getData, dom)).not.toThrow();
       expect(parent.child.textContent).toBe('');
     });
+
+    it('appends empty output when the output object is missing', () => {
+      const parent = { child: null, querySelector: jest.fn() };
+      parent.querySelector.mockReturnValue(parent);
+      const dropdown = {
+        value: 'text',
+        closest: jest.fn(() => ({ id: 'post-y' })),
+        parentNode: parent,
+      };
+      const getData = jest.fn(() => ({}));
+      const dom = {
+        querySelector: (el, selector) => el.querySelector(selector),
+        removeAllChildren: jest.fn(p => {
+          p.child = null;
+        }),
+        appendChild: jest.fn((p, c) => {
+          p.child = c;
+        }),
+        createElement: jest.fn(() => ({ textContent: '' })),
+        setTextContent: jest.fn((el, txt) => {
+          el.textContent = txt;
+        }),
+      };
+
+      expect(() => handleDropdownChange(dropdown, getData, dom)).not.toThrow();
+      expect(dom.appendChild).toHaveBeenCalledWith(parent, expect.any(Object));
+      expect(parent.child.textContent).toBe('');
+    });
   });
 
   let entry;


### PR DESCRIPTION
## Summary
- extend handleDropdownChange tests for missing output

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684099550e3c832ebb22cfca889b9428