### PR TITLE
Fix surviving mutant by adding column clue validation test

### DIFF
--- a/test/presenters/battleshipSolitaireClues.test.js
+++ b/test/presenters/battleshipSolitaireClues.test.js
@@ -72,6 +72,13 @@ describe('createBattleshipCluesBoardElement – error handling', () => {
     expectEmpty10x10Board(el);
   });
 
+  test('renders 10x10 empty board when column clue values are non‑numeric', () => {
+    const dom = makeDom();
+    const bad = JSON.stringify({ rowClues: [1, 2], colClues: [3, "x"] });
+    const el = createBattleshipCluesBoardElement(bad, dom);
+    expectEmpty10x10Board(el);
+  });
+
   test('renders 10x10 empty board when any array is empty', () => {
     const dom = makeDom();
     const bad = JSON.stringify({ rowClues: [], colClues: [1] });


### PR DESCRIPTION
## Summary
- add a test for invalid column clue values in the battleship clues presenter

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684121266b70832ebb1dd01cd0636075