### PR TITLE
Add null fleet test for Battleship clues

### DIFF
--- a/test/toys/2025-05-11/battleshipSolitaireClues.test.js
+++ b/test/toys/2025-05-11/battleshipSolitaireClues.test.js
@@ -83,4 +83,9 @@ describe('generateClues', () => {
     expect(output.rowClues).toEqual(expectedRow);
     expect(output.colClues).toEqual(expectedCol);
   });
+
+  it('returns an error when the fleet is null', () => {
+    const output = JSON.parse(generateClues('null'));
+    expect(output).toEqual({ error: 'Invalid fleet structure' });
+  });
 });


### PR DESCRIPTION
## Summary
- add test to check `generateClues` with a null fleet

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6840a24d3054832e8fac2f756f30bd12