### PR TITLE
Add regression for footer wrapping

### DIFF
--- a/test/generator/generator.constants.test.js
+++ b/test/generator/generator.constants.test.js
@@ -15,4 +15,9 @@ describe('generator constants usage', () => {
     expect(html).toContain('<body>');
     expect(html).toContain('</body>');
   });
+
+  test('footer content is not wrapped in an extra value div', () => {
+    const html = generateBlogOuter({ posts: [] });
+    expect(html.includes('<div class="value"><div class="footer')).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- extend generator constants tests to check footer structure

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6841892745d8832e84f9ff5fabae225c