### PR TITLE
Add test for setOutput merge

### DIFF
--- a/test/browser/toys.processInputAndSetOutput.test.js
+++ b/test/browser/toys.processInputAndSetOutput.test.js
@@ -146,7 +146,12 @@ describe('processInputAndSetOutput', () => {
     const article = { id: 'post1' };
     const outputSelect = { value: 'text' };
     const outputParentElement = {};
-    const elements = { inputElement, article, outputSelect, outputParentElement };
+    const elements = {
+      inputElement,
+      article,
+      outputSelect,
+      outputParentElement,
+    };
     const result = '{"request":{"url":""}}';
     const processingFunction = jest.fn(() => result);
     const setData = jest.fn();
@@ -161,12 +166,51 @@ describe('processInputAndSetOutput', () => {
       createElement: jest.fn(() => ({})),
       appendChild: jest.fn(),
     };
-    const fetchFn = jest.fn(() => Promise.resolve({ text: () => Promise.resolve('') }));
+    const fetchFn = jest.fn(() =>
+      Promise.resolve({ text: () => Promise.resolve('') })
+    );
     const env = { createEnv, dom, fetchFn };
 
     processInputAndSetOutput(elements, processingFunction, env);
 
     const expectedOutput = { [article.id]: result };
     expect(setData).toHaveBeenCalledWith({ output: expectedOutput });
+  });
+
+  it('merges output data when existing output present', () => {
+    const inputElement = { value: 'ignored' };
+    const article = { id: 'post1' };
+    const outputSelect = { value: 'text' };
+    const outputParentElement = {};
+    const elements = {
+      inputElement,
+      article,
+      outputSelect,
+      outputParentElement,
+    };
+    const result = '{"request":{"url":""}}';
+    const processingFunction = jest.fn(() => result);
+    const setData = jest.fn();
+    const toyEnv = new Map([
+      ['getData', () => ({ output: { other: 'prev' } })],
+      ['setData', setData],
+    ]);
+    const createEnv = jest.fn(() => toyEnv);
+    const dom = {
+      setTextContent: jest.fn(),
+      removeAllChildren: jest.fn(),
+      createElement: jest.fn(() => ({})),
+      appendChild: jest.fn(),
+    };
+    const fetchFn = jest.fn(() =>
+      Promise.resolve({ text: () => Promise.resolve('') })
+    );
+    const env = { createEnv, dom, fetchFn };
+
+    processInputAndSetOutput(elements, processingFunction, env);
+
+    expect(setData).toHaveBeenCalledWith({
+      output: { other: 'prev', [article.id]: result },
+    });
   });
 });


### PR DESCRIPTION
## Summary
- add unit test ensuring existing output is merged when processing input

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6840a92b1f20832eb7b807ec748240a1