### PR TITLE
Add test for button element type

### DIFF
--- a/test/browser/toys.createKeyValueRow.test.js
+++ b/test/browser/toys.createKeyValueRow.test.js
@@ -163,6 +163,20 @@ describe('createKeyValueRow', () => {
     expect(mockDom.setTextContent).toHaveBeenCalledWith(mockButton, '+');
   });
 
+  it('creates the button element with the correct type', () => {
+    const mockButton = {};
+    mockDom.createElement
+      .mockReturnValueOnce({})
+      .mockReturnValueOnce({})
+      .mockReturnValueOnce({})
+      .mockReturnValue(mockButton);
+
+    rowCreator(mockEntries[0], 0);
+
+    expect(mockDom.createElement).toHaveBeenNthCalledWith(4, 'button');
+    expect(mockDom.setType).toHaveBeenCalledWith(mockButton, 'button');
+  });
+
   it('adds event listeners for key and value changes', () => {
     // Setup mock elements
     const mockKeyInput = {};


### PR DESCRIPTION
## Summary
- ensure `createKeyValueRow` creates a button element of type `button`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6840a256f4dc832e84e5b1c8a779a480