### PR TITLE
Add test for enableInteractiveControls call

### DIFF
--- a/test/browser/toys.test.js
+++ b/test/browser/toys.test.js
@@ -1281,10 +1281,18 @@ describe('toys', () => {
         removeChild: jest.fn(),
         appendChild: jest.fn(),
         querySelector: jest.fn((_, selector) => {
-          if (selector === 'input') {return inputElement;}
-          if (selector === 'button') {return submitButton;}
-          if (selector === 'div.output') {return outputParent;}
-          if (selector === 'select.output') {return {};}
+          if (selector === 'input') {
+            return inputElement;
+          }
+          if (selector === 'button') {
+            return submitButton;
+          }
+          if (selector === 'div.output') {
+            return outputParent;
+          }
+          if (selector === 'select.output') {
+            return {};
+          }
           return {};
         }),
         removeWarning: jest.fn(),
@@ -1309,6 +1317,7 @@ describe('toys', () => {
 
       expect(dom.enable).toHaveBeenCalledWith(inputElement);
       expect(dom.enable).toHaveBeenCalledWith(submitButton);
+      expect(dom.removeWarning).toHaveBeenCalledWith(outputParent);
     });
   });
 


### PR DESCRIPTION
## Summary
- extend `initializeInteractiveComponent` tests to ensure `enableInteractiveControls` receives the correct parent

## Testing
- `node --experimental-vm-modules node_modules/jest/bin/jest.js --coverage --runInBand`
- `npm run lint --silent`

------
https://chatgpt.com/codex/tasks/task_e_6841891c6d84832eaeb9f62201df849f