### PR TITLE
Add header comment test

### DIFF
--- a/test/generator/getBlogGenerationArgs.test.js
+++ b/test/generator/getBlogGenerationArgs.test.js
@@ -43,6 +43,11 @@ describe('getBlogGenerationArgs', () => {
     expect(header).toContain('<div id="container">');
   });
 
+  it('includes the header comment in the header HTML', () => {
+    const { header } = getBlogGenerationArgs();
+    expect(header).toContain('<!-- Header -->');
+  });
+
   it('includes the copyright warning message in the footer HTML', () => {
     const { footer } = getBlogGenerationArgs();
     expect(footer).toContain('All content is authored by Matt Heard and is');


### PR DESCRIPTION
## Summary
- extend blog generator tests to assert header comment

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6841957a0d4c832ebdc9fbeabfeab33b