### PR TITLE
Add test for related links presence

### DIFF
--- a/test/generator/isNonEmptyArray.test.js
+++ b/test/generator/isNonEmptyArray.test.js
@@ -36,4 +36,28 @@ describe('isNonEmptyArray/hasRelatedLinks via generateBlog', () => {
     const html = generateBlog({ blog, header, footer }, wrapHtml);
     expect(html).not.toContain('related-links');
   });
+
+  test('renders related links when array has items', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'ONE',
+          title: 'One',
+          publicationDate: '2024-06-03',
+          content: ['text'],
+          relatedLinks: [
+            {
+              url: 'https://example.com',
+              title: 'Example',
+              author: 'Author',
+              type: 'article',
+            },
+          ],
+        },
+      ],
+    };
+    const html = generateBlog({ blog, header, footer }, wrapHtml);
+    expect(html).toContain('<ul class="related-links">');
+    expect(html).toContain('https://example.com');
+  });
 });


### PR DESCRIPTION
## Summary
- test `generateBlog` renders related links when they are provided

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6840a9205b70832e894dccfb99efa067