### PR TITLE
Add fishingGame time of day test

### DIFF
--- a/test/toys/2025-03-29/fishingGame.test.js
+++ b/test/toys/2025-03-29/fishingGame.test.js
@@ -2,24 +2,27 @@
 import { fishingGame } from '../../../src/toys/2025-03-29/fishingGame';
 
 // Helper function to create a fixed environment.
-const createEnv = (randomValue, currentTime) => new Map([
-  ["getRandomNumber", () => randomValue],
-  ["getCurrentTime", () => currentTime],
-]);
+const createEnv = (randomValue, currentTime) =>
+  new Map([
+    ['getRandomNumber', () => randomValue],
+    ['getCurrentTime', () => currentTime],
+  ]);
 
 describe('fishingGame', () => {
   // Test various outcomes based on bait and random values.
 
   test('handles empty input gracefully', () => {
-    const env = createEnv(0.5, "2025-03-29T08:00:00");
-    const output = fishingGame("   ", env);
+    const env = createEnv(0.5, '2025-03-29T08:00:00');
+    const output = fishingGame('   ', env);
     expect(output).toMatch(/without any bait/i);
-    expect(output).toMatch(/bubbling, fresh currents as dawn breaks with promise/i);
+    expect(output).toMatch(
+      /bubbling, fresh currents as dawn breaks with promise/i
+    );
   });
 
   test('recognizes a known bait and applies its modifier (e.g., worm, modifier 0.0)', () => {
-    const env = createEnv(0.25, "2025-12-15T22:00:00"); // winter night
-    const output = fishingGame("worm", env);
+    const env = createEnv(0.25, '2025-12-15T22:00:00'); // winter night
+    const output = fishingGame('worm', env);
     // With base chance 0.25, effective chance remains 0.25 (< 0.3) → no catch.
     expect(output).toMatch(/wriggling worm/i);
     expect(output).toMatch(/water stays silent/i);
@@ -27,8 +30,8 @@ describe('fishingGame', () => {
   });
 
   test('applies negative modifier for poor bait (e.g., bread, modifier -0.05)', () => {
-    const env = createEnv(0.35, "2025-06-10T14:00:00"); // summer afternoon
-    const output = fishingGame("bread", env);
+    const env = createEnv(0.35, '2025-06-10T14:00:00'); // summer afternoon
+    const output = fishingGame('bread', env);
     // With base chance 0.35 and modifier -0.05, effective chance is 0.3 (edge case: 0.3 → should get common carp outcome)
     expect(output).toMatch(/slice of bread/i);
     // Effective chance exactly 0.3 should be in the next bracket.
@@ -37,8 +40,8 @@ describe('fishingGame', () => {
   });
 
   test('applies positive modifier for good bait (e.g., cheese, modifier 0.1)', () => {
-    const env = createEnv(0.75, "2025-09-05T19:00:00"); // fall evening
-    const output = fishingGame("cheese", env);
+    const env = createEnv(0.75, '2025-09-05T19:00:00'); // fall evening
+    const output = fishingGame('cheese', env);
     // With base chance 0.75 and modifier 0.1, effective chance is 0.85 (edge: should get legendary outcome)
     expect(output).toMatch(/pungent piece of cheese/i);
     expect(output).toMatch(/legendary golden fish leaps forth/i);
@@ -46,17 +49,19 @@ describe('fishingGame', () => {
   });
 
   test('handles unrecognized bait as unconventional bait with no modifier', () => {
-    const env = createEnv(0.8, "2025-04-01T10:00:00"); // spring morning
-    const output = fishingGame("mystery lure", env);
+    const env = createEnv(0.8, '2025-04-01T10:00:00'); // spring morning
+    const output = fishingGame('mystery lure', env);
     expect(output).toMatch(/unconventional bait/i);
     // With base chance 0.8 and modifier 0, effective chance is 0.8 → glimmering trout outcome.
     expect(output).toMatch(/glimmering trout appears/i);
-    expect(output).toMatch(/bubbling, fresh currents as dawn breaks with promise/i);
+    expect(output).toMatch(
+      /bubbling, fresh currents as dawn breaks with promise/i
+    );
   });
 
   test('produces common carp outcome for effectiveChance between 0.3 and 0.6', () => {
-    const env = createEnv(0.5, "2025-11-20T16:00:00"); // fall afternoon
-    const output = fishingGame("minnow", env);
+    const env = createEnv(0.5, '2025-11-20T16:00:00'); // fall afternoon
+    const output = fishingGame('minnow', env);
     // Minnow modifier is 0.1, so effective chance = 0.6 → borderline. We define < 0.6 as common carp.
     // Since effectiveChance equals 0.6 exactly, it should fall into the next bracket (trout) if we use < comparison.
     // Let’s adjust: effectiveChance < 0.3, < 0.6, < 0.85, else. So 0.6 goes to trout.
@@ -65,11 +70,17 @@ describe('fishingGame', () => {
   });
 
   test('produces legendary outcome for very high effectiveChance', () => {
-    const env = createEnv(0.9, "2025-07-04T12:00:00"); // summer noon
-    const output = fishingGame("doughnut", env);
+    const env = createEnv(0.9, '2025-07-04T12:00:00'); // summer noon
+    const output = fishingGame('doughnut', env);
     // Doughnut modifier is 0.2, so effective chance = 1.1 clamped to 1 → legendary fish.
     expect(output).toMatch(/tempting doughnut/i);
     expect(output).toMatch(/legendary golden fish leaps forth/i);
     expect(output).toMatch(/warm, shimmering waves under a vibrant sun/i);
+  });
+
+  test('uses night mood for early morning hours', () => {
+    const env = createEnv(0.5, '2025-06-10T03:00:00'); // summer night
+    const output = fishingGame('worm', env);
+    expect(output).toMatch(/beneath a silent, starry sky/i);
   });
 });


### PR DESCRIPTION
## Summary
- add unit test covering early morning mood in `fishingGame`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684142150e2c832ea9055cd187b1427d