### PR TITLE
Add negative coordinate test for battleship clues

### DIFF
--- a/test/toys/2025-05-11/battleshipSolitaireClues.test.js
+++ b/test/toys/2025-05-11/battleshipSolitaireClues.test.js
@@ -70,6 +70,22 @@ describe('generateClues', () => {
     expect(output.colClues).toEqual(expectedCol);
   });
 
+  it('ignores ship cells with negative coordinates', () => {
+    const fleet = {
+      width: 3,
+      height: 3,
+      ships: [
+        { start: { x: -1, y: 1 }, length: 2, direction: 'H' }, // (-1,1) out, (0,1) in
+      ],
+    };
+    const expectedRow = [0, 1, 0];
+    const expectedCol = [1, 0, 0];
+
+    const output = JSON.parse(generateClues(JSON.stringify(fleet)));
+    expect(output.rowClues).toEqual(expectedRow);
+    expect(output.colClues).toEqual(expectedCol);
+  });
+
   it('computes correct clues for a vertical ship away from edges', () => {
     const fleet = {
       width: 5,


### PR DESCRIPTION
## Summary
- add unit test for ships with negative coordinates

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6840a9248fa4832ebb08fd10dff6a4b6