### PR TITLE
Add empty string case to parseJSONResult tests

### DIFF
--- a/test/browser/parseJSONResult.test.js
+++ b/test/browser/parseJSONResult.test.js
@@ -42,4 +42,9 @@ describe('parseJSONResult', () => {
     const parseJSONResult = await getParseJSONResult();
     expect(parseJSONResult(undefined)).toBeNull();
   });
+
+  it('returns null when called with an empty string', async () => {
+    const parseJSONResult = await getParseJSONResult();
+    expect(parseJSONResult('')).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- improve coverage for `parseJSONResult`
- ensure empty strings return `null`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841957c6514832ebf8a7c123e657dad