### PR TITLE
Add tests for prevKey retrieval

### DIFF
--- a/test/browser/toys.createKeyInputHandler.test.js
+++ b/test/browser/toys.createKeyInputHandler.test.js
@@ -64,6 +64,7 @@ describe('createKeyInputHandler', () => {
     handler(event);
 
     // Assert
+    expect(dom.getDataAttribute).toHaveBeenCalledTimes(1);
     expect(dom.getDataAttribute).toHaveBeenCalledWith(keyEl, 'prevKey');
   });
 

--- a/test/browser/toys.keyValueInput.test.js
+++ b/test/browser/toys.keyValueInput.test.js
@@ -103,6 +103,8 @@ describe('Key-Value Input', () => {
         newKey: 'someValue'
       });
       expect(rows).not.toHaveProperty('oldKey');
+      expect(dom.getDataAttribute).toHaveBeenCalledTimes(1);
+      expect(dom.getDataAttribute).toHaveBeenCalledWith(keyEl, 'prevKey');
       expect(dom.setDataAttribute).toHaveBeenCalledWith(keyEl, 'prevKey', 'newKey');
       expect(mockSyncHiddenField).toHaveBeenCalledWith(textInput, rows, dom);
     });


### PR DESCRIPTION
## Summary
- strengthen tests for createKeyInputHandler
- ensure createKeyInputHandler gets `prevKey` data attribute

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6840a25b154c832e946bdcdfcae23618