### PR TITLE
Add fresh import test for generator header

### DIFF
--- a/test/generator/headerContentFresh.test.js
+++ b/test/generator/headerContentFresh.test.js
@@ -1,0 +1,21 @@
+import { describe, test, expect } from '@jest/globals';
+import path from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+
+function loadFreshGenerator() {
+  const filePath = path.join(
+    path.dirname(fileURLToPath(import.meta.url)),
+    '../../src/generator/generator.js'
+  );
+  const url = pathToFileURL(filePath).toString();
+  return import(url + `?fresh=${Date.now()}`);
+}
+
+describe('header generation fresh import', () => {
+  test('fresh import includes banner and metadata', async () => {
+    const { generateBlogOuter } = await loadFreshGenerator();
+    const html = generateBlogOuter({ posts: [] });
+    expect(html).toContain('aria-label="Matt Heard"');
+    expect(html).toContain('Software developer and philosopher in Berlin');
+  });
+});


### PR DESCRIPTION
## Summary
- add a test that loads generator.js with a cache-busting query to verify the blog header includes banner and metadata

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684185be2cbc832e933837fa1ff1dc28