### PR TITLE
Add createSection unit test

### DIFF
--- a/test/generator/createSection.test.js
+++ b/test/generator/createSection.test.js
@@ -1,4 +1,7 @@
 import { describe, test, expect, beforeAll } from '@jest/globals';
+import { readFileSync, writeFileSync, unlinkSync } from 'fs';
+import path from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
 
 let getBlogGenerationArgs;
 
@@ -13,5 +16,30 @@ describe('createSection integration', () => {
     const { header, footer } = getBlogGenerationArgs();
     expect(header).toContain('<div class="entry">');
     expect(footer).toContain('<div class="entry">');
+  });
+});
+
+async function loadCreateSection() {
+  const filePath = path.join(
+    path.dirname(fileURLToPath(import.meta.url)),
+    '../../src/generator/generator.js'
+  );
+  const code = readFileSync(filePath, 'utf8');
+  const tempPath = path.join(path.dirname(filePath), `__cs_${process.pid}.js`);
+  writeFileSync(
+    tempPath,
+    `${code}\nexport { createSection as __createSection };`
+  );
+  const url = pathToFileURL(tempPath).toString();
+  const module = await import(url + `?cacheBust=${Date.now()}`);
+  unlinkSync(tempPath);
+  return module.__createSection;
+}
+
+describe('createSection unit', () => {
+  test('wraps content in entry div', async () => {
+    const createSection = await loadCreateSection();
+    const result = createSection('foo');
+    expect(result).toBe('<div class="entry">foo</div>');
   });
 });


### PR DESCRIPTION
## Summary
- verify header and footer components via existing integration test
- add helper to load the unexported `createSection` function for testing
- ensure `createSection` wraps content in the expected div

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68418d29640c832ebbf21b0e28cfc95b