### PR TITLE
Add test for initialization log message

### DIFF
--- a/test/browser/toys.test.js
+++ b/test/browser/toys.test.js
@@ -1165,6 +1165,48 @@ describe('toys', () => {
       expect(querySelector).toHaveBeenCalledWith(article, 'div.output');
       expect(querySelector).toHaveBeenCalledWith(article, 'select.output');
     });
+
+    it('logs initialization message with article id', () => {
+      const createEnvFn = () => ({});
+      const errorFn = jest.fn();
+      const fetchFn = jest.fn();
+      const logInfo = jest.fn();
+      const dom = {
+        removeAllChildren: jest.fn(),
+        createElement: jest.fn(() => ({ textContent: '' })),
+        stopDefault: jest.fn(),
+        addWarning: jest.fn(),
+        addWarningFn: jest.fn(),
+        addEventListener: jest.fn(),
+        removeChild: jest.fn(),
+        appendChild: jest.fn(),
+        querySelector,
+        setTextContent: jest.fn(),
+        removeWarning: jest.fn(),
+        enable: jest.fn(),
+        contains: () => true,
+      };
+      const processingFunction = jest.fn();
+      const config = {
+        globalState: {},
+        createEnvFn,
+        errorFn,
+        fetchFn,
+        dom,
+        loggers: {
+          logInfo,
+          logError: jest.fn(),
+          logWarning: jest.fn(),
+        },
+      };
+
+      initializeInteractiveComponent(article, processingFunction, config);
+
+      expect(logInfo).toHaveBeenCalledWith(
+        'Initializing interactive component for article',
+        article.id
+      );
+    });
   });
 
   describe('initializeVisibleComponents', () => {


### PR DESCRIPTION
## Summary
- extend initializeInteractiveComponent tests to verify log message

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68412121b8b8832e8adf77961e54e4a1