### PR TITLE
Improve coverage of makeCreateIntersectionObserver

### DIFF
--- a/test/browser/toys.test.js
+++ b/test/browser/toys.test.js
@@ -582,6 +582,22 @@ describe('toys', () => {
       expect(moduleFn).toHaveBeenCalled();
     });
 
+    it('initializes using the provided module info', () => {
+      // --- GIVEN ---
+      createObserver(article, modulePath, functionName);
+      intersectionCallback([entry], observer);
+      const [calledPath, initializer] = dom.importModule.mock.calls[0];
+      const moduleFn = jest.fn();
+      dom.querySelector.mockClear();
+      // --- WHEN ---
+      initializer({ [functionName]: moduleFn });
+      dom.listeners.click({ preventDefault: jest.fn() });
+      // --- THEN ---
+      expect(calledPath).toBe(modulePath);
+      expect(moduleFn).toHaveBeenCalled();
+      expect(dom.querySelector).toHaveBeenCalledWith(article, 'input');
+    });
+
     it('passes the article to initializeInteractiveComponent', () => {
       createObserver(article, modulePath, functionName);
       intersectionCallback([entry], observer);


### PR DESCRIPTION
## Summary
- add regression test ensuring makeCreateIntersectionObserver passes module info

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6840a9225f24832eb571bbfce3072349