### PR TITLE
Add isolated test for markdown constants

### DIFF
--- a/test/constants/markdown.dynamic.test.js
+++ b/test/constants/markdown.dynamic.test.js
@@ -1,0 +1,15 @@
+import { describe, test, expect, jest } from '@jest/globals';
+
+/**
+ * Dynamic import tests to ensure constants survive module cache resets.
+ */
+describe('markdown constants isolated', () => {
+  test('HTML_TAGS values via dynamic import', async () => {
+    jest.resetModules();
+    const module = await import('../../src/constants/markdown.js');
+    const { HTML_TAGS } = module;
+    expect(HTML_TAGS.LIST).toBe('ul');
+    expect(HTML_TAGS.LIST_ITEM).toBe('li');
+    expect(HTML_TAGS.HORIZONTAL_RULE).toBe('hr');
+  });
+});


### PR DESCRIPTION
## Summary
- add dynamic import test ensuring markdown HTML_TAGS are correct

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6840a9243a40832e88562210fe72735a