### PR TITLE
Add test for parseJSONResult syntax errors

### DIFF
--- a/test/browser/parseJSONResult.test.js
+++ b/test/browser/parseJSONResult.test.js
@@ -29,4 +29,9 @@ describe('parseJSONResult', () => {
     const result = parseJSONResult('{"a":1}');
     expect(result).toEqual({ a: 1 });
   });
+
+  it('returns null for JSON with syntax error', async () => {
+    const parseJSONResult = await getParseJSONResult();
+    expect(parseJSONResult('{"a":1,}')).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- extend parseJSONResult tests with extra invalid JSON case

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841891d7eb8832eb853baa22daf9e85