### PR TITLE
Update AGENTS jest restrictions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,14 @@ If either command fails due to missing dependencies or other issues, note the
 failure in the PR message's Testing section.
 Before opening a pull request, ensure that branch coverage remains at 100%.
 
+## Jest Restrictions
+
+The following Jest features cause issues with Stryker mutation testing and must never be used:
+
+- `jest.resetModules`
+- `jest.unstable_mockModule`
+- `import.meta.url`
+
 ## Code Style
 
 - Follow the guidelines in `CLAUDE.md` for naming and formatting.


### PR DESCRIPTION
## Summary
- add Jest restrictions to `AGENTS.md` prohibiting problematic features

## Testing
- `npm test` *(fails: Cannot find module '/workspace/dadeto/node_modules/.bin/jest')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6841b2449abc832eaa3ae59e83fc02db