### PR TITLE
Add test for parseJSONResult

### DIFF
--- a/test/browser/parseJSONResult.test.js
+++ b/test/browser/parseJSONResult.test.js
@@ -1,0 +1,24 @@
+import { describe, it, expect } from '@jest/globals';
+import { readFileSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const filePath = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../src/browser/toys.js'
+);
+
+function getParseJSONResult() {
+  const code = readFileSync(filePath, 'utf8');
+  const match = code.match(/function parseJSONResult\(result\) {[^]*?\n}\n/);
+  if (!match) {throw new Error('parseJSONResult not found');}
+
+  return new Function(`${match[0]}; return parseJSONResult;`)();
+}
+
+describe('parseJSONResult', () => {
+  it('returns null when JSON parsing fails', () => {
+    const parseJSONResult = getParseJSONResult();
+    expect(parseJSONResult('not json')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add a unit test for parseJSONResult to verify null is returned on parse failure

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6840a927e73c832e8af22252baaab443