### PR TITLE
Add disposal test for key listener

### DIFF
--- a/test/browser/toys.createKeyValueRow.test.js
+++ b/test/browser/toys.createKeyValueRow.test.js
@@ -1,5 +1,6 @@
 import { jest } from '@jest/globals';
-import { createKeyValueRow } from '../../src/browser/toys.js';
+import * as toys from '../../src/browser/toys.js';
+const { createKeyValueRow } = toys;
 
 describe('createKeyValueRow', () => {
   let mockDom;
@@ -212,6 +213,29 @@ describe('createKeyValueRow', () => {
       [mockValueInput, 'input', expect.any(Function)],
       [mockButton, 'click', expect.any(Function)],
     ]);
+  });
+
+  it('key disposer removes the key input listener', () => {
+    const keyInput = {};
+    mockDom.createElement
+      .mockReturnValueOnce({})
+      .mockReturnValueOnce(keyInput)
+      .mockReturnValueOnce({})
+      .mockReturnValue({});
+
+    rowCreator(mockEntries[0], 0);
+
+    const handler = mockDom.addEventListener.mock.calls[0][2];
+    const [keyDisposer] = mockDisposers;
+
+    mockDom.removeEventListener.mockClear();
+    keyDisposer();
+
+    expect(mockDom.removeEventListener).toHaveBeenCalledWith(
+      keyInput,
+      'input',
+      handler
+    );
   });
 
   it('adds cleanup functions to disposers array', () => {


### PR DESCRIPTION
## Summary
- extend createKeyValueRow tests with coverage for key listener cleanup

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6840a920b710832ea398402d5e6a0a1a