### PR TITLE
Add test for vertical ship clues

### DIFF
--- a/test/generator/generator.test.js
+++ b/test/generator/generator.test.js
@@ -218,6 +218,33 @@ describe('Blog Generator', () => {
     expect(html).toBe(expectedHtml);
   });
 
+  // Posts with undefined or empty relatedLinks shouldn't render the section
+  test('should omit related links section when none are provided', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'NOL1',
+          title: 'No Links',
+          publicationDate: '2024-06-01',
+          content: ['No links here'],
+        },
+        {
+          key: 'NOL2',
+          title: 'Empty Links',
+          publicationDate: '2024-06-02',
+          content: ['Still no links'],
+          relatedLinks: [],
+        },
+      ],
+    };
+
+    const htmlNoLinks = generateBlog({ blog, header, footer }, wrapHtml);
+    expect(htmlNoLinks).toContain('<article class="entry" id="NOL1">');
+    expect(htmlNoLinks).toContain('<article class="entry" id="NOL2">');
+    expect(htmlNoLinks).not.toMatch('<div class="key">links</div>');
+    expect(htmlNoLinks).not.toMatch('related-links');
+  });
+
   test('should contain a YouTube video for a post', () => {
     const blog = {
       posts: [

--- a/test/toys/2025-05-11/battleshipSolitaireClues.test.js
+++ b/test/toys/2025-05-11/battleshipSolitaireClues.test.js
@@ -26,8 +26,8 @@ describe('generateClues', () => {
       width: 5,
       height: 5,
       ships: [
-        { start: { x: 1, y: 2 }, length: 3, direction: 'H' } // cells (1,2), (2,2), (3,2)
-      ]
+        { start: { x: 1, y: 2 }, length: 3, direction: 'H' }, // cells (1,2), (2,2), (3,2)
+      ],
     };
     const expectedRow = [0, 0, 3, 0, 0];
     const expectedCol = [0, 1, 1, 1, 0];
@@ -43,8 +43,8 @@ describe('generateClues', () => {
       height: 4,
       ships: [
         { start: { x: 0, y: 0 }, length: 4, direction: 'V' }, // (0,0)–(0,3)
-        { start: { x: 1, y: 1 }, length: 2, direction: 'H' } // (1,1), (2,1)
-      ]
+        { start: { x: 1, y: 1 }, length: 2, direction: 'H' }, // (1,1), (2,1)
+      ],
     };
     const expectedRow = [1, 3, 1, 1]; // rows 0–3
     const expectedCol = [4, 1, 1, 0]; // cols 0–3
@@ -59,11 +59,25 @@ describe('generateClues', () => {
       width: 3,
       height: 3,
       ships: [
-        { start: { x: 2, y: 2 }, length: 2, direction: 'H' } // (2,2) in, (3,2) out
-      ]
+        { start: { x: 2, y: 2 }, length: 2, direction: 'H' }, // (2,2) in, (3,2) out
+      ],
     };
     const expectedRow = [0, 0, 1];
     const expectedCol = [0, 0, 1];
+
+    const output = JSON.parse(generateClues(JSON.stringify(fleet)));
+    expect(output.rowClues).toEqual(expectedRow);
+    expect(output.colClues).toEqual(expectedCol);
+  });
+
+  it('computes correct clues for a vertical ship away from edges', () => {
+    const fleet = {
+      width: 5,
+      height: 6,
+      ships: [{ start: { x: 2, y: 1 }, length: 3, direction: 'V' }],
+    };
+    const expectedRow = [0, 1, 1, 1, 0, 0];
+    const expectedCol = [0, 0, 3, 0, 0];
 
     const output = JSON.parse(generateClues(JSON.stringify(fleet)));
     expect(output.rowClues).toEqual(expectedRow);


### PR DESCRIPTION
## Summary
- extend Battleship Solitaire clue generator tests for a vertical ship away from board edges

## Testing
- `npm test`
- `npm run lint` *(warnings only)*

------
https://chatgpt.com/codex/tasks/task_e_68409bfc7c30832eb3672592b2909a20