### PR TITLE
Add regression test for dropdown change when output missing

### DIFF
--- a/test/browser/toys.test.js
+++ b/test/browser/toys.test.js
@@ -279,6 +279,40 @@ describe('toys', () => {
       expect(() => handleDropdownChange(dropdown, getData, dom)).not.toThrow();
       expect(parent.child.textContent).toBe('');
     });
+
+    it('does not throw when data lacks an output property', () => {
+      const parent = { child: null, querySelector: jest.fn() };
+      parent.querySelector.mockReturnValue(parent);
+      const dropdown = {
+        value: 'text',
+        closest: jest.fn(() => ({ id: 'post-y' })),
+        parentNode: parent,
+      };
+      const getData = jest.fn(() => ({}));
+      const dom = {
+        querySelector: (el, selector) => el.querySelector(selector),
+        removeAllChildren: jest.fn(p => {
+          p.child = null;
+        }),
+        appendChild: jest.fn((p, c) => {
+          p.child = c;
+        }),
+        createElement: jest.fn(() => ({ textContent: '' })),
+        setTextContent: jest.fn((el, txt) => {
+          el.textContent = txt;
+        }),
+      };
+
+      let error;
+      try {
+        handleDropdownChange(dropdown, getData, dom);
+      } catch (e) {
+        error = e;
+      }
+
+      expect(error).toBeUndefined();
+      expect(parent.child.textContent).toBe('');
+    });
   });
 
   let entry;


### PR DESCRIPTION
## Summary
- add regression test for `handleDropdownChange` when state lacks `output`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68409950f494832e98061891fc19a330