### PR TITLE
Add missing test for related links

### DIFF
--- a/test/generator/generator.test.js
+++ b/test/generator/generator.test.js
@@ -336,6 +336,32 @@ describe('Blog Generator', () => {
     expect(htmlNoTags).not.toMatch('tag-');
   });
 
+  test('should omit related links section when none are provided', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'NL1',
+          title: 'No Links',
+          publicationDate: '2024-05-01',
+          content: ['No links here'],
+        },
+        {
+          key: 'NL2',
+          title: 'Empty Links',
+          publicationDate: '2024-05-02',
+          content: ['Still no links'],
+          relatedLinks: [],
+        },
+      ],
+    };
+
+    const htmlNoLinks = generateBlog({ blog, header, footer }, wrapHtml);
+    expect(htmlNoLinks).toContain('<article class="entry" id="NL1">');
+    expect(htmlNoLinks).toContain('<article class="entry" id="NL2">');
+    expect(htmlNoLinks).not.toMatch('<div class="key">links</div>');
+    expect(htmlNoLinks).not.toMatch('related-links');
+  });
+
   test('should render quotes as blockquotes', () => {
     const blog = {
       posts: [


### PR DESCRIPTION
## Summary
- add test case verifying blog generator omits related links section when no links are present

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68409c107d10832eb5fd8ee6e249537d