### PR TITLE
Improve mutant coverage for parseJSONResult

### DIFF
--- a/test/browser/parseJSONResult.test.js
+++ b/test/browser/parseJSONResult.test.js
@@ -11,7 +11,10 @@ const filePath = require.resolve('../../src/browser/toys.js');
 async function getParseJSONResult() {
   const code = readFileSync(filePath, 'utf8');
   const tempPath = join(dirname(filePath), `parseJSONResult.${Date.now()}.js`);
-  writeFileSync(tempPath, `${code}\nexport { parseJSONResult };`);
+  writeFileSync(
+    tempPath,
+    `${code}\nexport { parseJSONResult };\n//# sourceURL=${filePath}`
+  );
   const module = await import(`${pathToFileURL(tempPath).href}`);
   const fn = module.parseJSONResult;
   await fsPromises.unlink(tempPath);


### PR DESCRIPTION
## Summary
- map temporary module in parseJSONResult tests back to the original source file

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68418d2fdb38832eb2d2126285497280