### PR TITLE
Add test for CSS code class constant

### DIFF
--- a/test/constants/markdown.test.js
+++ b/test/constants/markdown.test.js
@@ -27,4 +27,8 @@ describe('markdown constants', () => {
     expect(CSS_CLASSES.HEADING).toBe('markdown-heading');
     expect(CSS_CLASSES.PARAGRAPH).toBe('markdown-paragraph');
   });
+
+  test('CSS_CLASSES includes a code class', () => {
+    expect(CSS_CLASSES.CODE).toBe('markdown-code');
+  });
 });


### PR DESCRIPTION
## Summary
- verify `CSS_CLASSES.CODE` is set to `'markdown-code'`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6840a569c3c8832ea0a1b76ea2cd4fb8