### PR TITLE
Extend test for key element disposer

### DIFF
--- a/test/browser/toys.createKeyElement.test.js
+++ b/test/browser/toys.createKeyElement.test.js
@@ -87,4 +87,25 @@ describe('createKeyElement', () => {
       handler
     );
   });
+
+  it('calls removeEventListener each time the disposer runs', () => {
+    const key = 'testKey';
+
+    keyEl = createKeyElement(
+      mockDom,
+      key,
+      textInput,
+      rows,
+      syncHiddenField,
+      disposers
+    );
+
+    const disposer = disposers[0];
+
+    disposer();
+    expect(mockDom.removeEventListener).toHaveBeenCalledTimes(1);
+
+    disposer();
+    expect(mockDom.removeEventListener).toHaveBeenCalledTimes(2);
+  });
 });


### PR DESCRIPTION
## Summary
- ensure key element disposer removes listener on each call

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6840a92994d8832e9bdf332c0e348e47