### PR TITLE
Add failing Stryker mutant test

### DIFF
--- a/test/browser/toys.test.js
+++ b/test/browser/toys.test.js
@@ -428,6 +428,8 @@ describe('toys', () => {
     let functionName;
     let intersectionCallback;
     let isIntersecting;
+    let inputElement;
+    let submitButton;
 
     beforeEach(() => {
       expectedResult = {};
@@ -436,6 +438,23 @@ describe('toys', () => {
         return expectedResult;
       });
       isIntersecting = () => true;
+      inputElement = { disabled: false };
+      submitButton = { disabled: false };
+      const outputParent = {};
+      const outputSelect = {};
+      const selectorMap = new Map([
+        ['input', inputElement],
+        ['button', submitButton],
+        ['div.output', outputParent],
+        ['select.output', outputSelect],
+      ]);
+      const querySelector = jest.fn((el, selector) =>
+        selectorMap.get(selector)
+      );
+      const listeners = {};
+      const addEventListener = jest.fn((el, event, handler) => {
+        listeners[event] = handler;
+      });
       dom = {
         makeIntersectionObserver,
         importModule: jest.fn(),
@@ -443,9 +462,29 @@ describe('toys', () => {
         error: jest.fn(),
         isIntersecting,
         contains: () => true,
+        querySelector,
+        addEventListener,
+        removeAllChildren: jest.fn(),
+        createElement: jest.fn(() => ({})),
+        setTextContent: jest.fn(() => ({})),
+        appendChild: jest.fn(),
+        removeChild: jest.fn(),
+        enable: jest.fn(),
+        removeWarning: jest.fn(),
+        addWarning: jest.fn(),
+        stopDefault: jest.fn(),
+        listeners,
+        inputElement,
+        submitButton,
       };
       // Always provide loggers for moduleConfig compatibility
-      env = { loggers: { logError: jest.fn() } };
+      env = {
+        loggers: { logError: jest.fn(), logInfo: jest.fn() },
+        error: jest.fn(),
+        fetch: jest.fn(),
+        globalState: {},
+        createEnv: jest.fn(),
+      };
       createObserver = makeCreateIntersectionObserver(dom, env);
       functionName = 'fn';
       entry = {};
@@ -489,6 +528,19 @@ describe('toys', () => {
         expect.any(Function),
         expect.any(Function)
       );
+    });
+
+    it('initializes module with the provided function name', () => {
+      // --- GIVEN ---
+      createObserver(article, modulePath, functionName);
+      intersectionCallback([entry], observer);
+      const [, initializer] = dom.importModule.mock.calls[0];
+      const moduleFn = jest.fn();
+      // --- WHEN ---
+      initializer({ [functionName]: moduleFn });
+      dom.listeners.click({ preventDefault: jest.fn() });
+      // --- THEN ---
+      expect(moduleFn).toHaveBeenCalled();
     });
 
     it('calls disconnectObserver when entry is intersecting', () => {


### PR DESCRIPTION
## Summary
- improve coverage for `makeCreateIntersectionObserver`
- check that the dynamic module initializer uses the provided function name

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6840a2596e90832eaa100d619fb7d18a