### PR TITLE
Add test for negative ship coordinates

### DIFF
--- a/test/presenters/battleshipSolitaireFleet.test.js
+++ b/test/presenters/battleshipSolitaireFleet.test.js
@@ -170,4 +170,17 @@ describe('createBattleshipFleetBoardElement', () => {
     expect(lines[0].replace(/ /g, '')).toBe('·#');
     expect(lines[1].replace(/ /g, '')).toBe('··');
   });
+
+  test('ignores ships with negative start coordinates', () => {
+    const fleet = {
+      width: 3,
+      height: 3,
+      ships: [{ start: { x: -1, y: 1 }, length: 2, direction: 'H' }],
+    };
+    const input = JSON.stringify(fleet);
+    const el = createBattleshipFleetBoardElement(input, dom);
+    expect(el.tag).toBe('pre');
+    const lines = el.text.trim().split('\n');
+    expect(lines).toEqual(['· · ·', '# · ·', '· · ·']);
+  });
 });


### PR DESCRIPTION
## Summary
- add a regression test ensuring ships with negative start coordinates are ignored

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841891f750c832eaabe9df483f5702a