### PR TITLE
Add header metadata class test

### DIFF
--- a/test/generator/headerContent.test.js
+++ b/test/generator/headerContent.test.js
@@ -19,4 +19,10 @@ describe('header generation', () => {
     expect(html).toContain('aria-label="Matt Heard"');
     expect(html).toContain('Software developer and philosopher in Berlin');
   });
+
+  test('metadata div has the metadata class', async () => {
+    const { getBlogGenerationArgs } = await loadGenerator();
+    const { header } = getBlogGenerationArgs();
+    expect(header).toContain('class="value metadata"');
+  });
 });


### PR DESCRIPTION
## Summary
- extend headerContent tests to assert metadata div has the metadata class

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684185bf2cfc832e8c2376c5818c52e6