### PR TITLE
Extend tests to kill surviving mutant

### DIFF
--- a/test/toys/2025-03-30/cyberpunkAdventure.test.js
+++ b/test/toys/2025-03-30/cyberpunkAdventure.test.js
@@ -189,6 +189,12 @@ describe('Cyberpunk Text Game', () => {
     );
   });
 
+  test('visited list starts empty when starting new game', () => {
+    cyberpunkAdventure('Blaze', env);
+    cyberpunkAdventure('start', env);
+    expect(tempData.visited).toEqual([]);
+  });
+
   test("defaults name to 'Stray' if no input and no name in temporary data", () => {
     env.set('getData', () => ({ temporary: {} }));
     const result = cyberpunkAdventure('   ', env);


### PR DESCRIPTION
## Summary
- add a new test verifying the visited list starts empty in `cyberpunkAdventure`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684185c295a4832ea050e4504278107d