### PR TITLE
Add dynamic header args test

### DIFF
--- a/test/generator/headerContentGetArgs.test.js
+++ b/test/generator/headerContentGetArgs.test.js
@@ -1,0 +1,21 @@
+import { describe, test, expect } from '@jest/globals';
+import path from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+
+function loadGenerator() {
+  const filePath = path.join(
+    path.dirname(fileURLToPath(import.meta.url)),
+    '../../src/generator/generator.js'
+  );
+  const url = pathToFileURL(filePath).toString();
+  return import(url + `?cacheBust=${Date.now()}`);
+}
+
+describe('header generation via getBlogGenerationArgs', () => {
+  test('header contains banner and metadata', async () => {
+    const { getBlogGenerationArgs } = await loadGenerator();
+    const { header } = getBlogGenerationArgs();
+    expect(header).toContain('aria-label="Matt Heard"');
+    expect(header).toContain('Software developer and philosopher in Berlin');
+  });
+});


### PR DESCRIPTION
## Summary
- check banner and metadata via `getBlogGenerationArgs`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68414213f8a4832eb12041f0a479d7e1