### PR TITLE
Improve disposers test to kill mutant

### DIFF
--- a/test/browser/toys.createKeyValueRow.test.js
+++ b/test/browser/toys.createKeyValueRow.test.js
@@ -205,16 +205,48 @@ describe('createKeyValueRow', () => {
   });
 
   it('handles cleanup when disposers are called', () => {
-    // Call the row creator
+    const rowEl = {};
+    const keyInput = {};
+    const valueInput = {};
+    const btnEl = {};
+    mockDom.createElement
+      .mockReturnValueOnce(rowEl)
+      .mockReturnValueOnce(keyInput)
+      .mockReturnValueOnce(valueInput)
+      .mockReturnValueOnce(btnEl);
+
     rowCreator(mockEntries[0], 0);
 
-    // Get all cleanup functions
-    const cleanupFunctions = [...mockDisposers];
+    const [
+      [addedKeyEl, , keyHandler],
+      [addedValueEl, , valueHandler],
+      [addedBtnEl, , btnHandler],
+    ] = mockDom.addEventListener.mock.calls;
 
-    // Call each cleanup function
-    cleanupFunctions.forEach(cleanup => cleanup());
+    const [keyDisposer, valueDisposer, btnDisposer] = mockDisposers;
 
-    // Verify removeEventListener was called for each cleanup
-    expect(mockDom.removeEventListener).toHaveBeenCalled();
+    mockDom.removeEventListener.mockClear();
+    keyDisposer();
+    expect(mockDom.removeEventListener).toHaveBeenCalledWith(
+      addedKeyEl,
+      'input',
+      keyHandler
+    );
+
+    mockDom.removeEventListener.mockClear();
+    valueDisposer();
+    expect(mockDom.removeEventListener).toHaveBeenCalledWith(
+      addedValueEl,
+      'input',
+      valueHandler
+    );
+
+    mockDom.removeEventListener.mockClear();
+    btnDisposer();
+    expect(mockDom.removeEventListener).toHaveBeenCalledWith(
+      addedBtnEl,
+      'click',
+      btnHandler
+    );
   });
 });


### PR DESCRIPTION
## Summary
- verify each disposer removes its event listener in `createKeyValueRow` tests

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840a254cdf4832e8376a521d955c7d8