### PR TITLE
Fix mutation survivor by dynamic imports

### DIFF
--- a/test/generator/createSection.test.js
+++ b/test/generator/createSection.test.js
@@ -1,5 +1,12 @@
-import { describe, test, expect } from '@jest/globals';
-import { getBlogGenerationArgs } from '../../src/generator/generator.js';
+import { describe, test, expect, beforeAll } from '@jest/globals';
+
+let getBlogGenerationArgs;
+
+beforeAll(async () => {
+  ({ getBlogGenerationArgs } = await import(
+    '../../src/generator/generator.js'
+  ));
+});
 
 describe('createSection integration', () => {
   test('header and footer sections include entry div', () => {

--- a/test/generator/generator.constants.test.js
+++ b/test/generator/generator.constants.test.js
@@ -1,5 +1,10 @@
-import { describe, test, expect } from '@jest/globals';
-import { generateBlogOuter } from '../../src/generator/generator.js';
+import { describe, test, expect, beforeAll } from '@jest/globals';
+
+let generateBlogOuter;
+
+beforeAll(async () => {
+  ({ generateBlogOuter } = await import('../../src/generator/generator.js'));
+});
 
 describe('generator constants usage', () => {
   test('blog output includes container id and footer classes', () => {

--- a/test/generator/generator.test.js
+++ b/test/generator/generator.test.js
@@ -1,4 +1,8 @@
-import { generateBlog } from '../../src/generator/generator.js';
+let generateBlog;
+
+beforeAll(async () => {
+  ({ generateBlog } = await import('../../src/generator/generator.js'));
+});
 
 const header = '<body>';
 const footer = '</body>';

--- a/test/generator/getBlogGenerationArgs.test.js
+++ b/test/generator/getBlogGenerationArgs.test.js
@@ -1,7 +1,13 @@
-import {
-  getBlogGenerationArgs,
-  generateBlogOuter,
-} from '../../src/generator/generator.js';
+import { beforeAll, describe, it, expect } from '@jest/globals';
+
+let getBlogGenerationArgs;
+let generateBlogOuter;
+
+beforeAll(async () => {
+  ({ getBlogGenerationArgs, generateBlogOuter } = await import(
+    '../../src/generator/generator.js'
+  ));
+});
 
 describe('generateBlogOuter', () => {
   it('returns a string of HTML when given a blog object with an empty posts array', () => {

--- a/test/generator/isNonEmptyArray.test.js
+++ b/test/generator/isNonEmptyArray.test.js
@@ -1,4 +1,10 @@
-import { generateBlog } from '../../src/generator/generator.js';
+import { beforeAll, describe, test, expect } from '@jest/globals';
+
+let generateBlog;
+
+beforeAll(async () => {
+  ({ generateBlog } = await import('../../src/generator/generator.js'));
+});
 
 const header = '<body>';
 const footer = '</body>';


### PR DESCRIPTION
## Summary
- adjust generator-related tests to import the module inside `beforeAll`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841891b57f4832eac8a74a89677c162