### PR TITLE
Add mutant-killing markdown constants test

### DIFF
--- a/test/constants/markdown.mutant.test.js
+++ b/test/constants/markdown.mutant.test.js
@@ -1,0 +1,22 @@
+import { describe, test, expect } from '@jest/globals';
+import { CSS_CLASSES } from '../../src/constants/markdown.js';
+
+// Additional coverage to kill Stryker mutants around CSS_CLASSES values
+
+describe('markdown constants mutants', () => {
+  test('CSS_CLASSES object has expected values', () => {
+    expect(CSS_CLASSES).toEqual({
+      CONTAINER: 'markdown-container',
+      HEADING: 'markdown-heading',
+      PARAGRAPH: 'markdown-paragraph',
+      LIST: 'markdown-list',
+      LIST_ITEM: 'markdown-list-item',
+      BLOCKQUOTE: 'markdown-blockquote',
+      CODE: 'markdown-code',
+      INLINE_CODE: 'markdown-inline-code',
+      LINK: 'markdown-link',
+      IMAGE: 'markdown-image',
+      HORIZONTAL_RULE: 'markdown-hr',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add additional unit test ensuring CSS_CLASSES contains all expected values

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684121259b4c832eb3a850738715d651