### PR TITLE
Add tests for more markdown constants

### DIFF
--- a/test/constants/markdown.test.js
+++ b/test/constants/markdown.test.js
@@ -12,6 +12,15 @@ describe('markdown constants', () => {
     expect(HTML_TAGS.PRE).toBe('pre');
   });
 
+  test('HTML_TAGS includes list and rule tags', () => {
+    expect(HTML_TAGS.LIST).toBe('ul');
+    expect(HTML_TAGS.LIST_ITEM).toBe('li');
+    expect(HTML_TAGS.ORDERED_LIST).toBe('ol');
+    expect(HTML_TAGS.HORIZONTAL_RULE).toBe('hr');
+    expect(HTML_TAGS.LINE_BREAK).toBe('br');
+    expect(HTML_TAGS.IMAGE).toBe('img');
+  });
+
   test('DEFAULT_OPTIONS has correct default values', () => {
     expect(DEFAULT_OPTIONS.breaks).toBe(false);
     expect(DEFAULT_OPTIONS.sanitize).toBe(false);


### PR DESCRIPTION
## Summary
- add unit test coverage for additional `HTML_TAGS` constants

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6840a56445f4832ea4bee127f1b9acc8