### PR TITLE
Add test to kill optional chaining mutant

### DIFF
--- a/test/browser/toys.test.js
+++ b/test/browser/toys.test.js
@@ -308,6 +308,34 @@ describe('toys', () => {
       expect(dom.appendChild).toHaveBeenCalledWith(parent, expect.any(Object));
       expect(parent.child.textContent).toBe('');
     });
+
+    it('handles undefined output without failing', () => {
+      const parent = { child: null, querySelector: jest.fn() };
+      parent.querySelector.mockReturnValue(parent);
+      const dropdown = {
+        value: 'text',
+        closest: jest.fn(() => ({ id: 'post-z' })),
+        parentNode: parent,
+      };
+      const getData = jest.fn(() => ({}));
+      const dom = {
+        querySelector: (el, selector) => el.querySelector(selector),
+        removeAllChildren: jest.fn(p => {
+          p.child = null;
+        }),
+        appendChild: jest.fn((p, c) => {
+          p.child = c;
+        }),
+        createElement: jest.fn(() => ({ textContent: '' })),
+        setTextContent: jest.fn((el, txt) => {
+          el.textContent = txt;
+        }),
+      };
+
+      handleDropdownChange(dropdown, getData, dom);
+
+      expect(parent.child.textContent).toBe('');
+    });
   });
 
   let entry;


### PR DESCRIPTION
## Summary
- added a new unit test exercising `handleDropdownChange` when `data.output` is `undefined`
- ensured existing behavior remains unchanged

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68409bfb0ed8832e9ee788e0bb02d415