### PR TITLE
Add test to kill audio-controls mutant

### DIFF
--- a/test/browser/audio-controls.test.js
+++ b/test/browser/audio-controls.test.js
@@ -547,6 +547,18 @@ describe('setupAudio', () => {
     expect(aCalls).toHaveLength(3);
   });
 
+  it('creates DOM elements in the correct order', () => {
+    // When
+    setupAudio(dom);
+
+    // Then
+    expect(createElement).toHaveBeenNthCalledWith(1, 'div');
+    expect(createElement).toHaveBeenNthCalledWith(2, 'span');
+    expect(createElement).toHaveBeenNthCalledWith(3, 'a');
+    expect(createElement).toHaveBeenNthCalledWith(4, 'a');
+    expect(createElement).toHaveBeenNthCalledWith(5, 'a');
+  });
+
   it('inserts spaces between control buttons', () => {
     // When
     setupAudio(dom);


### PR DESCRIPTION
## Summary
- add regression test ensuring audio control elements are created in the correct order
- use `toHaveBeenNthCalledWith` for clearer ordering expectations

## Testing
- `npm test`
- `npm run lint` *(warnings only)*

------
https://chatgpt.com/codex/tasks/task_e_68408fe28480832eb664b5bd1efb51fa