### PR TITLE
Improve test coverage for handleDropdownChange

### DIFF
--- a/test/browser/toys.test.js
+++ b/test/browser/toys.test.js
@@ -336,6 +336,27 @@ describe('toys', () => {
 
       expect(parent.child.textContent).toBe('');
     });
+
+    it('calls setTextContent with empty string when data.output is missing', () => {
+      const parent = {};
+      const dropdown = {
+        value: 'text',
+        closest: jest.fn(() => ({ id: 'post-missing' })),
+        parentNode: parent,
+      };
+      const getData = jest.fn(() => ({}));
+      const dom = {
+        querySelector: jest.fn(() => parent),
+        removeAllChildren: jest.fn(),
+        appendChild: jest.fn(),
+        createElement: jest.fn(() => ({})),
+        setTextContent: jest.fn(),
+      };
+
+      expect(() => handleDropdownChange(dropdown, getData, dom)).not.toThrow();
+      expect(dom.removeAllChildren).toHaveBeenCalledWith(parent);
+      expect(dom.appendChild).toHaveBeenCalledWith(parent, expect.any(Object));
+    });
   });
 
   let entry;


### PR DESCRIPTION
## Summary
- add regression test for handleDropdownChange when data.output is missing

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68409fad6f80832eaefed66e4d4de648