### PR TITLE
Add test for createKeyInputHandler prevKey usage

### DIFF
--- a/test/browser/toys.createKeyInputHandler.test.js
+++ b/test/browser/toys.createKeyInputHandler.test.js
@@ -55,6 +55,18 @@ describe('createKeyInputHandler', () => {
     expect(dom.setDataAttribute).not.toHaveBeenCalled();
   });
 
+  it('should read previous key from the prevKey attribute', () => {
+    // Arrange
+    dom.getDataAttribute.mockReturnValue('anyKey');
+    dom.getTargetValue.mockReturnValue('anyKey');
+
+    // Act
+    handler(event);
+
+    // Assert
+    expect(dom.getDataAttribute).toHaveBeenCalledWith(keyEl, 'prevKey');
+  });
+
   it('should update rows with new key when key is unique and non-empty', () => {
     // Arrange
     dom.getDataAttribute.mockReturnValue('oldKey');


### PR DESCRIPTION
## Summary
- ensure `createKeyInputHandler` reads the `prevKey` attribute

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68409faee210832e9470427f96f1cae1