### PR TITLE
Improve coverage for makeCreateIntersectionObserver

### DIFF
--- a/test/browser/toys.test.js
+++ b/test/browser/toys.test.js
@@ -556,6 +556,19 @@ describe('toys', () => {
       );
     });
 
+    it('passes the article to querySelector when initializing', () => {
+      // --- GIVEN ---
+      createObserver(article, modulePath, functionName);
+      intersectionCallback([entry], observer);
+      const [, initializer] = dom.importModule.mock.calls[0];
+      dom.querySelector.mockClear();
+      const moduleFn = jest.fn();
+      // --- WHEN ---
+      initializer({ [functionName]: moduleFn });
+      // --- THEN ---
+      expect(dom.querySelector).toHaveBeenCalledWith(article, 'input');
+    });
+
     it('initializes module with the provided function name', () => {
       // --- GIVEN ---
       createObserver(article, modulePath, functionName);


### PR DESCRIPTION
## Summary
- add regression test for makeCreateIntersectionObserver to verify the article is passed through to initialization

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6840a566f958832ebaa549535eb1a41a