### PR TITLE
Add test for null content normalization

### DIFF
--- a/test/generator/normalizeContentItem.null.test.js
+++ b/test/generator/normalizeContentItem.null.test.js
@@ -1,0 +1,19 @@
+import { describe, test, expect } from '@jest/globals';
+import { generateBlogOuter } from '../../src/generator/generator.js';
+
+describe('normalizeContentItem with null content', () => {
+  test('generateBlogOuter handles null in post content array', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'NULL',
+          title: 'Null Post',
+          publicationDate: '2024-06-01',
+          content: [null],
+        },
+      ],
+    };
+    const html = generateBlogOuter(blog);
+    expect(html).toContain('<p class="value">null</p>');
+  });
+});


### PR DESCRIPTION
## Summary
- add regression test for blog generation when a post contains `null`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68418926ee2c832ebe3cf40925384c99