### PR TITLE
Fix surviving mutant with prevKey expectation

### DIFF
--- a/test/browser/toys.createKeyInputHandler.test.js
+++ b/test/browser/toys.createKeyInputHandler.test.js
@@ -65,6 +65,7 @@ describe('createKeyInputHandler', () => {
     handler(event);
 
     // Assert
+    expect(dom.getDataAttribute).toHaveBeenCalledWith(keyEl, 'prevKey');
     expect(rows).toEqual({
       existingKey: 'value1',
       oldKey: undefined, // Should be deleted


### PR DESCRIPTION
## Summary
- ensure createKeyInputHandler fetches `prevKey`

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68409facee94832e80df2612f7a132ca