### PR TITLE
Extend tests for generator mutation

### DIFF
--- a/test/generator/defaultKeyExtraClasses.test.js
+++ b/test/generator/defaultKeyExtraClasses.test.js
@@ -1,0 +1,28 @@
+import { describe, test, expect } from '@jest/globals';
+import { readFileSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const filePath = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../src/generator/generator.js'
+);
+
+function getDefaultKeyExtraClasses() {
+  const code = readFileSync(filePath, 'utf8');
+  const match = code.match(/function defaultKeyExtraClasses\([^]*?\n\}/);
+  if (!match) {
+    throw new Error('defaultKeyExtraClasses not found');
+  }
+  return new Function(`${match[0]}; return defaultKeyExtraClasses;`)();
+}
+
+describe('defaultKeyExtraClasses', () => {
+  test('sets keyExtraClasses to empty string when undefined', () => {
+    const defaultKeyExtraClasses = getDefaultKeyExtraClasses();
+    const args = {};
+    const result = defaultKeyExtraClasses(args);
+    expect(result.keyExtraClasses).toBe('');
+    expect(args.keyExtraClasses).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test for `defaultKeyExtraClasses` to ensure it assigns a default value

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68414218dbfc832eaa3eb133e9910f48