### PR TITLE
Improve test coverage for dynamic imports

### DIFF
--- a/test/browser/parseJSONResult.test.js
+++ b/test/browser/parseJSONResult.test.js
@@ -10,7 +10,7 @@ const filePath = require.resolve('../../src/browser/toys.js');
 
 async function getParseJSONResult() {
   const code = readFileSync(filePath, 'utf8');
-  const tempPath = join(dirname(filePath), `parseJSONResult.${Date.now()}.mjs`);
+  const tempPath = join(dirname(filePath), `parseJSONResult.${Date.now()}.js`);
   writeFileSync(tempPath, `${code}\nexport { parseJSONResult };`);
   const module = await import(`${pathToFileURL(tempPath).href}`);
   const fn = module.parseJSONResult;

--- a/test/generator/createValueDiv.imported.test.js
+++ b/test/generator/createValueDiv.imported.test.js
@@ -12,7 +12,7 @@ async function loadCreateValueDiv() {
   const code = readFileSync(filePath, 'utf8');
   const injectedPath = path.join(
     path.dirname(filePath),
-    `__cvd_${process.pid}.mjs`
+    `__cvd_${process.pid}.js`
   );
   writeFileSync(
     injectedPath,


### PR DESCRIPTION
## Summary
- tweak dynamic import helper paths so Jest instruments them for coverage

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684189234e28832e96c8c90da51aa924