### PR TITLE
Improve header section test

### DIFF
--- a/test/generator/headerContentGetArgs.test.js
+++ b/test/generator/headerContentGetArgs.test.js
@@ -18,4 +18,10 @@ describe('header generation via getBlogGenerationArgs', () => {
     expect(header).toContain('aria-label="Matt Heard"');
     expect(header).toContain('Software developer and philosopher in Berlin');
   });
+
+  test('header section is wrapped in entry div', async () => {
+    const { getBlogGenerationArgs } = await loadGenerator();
+    const { header } = getBlogGenerationArgs();
+    expect(header).toContain('<div class="entry">');
+  });
 });


### PR DESCRIPTION
## Summary
- ensure blog header is wrapped in an entry div when using `getBlogGenerationArgs`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684185c330f4832ebacac9306492f1e3