### PR TITLE
Add test for error handler in makeCreateIntersectionObserver

### DIFF
--- a/test/browser/toys.test.js
+++ b/test/browser/toys.test.js
@@ -599,6 +599,23 @@ describe('toys', () => {
       expect(dom.disconnectObserver).toHaveBeenCalledWith(observer);
     });
 
+    it('passes module path to the error handler', () => {
+      // --- GIVEN ---
+      createObserver(article, modulePath, functionName);
+      intersectionCallback([entry], observer);
+      const [, , errorHandler] = dom.importModule.mock.calls[0];
+      const error = new Error('oops');
+
+      // --- WHEN ---
+      errorHandler(error);
+
+      // --- THEN ---
+      expect(env.loggers.logError).toHaveBeenCalledWith(
+        'Error loading module ' + modulePath + ':',
+        error
+      );
+    });
+
     it('does not call importModule when not intersecting', () => {
       // --- GIVEN ---
       const makeIntersectionObserver = jest.fn(fn => {


### PR DESCRIPTION
## Summary
- extend makeCreateIntersectionObserver tests to check module path on error handler

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6840a9234e50832ebcd393dbb46859a7