### PR TITLE
Add test for getFetchErrorHandler message

### DIFF
--- a/test/browser/toys.getFetchErrorHandler.test.js
+++ b/test/browser/toys.getFetchErrorHandler.test.js
@@ -28,4 +28,27 @@ describe('getFetchErrorHandler', () => {
     errorHandler(error);
     expect(errorFn).toHaveBeenCalled();
   });
+
+  it('adds a warning with a prefixed message', () => {
+    const dom = {
+      removeAllChildren: jest.fn(),
+      createElement: jest.fn(() => ({})),
+      setTextContent: jest.fn(),
+      appendChild: jest.fn(),
+      addWarning: jest.fn(),
+    };
+    const parent = {};
+    const presenterKey = 'text';
+    const errorFn = jest.fn();
+    const errorHandler = getFetchErrorHandler({ dom, errorFn }, parent, presenterKey);
+    const error = new Error('boom');
+
+    errorHandler(error);
+
+    expect(dom.setTextContent).toHaveBeenCalledWith(
+      expect.anything(),
+      'Error fetching URL: ' + error.message
+    );
+    expect(dom.addWarning).toHaveBeenCalledWith(parent);
+  });
 });


### PR DESCRIPTION
## Summary
- extend `getFetchErrorHandler` tests to verify message prefix and warning

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6840a251bf04832e9eb524dc339ec0ee