### PR TITLE
Add test for createValueDiv

### DIFF
--- a/test/generator/createValueDiv.test.js
+++ b/test/generator/createValueDiv.test.js
@@ -1,0 +1,31 @@
+import { describe, test, expect } from '@jest/globals';
+import { readFileSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { createAttrPair, createTag, ATTR_NAME } from '../../src/generator/html.js';
+
+const filePath = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../src/generator/generator.js'
+);
+
+function getCreateValueDiv() {
+  const code = readFileSync(filePath, 'utf8');
+  const match = code.match(/const CLASS[^]*?function createValueDiv\([^]*?\n\}/);
+  if (!match) {
+    throw new Error('createValueDiv not found');
+  }
+  return new Function('createAttrPair', 'createTag', 'ATTR_NAME', `${match[0]}; return createValueDiv;`)(
+    createAttrPair,
+    createTag,
+    ATTR_NAME
+  );
+}
+
+describe('createValueDiv', () => {
+  test('filters out falsy class names', () => {
+    const createValueDiv = getCreateValueDiv();
+    const result = createValueDiv('content', ['foo', '', undefined, null, 'bar']);
+    expect(result).toBe('<div class="value foo bar">content</div>');
+  });
+});


### PR DESCRIPTION
## Summary
- increase coverage for generator.js by testing `createValueDiv`
- ensure falsy class names are removed

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684121287a20832ea9f999d1e4062d8c