### PR TITLE
Add test to kill shuffle mutant

### DIFF
--- a/test/toys/2025-05-08/battleshipSolitaireFleet.test.js
+++ b/test/toys/2025-05-08/battleshipSolitaireFleet.test.js
@@ -142,4 +142,12 @@ describe('generateFleet', () => {
     const lengths = fleet.ships.map(ship => ship.length);
     expect(lengths).toEqual([2, 3, 1]);
   });
+
+  test('shuffles ship order differently for non-zero RNG', () => {
+    const cfg = { width: 4, height: 4, ships: [1, 2, 3] };
+    const env = new Map([['getRandomNumber', () => 0.5]]);
+    const fleet = JSON.parse(generateFleet(JSON.stringify(cfg), env));
+    const lengths = fleet.ships.map(ship => ship.length);
+    expect(lengths).toEqual([1, 3, 2]);
+  });
 });


### PR DESCRIPTION
## Summary
- exercise battleshipSolitaireFleet shuffle with non-zero RNG

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841891bc634832ea34c5d2d7157e18d