### PR TITLE
Add test for fetch error message

### DIFF
--- a/test/browser/toys.createHandleSubmit.test.js
+++ b/test/browser/toys.createHandleSubmit.test.js
@@ -41,8 +41,9 @@ describe('createHandleSubmit', () => {
       article: { id: 'a1' },
     };
 
+    const processingError = new Error('boom');
     const processingFunction = jest.fn(() => {
-      throw new Error('boom');
+      throw processingError;
     });
 
     const handler = createHandleSubmit(elements, processingFunction, env);
@@ -60,5 +61,9 @@ describe('createHandleSubmit', () => {
       elements.outputParentElement
     );
     expect(appendChild).toHaveBeenCalled();
+    expect(setTextContent).toHaveBeenCalledWith(
+      expect.anything(),
+      'Error: ' + processingError.message
+    );
   });
 });

--- a/test/browser/toys.handleRequestResponse.test.js
+++ b/test/browser/toys.handleRequestResponse.test.js
@@ -12,19 +12,19 @@ describe('handleRequestResponse', () => {
   beforeEach(() => {
     url = 'https://example.com';
     mockResponse = {
-      text: jest.fn().mockResolvedValue('response text')
+      text: jest.fn().mockResolvedValue('response text'),
     };
 
     mockParent = {
-      firstChild: null
+      firstChild: null,
     };
 
     mockDom = {
       removeAllChildren: jest.fn(),
-      createElement: jest.fn().mockImplementation((tagName) => ({
+      createElement: jest.fn().mockImplementation(tagName => ({
         tagName: tagName.toUpperCase(),
         textContent: '',
-        appendChild: jest.fn()
+        appendChild: jest.fn(),
       })),
       setTextContent: jest.fn(),
       appendChild: jest.fn().mockImplementation((parent, child) => {
@@ -32,18 +32,18 @@ describe('handleRequestResponse', () => {
         return child;
       }),
       addWarning: jest.fn(),
-      removeWarning: jest.fn()
+      removeWarning: jest.fn(),
     };
 
     mockEnv = {
       fetchFn: jest.fn().mockResolvedValue(mockResponse),
       dom: mockDom,
-      errorFn: jest.fn()
+      errorFn: jest.fn(),
     };
 
     mockOptions = {
       parent: mockParent,
-      presenterKey: 'text'
+      presenterKey: 'text',
     };
   });
 
@@ -75,7 +75,10 @@ describe('handleRequestResponse', () => {
 
     // Assert
     expect(mockDom.removeAllChildren).toHaveBeenCalledWith(mockParent);
-    expect(mockDom.appendChild).toHaveBeenCalledWith(mockParent, expect.anything());
+    expect(mockDom.appendChild).toHaveBeenCalledWith(
+      mockParent,
+      expect.anything()
+    );
   });
 
   it('should handle fetch errors', async () => {
@@ -90,11 +93,13 @@ describe('handleRequestResponse', () => {
     await new Promise(process.nextTick);
 
     // Assert
-    expect(mockEnv.errorFn).toHaveBeenCalledWith('Error fetching request URL:', error);
+    expect(mockEnv.errorFn).toHaveBeenCalledWith(
+      'Error fetching request URL:',
+      error
+    );
     expect(mockDom.setTextContent).toHaveBeenCalledWith(
-      { content: 'Error fetching URL: ' + error.message, presenterKey: mockOptions.presenterKey },
-      mockDom,
-      mockParent
+      expect.anything(),
+      'Error fetching URL: ' + error.message
     );
     expect(mockDom.addWarning).toHaveBeenCalledWith(mockParent);
   });
@@ -111,11 +116,13 @@ describe('handleRequestResponse', () => {
     await new Promise(process.nextTick);
 
     // Assert
-    expect(mockEnv.errorFn).toHaveBeenCalledWith('Error fetching request URL:', error);
+    expect(mockEnv.errorFn).toHaveBeenCalledWith(
+      'Error fetching request URL:',
+      error
+    );
     expect(mockDom.setTextContent).toHaveBeenCalledWith(
-      { content: 'Error fetching URL: ' + error.message, presenterKey: mockOptions.presenterKey },
-      mockDom,
-      mockParent
+      expect.anything(),
+      'Error fetching URL: ' + error.message
     );
     expect(mockDom.addWarning).toHaveBeenCalledWith(mockParent);
   });

--- a/test/browser/toys.handleRequestResponse.test.js
+++ b/test/browser/toys.handleRequestResponse.test.js
@@ -91,6 +91,11 @@ describe('handleRequestResponse', () => {
 
     // Assert
     expect(mockEnv.errorFn).toHaveBeenCalledWith('Error fetching request URL:', error);
+    expect(mockDom.setTextContent).toHaveBeenCalledWith(
+      { content: 'Error fetching URL: ' + error.message, presenterKey: mockOptions.presenterKey },
+      mockDom,
+      mockParent
+    );
     expect(mockDom.addWarning).toHaveBeenCalledWith(mockParent);
   });
 
@@ -107,6 +112,11 @@ describe('handleRequestResponse', () => {
 
     // Assert
     expect(mockEnv.errorFn).toHaveBeenCalledWith('Error fetching request URL:', error);
+    expect(mockDom.setTextContent).toHaveBeenCalledWith(
+      { content: 'Error fetching URL: ' + error.message, presenterKey: mockOptions.presenterKey },
+      mockDom,
+      mockParent
+    );
     expect(mockDom.addWarning).toHaveBeenCalledWith(mockParent);
   });
 });


### PR DESCRIPTION
## Summary
- extend fetch error tests to check the error message content is prefixed

## Testing
- `npm test` *(fails: npm not installed)*
- `npm run lint` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6840a92552f8832eb7fddfbe9073a474