### PR TITLE
Add test for non-array relatedLinks

### DIFF
--- a/test/generator/generator.test.js
+++ b/test/generator/generator.test.js
@@ -245,6 +245,25 @@ describe('Blog Generator', () => {
     expect(htmlNoLinks).not.toMatch('related-links');
   });
 
+  test('should omit related links section when value is not an array', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'STRL',
+          title: 'String Links',
+          publicationDate: '2024-06-03',
+          content: ['Still no links'],
+          relatedLinks: 'not-an-array',
+        },
+      ],
+    };
+
+    const html = generateBlog({ blog, header, footer }, wrapHtml);
+    expect(html).toContain('<article class="entry" id="STRL">');
+    expect(html).not.toMatch('<div class="key">links</div>');
+    expect(html).not.toMatch('related-links');
+  });
+
   test('should contain a YouTube video for a post', () => {
     const blog = {
       posts: [


### PR DESCRIPTION
## Summary
- add failing test covering `isNonEmptyArray` when `relatedLinks` is not an array

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6840a24fba00832ebb22a39eee3c36f5