### PR TITLE
Eliminate surviving mutant in markdown constants

### DIFF
--- a/test/constants/markdown.dynamic.test.js
+++ b/test/constants/markdown.dynamic.test.js
@@ -7,9 +7,10 @@ describe('markdown constants isolated', () => {
   test('HTML_TAGS values via dynamic import', async () => {
     jest.resetModules();
     const module = await import('../../src/constants/markdown.js');
-    const { HTML_TAGS } = module;
+    const { HTML_TAGS, CSS_CLASSES } = module;
     expect(HTML_TAGS.LIST).toBe('ul');
     expect(HTML_TAGS.LIST_ITEM).toBe('li');
     expect(HTML_TAGS.HORIZONTAL_RULE).toBe('hr');
+    expect(CSS_CLASSES.LIST_ITEM).toBe('markdown-list-item');
   });
 });


### PR DESCRIPTION
## Summary
- extend dynamic constant test to assert `CSS_CLASSES.LIST_ITEM`

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6841212a6a78832eba7b78d6d55be459