### PR TITLE
Add test for kv container creation

### DIFF
--- a/test/browser/toys.handleKVType.effects.test.js
+++ b/test/browser/toys.handleKVType.effects.test.js
@@ -37,10 +37,56 @@ describe('handleKVType effects', () => {
 
     handleKVType(dom, container, textInput);
 
-    expect(querySelector).toHaveBeenCalledWith(container, 'input[type="number"]');
+    expect(querySelector).toHaveBeenCalledWith(
+      container,
+      'input[type="number"]'
+    );
     expect(removeChild).toHaveBeenCalledWith(container, numberInput);
     expect(querySelector).toHaveBeenCalledWith(container, '.kv-container');
     expect(createElement).toHaveBeenCalledWith('div');
     expect(insertBefore).toHaveBeenCalled();
+  });
+
+  it('creates a kv-container div and applies the class', () => {
+    const numberInput = { _dispose: jest.fn() };
+    const container = {};
+    const textInput = {};
+    const querySelector = jest.fn((el, selector) => {
+      if (selector === 'input[type="number"]') {
+        return numberInput;
+      }
+      return null;
+    });
+    const kvContainer = {};
+    const extraEl = {};
+    const createElement = jest
+      .fn()
+      .mockReturnValueOnce(kvContainer)
+      .mockReturnValue(extraEl);
+    const setClassName = jest.fn();
+    const dom = {
+      querySelector,
+      removeChild: jest.fn(),
+      createElement,
+      setClassName,
+      getNextSibling: jest.fn(),
+      insertBefore: jest.fn(),
+      removeAllChildren: jest.fn(),
+      setType: jest.fn(),
+      setPlaceholder: jest.fn(),
+      setValue: jest.fn(),
+      setDataAttribute: jest.fn(),
+      addEventListener: jest.fn(),
+      setTextContent: jest.fn(),
+      appendChild: jest.fn(),
+      getValue: jest.fn(() => '{}'),
+      querySelectorAll: jest.fn(),
+      createTextNode: jest.fn(),
+    };
+
+    handleKVType(dom, container, textInput);
+
+    expect(createElement.mock.calls[0][0]).toBe('div');
+    expect(setClassName).toHaveBeenCalledWith(kvContainer, 'kv-container');
   });
 });


### PR DESCRIPTION
## Summary
- ensure `ensureKeyValueInput` creates a `div` with `kv-container` class

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68413d84e5c8832ea202d4e90913dcef