### PR TITLE
Add test for out-of-bounds related-link clues

### DIFF
--- a/test/toys/2025-05-11/battleshipSolitaireClues.test.js
+++ b/test/toys/2025-05-11/battleshipSolitaireClues.test.js
@@ -115,6 +115,19 @@ describe('generateClues', () => {
     expect(output.colClues).toEqual(expectedCol);
   });
 
+  it('ignores horizontal ship cells with y equal to board height', () => {
+    const fleet = {
+      width: 3,
+      height: 3,
+      ships: [{ start: { x: 0, y: 3 }, length: 2, direction: 'H' }],
+    };
+    const expectedRow = [0, 0, 0];
+    const expectedCol = [0, 0, 0];
+
+    const output = JSON.parse(generateClues(JSON.stringify(fleet)));
+    expect(output.rowClues).toEqual(expectedRow);
+    expect(output.colClues).toEqual(expectedCol);
+  });
 
   it('computes correct clues for a vertical ship away from edges', () => {
     const fleet = {


### PR DESCRIPTION
## Summary
- extend battleshipSolitaireClues tests with a horizontal out-of-bounds case

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68418d296570832eb6111d1665f22001