### PR TITLE
Add test for handleDropdownChange

### DIFF
--- a/test/browser/toys.test.js
+++ b/test/browser/toys.test.js
@@ -279,6 +279,37 @@ describe('toys', () => {
       expect(() => handleDropdownChange(dropdown, getData, dom)).not.toThrow();
       expect(parent.child.textContent).toBe('');
     });
+
+    it('displays output corresponding to the closest article id', () => {
+      const parent = { child: null, querySelector: jest.fn() };
+      parent.querySelector.mockReturnValue(parent);
+      const dropdown = {
+        value: 'text',
+        closest: jest.fn(() => ({ id: 'correct' })),
+        parentNode: parent,
+      };
+      const outputs = { correct: 'right' };
+      outputs[undefined] = 'wrong';
+      const getData = jest.fn(() => ({ output: outputs }));
+      const dom = {
+        querySelector: (el, selector) => el.querySelector(selector),
+        removeAllChildren: jest.fn(p => {
+          p.child = null;
+        }),
+        appendChild: jest.fn((p, c) => {
+          p.child = c;
+        }),
+        createElement: jest.fn(() => ({ textContent: '' })),
+        setTextContent: jest.fn((el, txt) => {
+          el.textContent = txt;
+        }),
+      };
+
+      handleDropdownChange(dropdown, getData, dom);
+
+      expect(dropdown.closest).toHaveBeenCalledWith('article.entry');
+      expect(parent.child.textContent).toBe('right');
+    });
   });
 
   let entry;


### PR DESCRIPTION
## Summary
- extend `handleDropdownChange` tests to verify that the article id from `closest` is used when displaying output

## Testing
- `npm test` *(fails: Cannot find module 'jest')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6840994b4bb4832eb99de1b974f870d2