### PR TITLE
Add undefined check for parseJSONResult

### DIFF
--- a/test/browser/parseJSONResult.test.js
+++ b/test/browser/parseJSONResult.test.js
@@ -24,6 +24,11 @@ describe('parseJSONResult', () => {
     expect(parseJSONResult('not json')).toBeNull();
   });
 
+  it('does not return undefined for invalid JSON', async () => {
+    const parseJSONResult = await getParseJSONResult();
+    expect(parseJSONResult('not json')).not.toBeUndefined();
+  });
+
   it('parses valid JSON into an object', async () => {
     const parseJSONResult = await getParseJSONResult();
     const result = parseJSONResult('{"a":1}');


### PR DESCRIPTION
## Summary
- ensure parseJSONResult never returns `undefined`

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68418d2c94e0832e8180650e6c900c43