### PR TITLE
Add Stryker regression test for module info

### DIFF
--- a/test/browser/toys.test.js
+++ b/test/browser/toys.test.js
@@ -428,6 +428,20 @@ describe('toys', () => {
       expect(dom.importModule).toHaveBeenCalled();
     });
 
+    // Regression test for a Stryker survivor that removed module info
+    it('passes module info to importModule when entry is intersecting', () => {
+      // --- GIVEN ---
+      createObserver(article, modulePath, functionName);
+      // --- WHEN ---
+      intersectionCallback([entry], observer);
+      // --- THEN ---
+      expect(dom.importModule).toHaveBeenCalledWith(
+        modulePath,
+        expect.any(Function),
+        expect.any(Function)
+      );
+    });
+
     it('calls disconnectObserver when entry is intersecting', () => {
       // --- GIVEN ---
       createObserver(article, modulePath, functionName);


### PR DESCRIPTION
## Summary
- document purpose of module info test in `toys.test.js`
- ensure `importModule` receives the module information when the observer fires

## Testing
- `npm run lint` *(warnings only)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68409bf940c4832e92a676c8b230a85b