### PR TITLE
Add import-based test for createValueDiv

### DIFF
--- a/test/generator/createValueDiv.imported.test.js
+++ b/test/generator/createValueDiv.imported.test.js
@@ -1,0 +1,38 @@
+import { describe, test, expect } from '@jest/globals';
+import { readFileSync, writeFileSync, unlinkSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const filePath = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../src/generator/generator.js'
+);
+
+async function loadCreateValueDiv() {
+  const code = readFileSync(filePath, 'utf8');
+  const injectedPath = path.join(
+    path.dirname(filePath),
+    `__cvd_${process.pid}.mjs`
+  );
+  writeFileSync(
+    injectedPath,
+    `${code}\nexport { createValueDiv as __createValueDiv };`
+  );
+  const module = await import(injectedPath);
+  unlinkSync(injectedPath);
+  return module.__createValueDiv;
+}
+
+describe('createValueDiv imported', () => {
+  test('filters out falsy class names when loaded via import', async () => {
+    const createValueDiv = await loadCreateValueDiv();
+    const result = createValueDiv('content', [
+      'foo',
+      '',
+      undefined,
+      null,
+      'bar',
+    ]);
+    expect(result).toBe('<div class="value foo bar">content</div>');
+  });
+});


### PR DESCRIPTION
## Summary
- add an additional unit test that loads `createValueDiv` via a temporary ESM module
- this test ensures falsy class names are filtered when the module is imported

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684185bc884c832e9816194e9ee9a817