### PR TITLE
Add test to kill mutation

### DIFF
--- a/test/browser/toys.createKeyElement.test.js
+++ b/test/browser/toys.createKeyElement.test.js
@@ -87,4 +87,28 @@ describe('createKeyElement', () => {
       handler
     );
   });
+
+  it('calls removeEventListener exactly once when disposed', () => {
+    const key = 'testKey';
+
+    keyEl = createKeyElement(
+      mockDom,
+      key,
+      textInput,
+      rows,
+      syncHiddenField,
+      disposers
+    );
+
+    mockDom.removeEventListener.mockClear();
+
+    disposers[0]();
+
+    expect(mockDom.removeEventListener).toHaveBeenCalledTimes(1);
+    expect(mockDom.removeEventListener).toHaveBeenCalledWith(
+      keyEl,
+      'input',
+      expect.any(Function)
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- extend createKeyElement tests to verify cleanup calls removeEventListener exactly once

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6840a91eeb68832ea822c24328d075b4