### PR TITLE
Add unit test for invalid battleship direction

### DIFF
--- a/test/presenters/battleshipSolitaireFleet.test.js
+++ b/test/presenters/battleshipSolitaireFleet.test.js
@@ -183,4 +183,22 @@ describe('createBattleshipFleetBoardElement', () => {
     const lines = el.text.trim().split('\n');
     expect(lines).toEqual(['· · ·', '# · ·', '· · ·']);
   });
+
+  test('skips ships with invalid direction', () => {
+    const fleet = {
+      width: 3,
+      height: 3,
+      ships: [
+        { start: { x: 0, y: 0 }, length: 2, direction: 'H' },
+        { start: { x: 1, y: 1 }, length: 2, direction: 'X' },
+      ],
+    };
+    const input = JSON.stringify(fleet);
+    const el = createBattleshipFleetBoardElement(input, dom);
+    expect(el.tag).toBe('pre');
+    const lines = el.text.trim().split('\n');
+    expect(lines[0].replace(/ /g, '')).toBe('##·');
+    expect(lines[1].replace(/ /g, '')).toBe('···');
+    expect(lines[2].replace(/ /g, '')).toBe('···');
+  });
 });


### PR DESCRIPTION
## Summary
- check that ships with invalid direction are skipped during board rendering

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6841957a740c832e87f7b8fe7de2d8f2