### PR TITLE
Add test to kill mutation in createRenderer

### DIFF
--- a/test/browser/toys.createRenderer.test.js
+++ b/test/browser/toys.createRenderer.test.js
@@ -73,4 +73,34 @@ describe('createRenderer', () => {
     render();
     expect(rows).toEqual({ '': '' });
   });
+
+  it('does not add an empty row when rows already contain values', () => {
+    const dom = {
+      removeAllChildren: jest.fn(),
+      createElement: jest.fn(),
+      setClassName: jest.fn(),
+      setType: jest.fn(),
+      setPlaceholder: jest.fn(),
+      setValue: jest.fn(),
+      setDataAttribute: jest.fn(),
+      addEventListener: jest.fn(),
+      setTextContent: jest.fn(),
+      appendChild: jest.fn(),
+    };
+    const disposers = [];
+    const container = {};
+    const rows = { existing: 'val' };
+    const textInput = {};
+    const syncHiddenField = jest.fn();
+    const render = createRenderer(
+      dom,
+      disposers,
+      container,
+      rows,
+      textInput,
+      syncHiddenField
+    );
+    render();
+    expect(rows).toEqual({ existing: 'val' });
+  });
 });


### PR DESCRIPTION
## Summary
- extend `createRenderer` tests to verify no empty row is added when rows already contain values

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6840a91d58e4832e8ccbade935445fc7