### PR TITLE
Add edge case test for parseJSONResult

### DIFF
--- a/test/browser/parseJSONResult.test.js
+++ b/test/browser/parseJSONResult.test.js
@@ -29,4 +29,9 @@ describe('parseJSONResult', () => {
     const result = parseJSONResult('{"a":1}');
     expect(result).toEqual({ a: 1 });
   });
+
+  it('returns null when called with undefined', async () => {
+    const parseJSONResult = await getParseJSONResult();
+    expect(parseJSONResult(undefined)).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- extend `parseJSONResult` tests to cover undefined input

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684189220760832e958b713f2d97fd0d