### PR TITLE
Add test for footer classes

### DIFF
--- a/test/generator/getBlogGenerationArgs.test.js
+++ b/test/generator/getBlogGenerationArgs.test.js
@@ -39,4 +39,10 @@ describe('getBlogGenerationArgs', () => {
     const { footer } = getBlogGenerationArgs();
     expect(footer).toContain('All content is authored by Matt Heard and is');
   });
+
+  it('includes the footer classes in the footer HTML', () => {
+    const { footer } = getBlogGenerationArgs();
+    expect(footer).toContain('class="footer value warning"');
+    expect(footer).not.toContain('undefined');
+  });
 });


### PR DESCRIPTION
## Summary
- improve `getBlogGenerationArgs` test to check footer classes

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841891db540832e935d8b18f1fbe56e