### PR TITLE
Add test for key listener disposer

### DIFF
--- a/test/browser/toys.createKeyElement.test.js
+++ b/test/browser/toys.createKeyElement.test.js
@@ -87,4 +87,28 @@ describe('createKeyElement', () => {
       handler
     );
   });
+
+  it('invokes removeEventListener exactly once when disposer is called', () => {
+    keyEl = createKeyElement(
+      mockDom,
+      'key',
+      textInput,
+      rows,
+      syncHiddenField,
+      disposers
+    );
+
+    const disposer = disposers[0];
+
+    expect(mockDom.removeEventListener).not.toHaveBeenCalled();
+
+    disposer();
+
+    expect(mockDom.removeEventListener).toHaveBeenCalledTimes(1);
+    expect(mockDom.removeEventListener).toHaveBeenCalledWith(
+      keyEl,
+      'input',
+      mockDom.addEventListener.mock.calls[0][2]
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- extend `createKeyElement` tests to verify disposer removes listener only once

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6840a91f9c98832e9f7f51fff6c54cab