### PR TITLE
Add test for header generation

### DIFF
--- a/test/generator/headerContent.test.js
+++ b/test/generator/headerContent.test.js
@@ -1,0 +1,22 @@
+import { describe, test, expect } from '@jest/globals';
+import path from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+
+function loadGenerator() {
+  const filePath = path.join(
+    path.dirname(fileURLToPath(import.meta.url)),
+    '../../src/generator/generator.js'
+  );
+  const url = pathToFileURL(filePath).toString();
+  const cacheBust = `?cacheBust=${Date.now()}`;
+  return import(url + cacheBust);
+}
+
+describe('header generation', () => {
+  test('generateBlogOuter includes banner and metadata', async () => {
+    const { generateBlogOuter } = await loadGenerator();
+    const html = generateBlogOuter({ posts: [] });
+    expect(html).toContain('aria-label="Matt Heard"');
+    expect(html).toContain('Software developer and philosopher in Berlin');
+  });
+});


### PR DESCRIPTION
## Summary
- add a unit test that dynamically loads generator.js to ensure the header contains the banner and metadata

## Testing
- `npm test --silent`
- `npm run lint --silent`

------
https://chatgpt.com/codex/tasks/task_e_68413d862c50832e86024e6270ddde00