### PR TITLE
Add test for generator constants

### DIFF
--- a/test/generator/generator.constants.test.js
+++ b/test/generator/generator.constants.test.js
@@ -1,0 +1,12 @@
+import { describe, test, expect } from '@jest/globals';
+import { generateBlogOuter } from '../../src/generator/generator.js';
+
+describe('generator constants usage', () => {
+  test('blog output includes container id and footer classes', () => {
+    const html = generateBlogOuter({ posts: [] });
+    expect(html).toContain('id="container"');
+    expect(html).toContain('class="footer value warning"');
+    expect(html).toContain('All content is authored by Matt Heard');
+    expect(html).toContain('Software developer and philosopher in Berlin');
+  });
+});


### PR DESCRIPTION
## Summary
- cover generator constants used in the HTML output

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684121279e70832ebdcb49faa770b5e6