### PR TITLE
Extend test to kill surviving mutant

### DIFF
--- a/test/browser/toys.createKeyInputHandler.test.js
+++ b/test/browser/toys.createKeyInputHandler.test.js
@@ -51,6 +51,7 @@ describe('createKeyInputHandler', () => {
     handler(event);
 
     // Assert
+    expect(dom.getDataAttribute).toHaveBeenCalledWith(keyEl, 'prevKey');
     expect(syncHiddenField).toHaveBeenCalledWith(textInput, rows, dom);
     expect(dom.setDataAttribute).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- add assertion for `prevKey` attribute usage in key input handler

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6840a56a5b94832eb5c5fd2816a2d044