### PR TITLE
Add test for createKeyElement

### DIFF
--- a/test/browser/toys.createKeyElement.test.js
+++ b/test/browser/toys.createKeyElement.test.js
@@ -1,0 +1,62 @@
+import { jest } from '@jest/globals';
+import { createKeyElement } from '../../src/browser/toys.js';
+
+describe('createKeyElement', () => {
+  let mockDom;
+  let keyEl;
+  let textInput;
+  let rows;
+  let syncHiddenField;
+  let disposers;
+
+  beforeEach(() => {
+    mockDom = {
+      createElement: jest.fn().mockReturnValue({}),
+      setType: jest.fn(),
+      setPlaceholder: jest.fn(),
+      setValue: jest.fn(),
+      setDataAttribute: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn()
+    };
+    textInput = {};
+    rows = {};
+    syncHiddenField = jest.fn();
+    disposers = [];
+  });
+
+  it('creates a key input element with the correct initial properties', () => {
+    const key = 'testKey';
+
+    keyEl = createKeyElement(
+      mockDom,
+      key,
+      textInput,
+      rows,
+      syncHiddenField,
+      disposers
+    );
+
+    expect(mockDom.createElement).toHaveBeenCalledWith('input');
+    expect(mockDom.setType).toHaveBeenCalledWith(keyEl, 'text');
+    expect(mockDom.setPlaceholder).toHaveBeenCalledWith(keyEl, 'Key');
+    expect(mockDom.setValue).toHaveBeenCalledWith(keyEl, key);
+    expect(mockDom.setDataAttribute).toHaveBeenCalledWith(keyEl, 'prevKey', key);
+    expect(mockDom.addEventListener).toHaveBeenCalledWith(
+      keyEl,
+      'input',
+      expect.any(Function)
+    );
+    expect(disposers).toHaveLength(1);
+    const disposer = disposers[0];
+    expect(disposer).toBeInstanceOf(Function);
+
+    disposer();
+
+    expect(mockDom.removeEventListener).toHaveBeenCalledWith(
+      keyEl,
+      'input',
+      expect.any(Function)
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for `createKeyElement` to ensure the correct DOM element is created and listeners cleaned up

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68409bfe7aa4832e97265ab839aa2b26