### PR TITLE
Add createRenderer empty rows test

### DIFF
--- a/test/browser/toys.createRenderer.test.js
+++ b/test/browser/toys.createRenderer.test.js
@@ -1,5 +1,6 @@
 import { jest } from '@jest/globals';
-import { createRenderer } from '../../src/browser/toys.js';
+import * as toys from '../../src/browser/toys.js';
+const { createRenderer } = toys;
 
 describe('createRenderer', () => {
   it('should create a renderer function', () => {
@@ -41,5 +42,35 @@ describe('createRenderer', () => {
     );
     render();
     expect(syncHiddenField).toHaveBeenCalled();
+  });
+
+  it('adds an empty row when no rows exist', () => {
+    const dom = {
+      removeAllChildren: jest.fn(),
+      createElement: jest.fn(),
+      setClassName: jest.fn(),
+      setType: jest.fn(),
+      setPlaceholder: jest.fn(),
+      setValue: jest.fn(),
+      setDataAttribute: jest.fn(),
+      addEventListener: jest.fn(),
+      setTextContent: jest.fn(),
+      appendChild: jest.fn(),
+    };
+    const disposers = [];
+    const container = {};
+    const rows = {};
+    const textInput = {};
+    const syncHiddenField = jest.fn();
+    const render = createRenderer(
+      dom,
+      disposers,
+      container,
+      rows,
+      textInput,
+      syncHiddenField
+    );
+    render();
+    expect(rows).toEqual({ '': '' });
   });
 });


### PR DESCRIPTION
## Summary
- add a unit test for `createRenderer` when rows are initially empty

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6840a25daef8832e8b4b9e85c4d1a713