### PR TITLE
Add tests for markdown CSS classes

### DIFF
--- a/test/constants/markdown.test.js
+++ b/test/constants/markdown.test.js
@@ -1,5 +1,9 @@
 import { describe, test, expect } from '@jest/globals';
-import { HTML_TAGS, DEFAULT_OPTIONS } from '../../src/constants/markdown.js';
+import {
+  HTML_TAGS,
+  DEFAULT_OPTIONS,
+  CSS_CLASSES,
+} from '../../src/constants/markdown.js';
 
 describe('markdown constants', () => {
   test('HTML_TAGS contains expected tag names', () => {
@@ -17,5 +21,10 @@ describe('markdown constants', () => {
     expect(DEFAULT_OPTIONS.headerIds).toBe(true);
     expect(DEFAULT_OPTIONS.headerPrefix).toBe('');
     expect(DEFAULT_OPTIONS.mangle).toBe(true);
+  });
+
+  test('CSS_CLASSES includes heading and paragraph classes', () => {
+    expect(CSS_CLASSES.HEADING).toBe('markdown-heading');
+    expect(CSS_CLASSES.PARAGRAPH).toBe('markdown-paragraph');
   });
 });


### PR DESCRIPTION
## Summary
- extend markdown constant tests to verify CSS class names

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6840a2572798832e870a43698b85e2ef