### PR TITLE
Add header metadata class check

### DIFF
--- a/test/generator/headerContent.imported.test.js
+++ b/test/generator/headerContent.imported.test.js
@@ -9,5 +9,6 @@ describe('generator header dynamic import', () => {
     expect(header).toContain('aria-label="Matt Heard"');
     expect(header).toContain('Software developer and philosopher in Berlin');
     expect(header).toContain('<div id="container">');
+    expect(header).toContain('class="value metadata"');
   });
 });


### PR DESCRIPTION
## Summary
- extend header test to verify metadata CSS class

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684185c046e0832e80dba35bef05642d