### PR TITLE
Add additional createValueDiv test

### DIFF
--- a/test/generator/createValueDiv.trailing.test.js
+++ b/test/generator/createValueDiv.trailing.test.js
@@ -1,0 +1,39 @@
+import { describe, test, expect } from '@jest/globals';
+import { readFileSync, writeFileSync, unlinkSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const filePath = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../src/generator/generator.js'
+);
+
+async function loadCreateValueDiv() {
+  const code = readFileSync(filePath, 'utf8');
+  const injectedPath = path.join(
+    path.dirname(filePath),
+    `__cvd_trailing_${process.pid}.js`
+  );
+  writeFileSync(
+    injectedPath,
+    `${code}\nexport { createValueDiv as __createValueDiv };`
+  );
+  const module = await import(injectedPath);
+  unlinkSync(injectedPath);
+  return module.__createValueDiv;
+}
+
+describe('createValueDiv trailing spaces', () => {
+  test('does not introduce double spaces with many falsy classes', async () => {
+    const createValueDiv = await loadCreateValueDiv();
+    const result = createValueDiv('x', [
+      'foo',
+      '',
+      null,
+      undefined,
+      false,
+      'bar',
+    ]);
+    expect(result).toBe('<div class="value foo bar">x</div>');
+  });
+});


### PR DESCRIPTION
## Summary
- extend unit tests for `createValueDiv` to cover many falsy class names

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68418d2c16e0832ea5ac7df45f8321c7