### PR TITLE
Add dynamic import test for header generation

### DIFF
--- a/test/generator/headerContent.imported.test.js
+++ b/test/generator/headerContent.imported.test.js
@@ -1,0 +1,13 @@
+import { describe, test, expect } from '@jest/globals';
+
+describe('generator header dynamic import', () => {
+  test('header includes banner, metadata and container', async () => {
+    const { getBlogGenerationArgs } = await import(
+      '../../src/generator/generator.js'
+    );
+    const { header } = getBlogGenerationArgs();
+    expect(header).toContain('aria-label="Matt Heard"');
+    expect(header).toContain('Software developer and philosopher in Berlin');
+    expect(header).toContain('<div id="container">');
+  });
+});


### PR DESCRIPTION
## Summary
- add test covering generator header via dynamic import

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68414217eea0832ebeeb42e6448d3057