### PR TITLE
Add tests for empty related links

### DIFF
--- a/test/generator/isNonEmptyArray.test.js
+++ b/test/generator/isNonEmptyArray.test.js
@@ -1,0 +1,39 @@
+import { generateBlog } from '../../src/generator/generator.js';
+
+const header = '<body>';
+const footer = '</body>';
+const wrapHtml = c => ['<html>', c, '</html>'].join('');
+
+describe('isNonEmptyArray/hasRelatedLinks via generateBlog', () => {
+  test('does not render related links for empty array', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'EMPTY',
+          title: 'Empty',
+          publicationDate: '2024-06-01',
+          content: ['text'],
+          relatedLinks: [],
+        },
+      ],
+    };
+    const html = generateBlog({ blog, header, footer }, wrapHtml);
+    expect(html).not.toContain('related-links');
+  });
+
+  test('does not render related links for non-array value', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'STR',
+          title: 'String',
+          publicationDate: '2024-06-02',
+          content: ['text'],
+          relatedLinks: 'not-an-array',
+        },
+      ],
+    };
+    const html = generateBlog({ blog, header, footer }, wrapHtml);
+    expect(html).not.toContain('related-links');
+  });
+});


### PR DESCRIPTION
## Summary
- ensure generateBlog doesn't render related links when none exist

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68409fb09a58832ea5eaae056abef31a