### PR TITLE
Improve mutation test for parseJSONResult

### DIFF
--- a/test/browser/parseJSONResult.test.js
+++ b/test/browser/parseJSONResult.test.js
@@ -1,17 +1,17 @@
 import { describe, it, expect } from '@jest/globals';
 import { readFileSync } from 'fs';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import { createRequire } from 'module';
 
-const filePath = path.join(
-  path.dirname(fileURLToPath(import.meta.url)),
-  '../../src/browser/toys.js'
-);
+const require = createRequire(import.meta.url);
+
+const filePath = require.resolve('../../src/browser/toys.js');
 
 function getParseJSONResult() {
   const code = readFileSync(filePath, 'utf8');
   const match = code.match(/function parseJSONResult\(result\) {[^]*?\n}\n/);
-  if (!match) {throw new Error('parseJSONResult not found');}
+  if (!match) {
+    throw new Error('parseJSONResult not found');
+  }
 
   return new Function(`${match[0]}; return parseJSONResult;`)();
 }


### PR DESCRIPTION
## Summary
- resolve the toys module path via `createRequire` in `parseJSONResult` tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841212c6e8c832e9780ed0f9f12f53d