### PR TITLE
Fix mutation survivor

### DIFF
--- a/test/generator/getBlogGenerationArgs.test.js
+++ b/test/generator/getBlogGenerationArgs.test.js
@@ -53,4 +53,13 @@ describe('getBlogGenerationArgs', () => {
     expect(footer).toContain('class="footer value warning"');
     expect(footer).not.toContain('undefined');
   });
+
+  it('generates header content when imported inside the test', async () => {
+    const { getBlogGenerationArgs } = await import(
+      '../../src/generator/generator.js'
+    );
+    const { header } = getBlogGenerationArgs();
+    expect(header).toContain('aria-label="Matt Heard"');
+    expect(header).toContain('Software developer and philosopher in Berlin');
+  });
 });


### PR DESCRIPTION
## Summary
- add regression test for header content generation to ensure parser utilities run when generator module is imported within a test

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68418d3096d0832e9891ff7b7a4303e3