### PR TITLE
Add test to kill Stryker mutant

### DIFF
--- a/test/browser/toys.processInputAndSetOutput.test.js
+++ b/test/browser/toys.processInputAndSetOutput.test.js
@@ -146,7 +146,12 @@ describe('processInputAndSetOutput', () => {
     const article = { id: 'post1' };
     const outputSelect = { value: 'text' };
     const outputParentElement = {};
-    const elements = { inputElement, article, outputSelect, outputParentElement };
+    const elements = {
+      inputElement,
+      article,
+      outputSelect,
+      outputParentElement,
+    };
     const result = '{"request":{"url":""}}';
     const processingFunction = jest.fn(() => result);
     const setData = jest.fn();
@@ -161,7 +166,9 @@ describe('processInputAndSetOutput', () => {
       createElement: jest.fn(() => ({})),
       appendChild: jest.fn(),
     };
-    const fetchFn = jest.fn(() => Promise.resolve({ text: () => Promise.resolve('') }));
+    const fetchFn = jest.fn(() =>
+      Promise.resolve({ text: () => Promise.resolve('') })
+    );
     const env = { createEnv, dom, fetchFn };
 
     processInputAndSetOutput(elements, processingFunction, env);

--- a/test/browser/toys.test.js
+++ b/test/browser/toys.test.js
@@ -1093,6 +1093,45 @@ describe('toys', () => {
       // Expectations at end
       expect(processingFunction).not.toHaveBeenCalled();
     });
+
+    it('queries the DOM for output elements using expected selectors', () => {
+      const createEnvFn = () => ({});
+      const errorFn = jest.fn();
+      const fetchFn = jest.fn();
+      const dom = {
+        removeAllChildren: jest.fn(),
+        createElement: jest.fn(() => ({ textContent: '' })),
+        stopDefault: jest.fn(),
+        addWarning: jest.fn(),
+        addWarningFn: jest.fn(),
+        addEventListener: jest.fn(),
+        removeChild: jest.fn(),
+        appendChild: jest.fn(),
+        querySelector,
+        setTextContent: jest.fn(),
+        removeWarning: jest.fn(),
+        enable: jest.fn(),
+        contains: () => true,
+      };
+      const processingFunction = jest.fn();
+      const config = {
+        globalState: {},
+        createEnvFn,
+        errorFn,
+        fetchFn,
+        dom,
+        loggers: {
+          logInfo: jest.fn(),
+          logError: jest.fn(),
+          logWarning: jest.fn(),
+        },
+      };
+
+      initializeInteractiveComponent(article, processingFunction, config);
+
+      expect(querySelector).toHaveBeenCalledWith(article, 'div.output');
+      expect(querySelector).toHaveBeenCalledWith(article, 'select.output');
+    });
   });
 
   describe('initializeVisibleComponents', () => {


### PR DESCRIPTION
## Summary
- extend `initializeInteractiveComponent` tests to assert DOM selectors
- ensure mutation on DOM query is covered

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6840a922315c832eb4728cfe9cc1334d