### PR TITLE
Add unit test to cover initializeInteractiveComponent

### DIFF
--- a/test/browser/initializeInteractiveComponent.enableInteractiveControls.test.js
+++ b/test/browser/initializeInteractiveComponent.enableInteractiveControls.test.js
@@ -1,0 +1,49 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { initializeInteractiveComponent } from '../../src/browser/toys.js';
+
+describe('initializeInteractiveComponent', () => {
+  it('enables controls using enableInteractiveControls', () => {
+    const inputElement = {};
+    const submitButton = {};
+    const outputParent = {};
+    const dom = {
+      querySelector: jest.fn((_, selector) => {
+        if (selector === 'input') {return inputElement;}
+        if (selector === 'button') {return submitButton;}
+        if (selector === 'div.output') {return outputParent;}
+        if (selector === 'select.output') {return {};}
+        return {};
+      }),
+      addEventListener: jest.fn(),
+      removeAllChildren: jest.fn(),
+      createElement: jest.fn(() => ({ textContent: '' })),
+      appendChild: jest.fn(),
+      setTextContent: jest.fn(),
+      removeWarning: jest.fn(),
+      enable: jest.fn(),
+      stopDefault: jest.fn(),
+      removeChild: jest.fn(),
+      addWarning: jest.fn(),
+      contains: () => true,
+    };
+    const config = {
+      globalState: {},
+      createEnvFn: () => ({}),
+      errorFn: jest.fn(),
+      fetchFn: jest.fn(),
+      dom,
+      loggers: {
+        logInfo: jest.fn(),
+        logError: jest.fn(),
+        logWarning: jest.fn(),
+      },
+    };
+    const processingFunction = jest.fn();
+
+    initializeInteractiveComponent({}, processingFunction, config);
+
+    expect(dom.enable).toHaveBeenCalledWith(inputElement);
+    expect(dom.enable).toHaveBeenCalledWith(submitButton);
+    expect(dom.removeWarning).toHaveBeenCalledWith(outputParent);
+  });
+});


### PR DESCRIPTION
## Summary
- add a focused test verifying `initializeInteractiveComponent` enables controls

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68419577ebbc832e8a25b47a7c747389