### PR TITLE
Improve createValueDiv test coverage

### DIFF
--- a/test/generator/createValueDiv.test.js
+++ b/test/generator/createValueDiv.test.js
@@ -39,7 +39,7 @@ function getCreateValueDiv() {
   `;
   const functionCode = `${helperCode}
     ${match[0]};
-    return createValueDiv;`;
+    return createValueDiv;\n//# sourceURL=${filePath}`;
   return new Function('createAttrPair', 'createTag', 'ATTR_NAME', functionCode)(
     createAttrPair,
     createTag,


### PR DESCRIPTION
## Summary
- add sourceURL comment to map `createValueDiv` coverage to original source

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68418d2ade38832ea029e3a312823854