### PR TITLE
Add header section test

### DIFF
--- a/test/generator/headerSection.test.js
+++ b/test/generator/headerSection.test.js
@@ -1,0 +1,10 @@
+import { describe, test, expect } from '@jest/globals';
+
+describe('header section generation', () => {
+  test('generateBlogOuter includes banner and metadata when importing normally', async () => {
+    const { generateBlogOuter } = await import('../../src/generator/generator.js');
+    const html = generateBlogOuter({ posts: [] });
+    expect(html).toContain('aria-label="Matt Heard"');
+    expect(html).toContain('Software developer and philosopher in Berlin');
+  });
+});


### PR DESCRIPTION
## Summary
- test the header section output using a normal import

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684185c6f014832eb05815f30773ae14