### PR TITLE
Improve null content normalization test

### DIFF
--- a/test/generator/normalizeContentItem.null.test.js
+++ b/test/generator/normalizeContentItem.null.test.js
@@ -1,5 +1,10 @@
-import { describe, test, expect } from '@jest/globals';
-import { generateBlogOuter } from '../../src/generator/generator.js';
+import { beforeAll, describe, test, expect } from '@jest/globals';
+
+let generateBlogOuter;
+
+beforeAll(async () => {
+  ({ generateBlogOuter } = await import('../../src/generator/generator.js'));
+});
 
 describe('normalizeContentItem with null content', () => {
   test('generateBlogOuter handles null in post content array', () => {


### PR DESCRIPTION
## Summary
- ensure `generateBlogOuter` is dynamically imported in the null content test
- verify blog generator handles `null` content correctly

## Testing
- `npm test --silent`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68418d2e948c832eb928bfd4b739af36