### PR TITLE
Add head element test

### DIFF
--- a/test/generator/headElement.test.js
+++ b/test/generator/headElement.test.js
@@ -1,0 +1,10 @@
+import { describe, test, expect } from '@jest/globals';
+import { headElement } from '../../src/generator/head.js';
+
+describe('headElement constant', () => {
+  test('contains basic head markup', () => {
+    expect(headElement).toContain('<head>');
+    expect(headElement).toContain('<meta charset="UTF-8">');
+    expect(headElement).toContain('</head>');
+  });
+});


### PR DESCRIPTION
## Summary
- add a unit test for `headElement` verifying the exported markup

## Testing
- `npm test --silent`
- `npm run lint --silent`

------
https://chatgpt.com/codex/tasks/task_e_6841891f3f5c832eb46a83c58251c5be