### PR TITLE
Add tests for createKeyElement

### DIFF
--- a/test/browser/toys.createKeyElement.test.js
+++ b/test/browser/toys.createKeyElement.test.js
@@ -1,0 +1,40 @@
+import { jest } from '@jest/globals';
+import { createKeyElement } from '../../src/browser/toys.js';
+
+describe('createKeyElement', () => {
+  let dom;
+  let disposers;
+  let keyEl;
+
+  beforeEach(() => {
+    keyEl = {};
+    dom = {
+      createElement: jest.fn().mockReturnValue(keyEl),
+      setType: jest.fn(),
+      setPlaceholder: jest.fn(),
+      setValue: jest.fn(),
+      setDataAttribute: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn()
+    };
+    disposers = [];
+  });
+
+  it('creates an input element for the key', () => {
+    const result = createKeyElement(dom, 'myKey', {}, {}, jest.fn(), disposers);
+
+    expect(dom.createElement).toHaveBeenCalledTimes(1);
+    expect(dom.createElement).toHaveBeenCalledWith('input');
+    expect(result).toBe(keyEl);
+  });
+
+  it('adds a disposer that removes the listener', () => {
+    createKeyElement(dom, 'myKey', {}, {}, jest.fn(), disposers);
+    expect(disposers).toHaveLength(1);
+
+    const onKey = dom.addEventListener.mock.calls[0][2];
+    disposers[0]();
+
+    expect(dom.removeEventListener).toHaveBeenCalledWith(keyEl, 'input', onKey);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for `createKeyElement` to verify DOM element creation and cleanup

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68409c1435dc832e9966ebf71e17ea93