### PR TITLE
Add test for header banner in blog output

### DIFF
--- a/test/generator/getBlogGenerationArgs.test.js
+++ b/test/generator/getBlogGenerationArgs.test.js
@@ -16,6 +16,12 @@ describe('generateBlogOuter', () => {
     expect(result.length).toBeGreaterThan(0);
     expect(result).toContain('id="container"');
   });
+
+  it('includes the banner and metadata in the generated HTML', () => {
+    const result = generateBlogOuter({ posts: [] });
+    expect(result).toContain('aria-label="Matt Heard"');
+    expect(result).toContain('Software developer and philosopher in Berlin');
+  });
 });
 
 describe('getBlogGenerationArgs', () => {


### PR DESCRIPTION
## Summary
- ensure `generateBlogOuter` output contains the header banner and metadata

## Testing
- `npm run lint`
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684195766ef8832eaabd25c40e196968