### PR TITLE
Add test for fetch error message

### DIFF
--- a/test/browser/toys.getFetchErrorHandler.test.js
+++ b/test/browser/toys.getFetchErrorHandler.test.js
@@ -30,14 +30,20 @@ describe('getFetchErrorHandler', () => {
   });
 
   it('adds a warning with a prefixed message', () => {
+    const parent = { firstChild: null };
     const dom = {
-      removeAllChildren: jest.fn(),
-      createElement: jest.fn(() => ({})),
-      setTextContent: jest.fn(),
-      appendChild: jest.fn(),
+      removeAllChildren: jest.fn(() => {
+        parent.firstChild = null;
+      }),
+      createElement: jest.fn(() => ({ textContent: '', appendChild: jest.fn() })),
+      setTextContent: jest.fn((el, text) => {
+        el.textContent = text;
+      }),
+      appendChild: jest.fn((p, child) => {
+        p.firstChild = child;
+      }),
       addWarning: jest.fn(),
     };
-    const parent = {};
     const presenterKey = 'text';
     const errorFn = jest.fn();
     const errorHandler = getFetchErrorHandler({ dom, errorFn }, parent, presenterKey);
@@ -47,6 +53,9 @@ describe('getFetchErrorHandler', () => {
 
     expect(dom.setTextContent).toHaveBeenCalledWith(
       expect.anything(),
+      'Error fetching URL: ' + error.message
+    );
+    expect(parent.firstChild.textContent).toBe(
       'Error fetching URL: ' + error.message
     );
     expect(dom.addWarning).toHaveBeenCalledWith(parent);


### PR DESCRIPTION
## Summary
- extend `getFetchErrorHandler` unit test to verify error text

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6840a92a81e8832ea7007ab894a312ae