### PR TITLE
Add parseJSONResult sync unit tests

### DIFF
--- a/test/browser/parseJSONResult.test.js
+++ b/test/browser/parseJSONResult.test.js
@@ -18,6 +18,15 @@ async function getParseJSONResult() {
   return fn;
 }
 
+function getParseJSONResultSync() {
+  const code = readFileSync(filePath, 'utf8');
+  const match = code.match(/function parseJSONResult\(result\) {[^]*?\n}\n/);
+  if (!match) {
+    throw new Error('parseJSONResult not found');
+  }
+  return new Function(`${match[0]}; return parseJSONResult;`)();
+}
+
 describe('parseJSONResult', () => {
   it('returns null when JSON parsing fails', async () => {
     const parseJSONResult = await getParseJSONResult();
@@ -28,5 +37,15 @@ describe('parseJSONResult', () => {
     const parseJSONResult = await getParseJSONResult();
     const result = parseJSONResult('{"a":1}');
     expect(result).toEqual({ a: 1 });
+  });
+
+  it('sync extraction returns null for invalid JSON', () => {
+    const parseJSONResult = getParseJSONResultSync();
+    expect(parseJSONResult('bad')).toBeNull();
+  });
+
+  it('sync extraction parses valid JSON', () => {
+    const parseJSONResult = getParseJSONResultSync();
+    expect(parseJSONResult('{"b":2}')).toEqual({ b: 2 });
   });
 });


### PR DESCRIPTION
## Summary
- improve mutation coverage around `parseJSONResult`
- add sync extraction tests so invalid JSON parsing is asserted without dynamic import

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684189210ad4832eb1118859d8cbdd0b