### PR TITLE
Add header coverage test

### DIFF
--- a/test/generator/headerContent.test.js
+++ b/test/generator/headerContent.test.js
@@ -1,0 +1,12 @@
+import { describe, test, expect } from '@jest/globals';
+
+// Dynamically import generator functions within the test to ensure coverage
+
+describe('header content generation', () => {
+  test('header includes banner and metadata text', async () => {
+    const { getBlogGenerationArgs } = await import('../../src/generator/generator.js');
+    const { header } = getBlogGenerationArgs();
+    expect(header).toContain('aria-label="Matt Heard"');
+    expect(header).toContain('Software developer and philosopher in Berlin');
+  });
+});


### PR DESCRIPTION
## Summary
- add a dynamic test ensuring blog header contains banner and metadata

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68413d7fc53c832eb4cf9209dd431fea