### PR TITLE
Add tests to kill ticTacToe row/column mutant

### DIFF
--- a/test/toys/2025-04-06/ticTacToe.test.js
+++ b/test/toys/2025-04-06/ticTacToe.test.js
@@ -301,6 +301,34 @@ test('handles out-of-bounds position', () => {
   });
 });
 
+test('handles invalid row with valid column', () => {
+  const env = new Map();
+  const input = {
+    moves: [{ player: 'X', position: { row: 5, column: 1 } }],
+  };
+  const result = ticTacToeMove(JSON.stringify(input), env);
+  const output = JSON.parse(result);
+  expect(output.moves).toHaveLength(1);
+  expect(output.moves[0]).toEqual({
+    player: 'X',
+    position: { row: 1, column: 1 },
+  });
+});
+
+test('handles invalid column with valid row', () => {
+  const env = new Map();
+  const input = {
+    moves: [{ player: 'X', position: { row: 0, column: 5 } }],
+  };
+  const result = ticTacToeMove(JSON.stringify(input), env);
+  const output = JSON.parse(result);
+  expect(output.moves).toHaveLength(1);
+  expect(output.moves[0]).toEqual({
+    player: 'X',
+    position: { row: 1, column: 1 },
+  });
+});
+
 test('assigns X to first move when moves list is empty', () => {
   const env = new Map();
   const input = {


### PR DESCRIPTION
## Summary
- extend ticTacToe tests with additional invalid row/column cases

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68419575cd50832e905b8287a3428f59