### PR TITLE
Add dynamic CSS_CLASSES tests

### DIFF
--- a/test/constants/markdown.dynamic.test.js
+++ b/test/constants/markdown.dynamic.test.js
@@ -12,4 +12,15 @@ describe('markdown constants isolated', () => {
     expect(HTML_TAGS.LIST_ITEM).toBe('li');
     expect(HTML_TAGS.HORIZONTAL_RULE).toBe('hr');
   });
+
+  test('CSS_CLASSES values via dynamic import', async () => {
+    jest.resetModules();
+    const module = await import('../../src/constants/markdown.js');
+    const { CSS_CLASSES } = module;
+    expect(CSS_CLASSES.LIST).toBe('markdown-list');
+    expect(CSS_CLASSES.LIST_ITEM).toBe('markdown-list-item');
+    expect(CSS_CLASSES.BLOCKQUOTE).toBe('markdown-blockquote');
+    expect(CSS_CLASSES.CODE).toBe('markdown-code');
+    expect(CSS_CLASSES.INLINE_CODE).toBe('markdown-inline-code');
+  });
 });


### PR DESCRIPTION
## Summary
- extend dynamic constant tests to cover CSS_CLASSES

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68412122d098832ebf5f04afb57bad57