### PR TITLE
Add unit test for parseJSONResult success case

### DIFF
--- a/test/browser/parseJSONResult.test.js
+++ b/test/browser/parseJSONResult.test.js
@@ -21,4 +21,10 @@ describe('parseJSONResult', () => {
     const parseJSONResult = getParseJSONResult();
     expect(parseJSONResult('not json')).toBeNull();
   });
+
+  it('parses valid JSON into an object', () => {
+    const parseJSONResult = getParseJSONResult();
+    const result = parseJSONResult('{"a":1}');
+    expect(result).toEqual({ a: 1 });
+  });
 });


### PR DESCRIPTION
## Summary
- add a new test covering successful JSON parsing in `parseJSONResult`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68413d84ab90832e838bdb8f8aa93e16