### PR TITLE
Add test for generator sections

### DIFF
--- a/test/generator/createSection.test.js
+++ b/test/generator/createSection.test.js
@@ -1,0 +1,10 @@
+import { describe, test, expect } from '@jest/globals';
+import { getBlogGenerationArgs } from '../../src/generator/generator.js';
+
+describe('createSection integration', () => {
+  test('header and footer sections include entry div', () => {
+    const { header, footer } = getBlogGenerationArgs();
+    expect(header).toContain('<div class="entry">');
+    expect(footer).toContain('<div class="entry">');
+  });
+});


### PR DESCRIPTION
## Summary
- add test to ensure header and footer sections wrap content in an entry div

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6841212e5040832eb5c4afb582c6087e