### PR TITLE
Kill surviving mutant in ensureKeyValueInput

### DIFF
--- a/test/browser/toys.keyValueInput.test.js
+++ b/test/browser/toys.keyValueInput.test.js
@@ -31,7 +31,7 @@ describe('Key-Value Input', () => {
       getValue: jest.fn(),
     };
     const result = ensureKeyValueInput(container, textInput, dom);
-    expect(createElement).toHaveBeenCalledWith('div');
+    expect(createElement).toHaveBeenNthCalledWith(1, 'div');
     expect(setClassName).toHaveBeenCalledWith(kvContainer, 'kv-container');
     expect(getNextSibling).toHaveBeenCalledWith(textInput);
     expect(insertBefore).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary
- enhance test for `ensureKeyValueInput` to assert the first call to `createElement`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68418d2dd0c8832eb833ee579c69687c