### PR TITLE
Add regression test for module error handling

### DIFF
--- a/test/browser/toys.getModuleInitializer.invoke.test.js
+++ b/test/browser/toys.getModuleInitializer.invoke.test.js
@@ -58,4 +58,70 @@ describe('getModuleInitializer minimal invoke', () => {
 
     expect(moduleFn).toHaveBeenCalledWith('in', expect.any(Object));
   });
+
+  it('handles errors from the module function', () => {
+    const article = { id: 'a1' };
+    const functionName = 'process';
+    const inputElement = { value: 'in', disabled: false };
+    const submitButton = {};
+    const outputParent = {};
+    const outputSelect = { value: 'text' };
+    const paragraph = {};
+    const handlers = {};
+    const selectorMap = new Map([
+      ['input', inputElement],
+      ['button', submitButton],
+      ['div.output', outputParent],
+      ['div.output > p', paragraph],
+      ['select.output', outputSelect],
+    ]);
+    const dom = {
+      querySelector: jest.fn((el, selector) => selectorMap.get(selector)),
+      addEventListener: jest.fn((el, event, handler) => {
+        if (el === submitButton && event === 'click') {
+          handlers.click = handler;
+        }
+      }),
+      removeAllChildren: jest.fn(),
+      createElement: jest.fn(() => paragraph),
+      appendChild: jest.fn(),
+      setTextContent: jest.fn(),
+      removeWarning: jest.fn(),
+      enable: jest.fn(),
+      stopDefault: jest.fn(),
+      getNextSibling: jest.fn(() => null),
+      addWarning: jest.fn(),
+      contains: jest.fn(() => true),
+    };
+    const errorFn = jest.fn();
+    const config = {
+      globalState: {},
+      createEnvFn: () => ({}),
+      errorFn,
+      fetchFn: jest.fn(),
+      dom,
+      loggers: {
+        logInfo: jest.fn(),
+        logError: jest.fn(),
+        logWarning: jest.fn(),
+      },
+    };
+    const moduleFn = jest.fn(() => {
+      throw new Error('boom');
+    });
+    const module = { [functionName]: moduleFn };
+
+    const initializer = getModuleInitializer(article, functionName, config);
+    initializer(module);
+
+    handlers.click({ preventDefault: jest.fn() });
+
+    expect(errorFn).toHaveBeenCalledWith(
+      'Error processing input:',
+      expect.any(Error)
+    );
+    expect(dom.addWarning).toHaveBeenCalledWith(outputParent);
+    expect(dom.removeAllChildren).toHaveBeenCalledWith(outputParent);
+    expect(dom.appendChild).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- add failing case in `getModuleInitializer.invoke` tests to cover error handling path

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6840a926c288832e8ad5eec811ba4ba8