### PR TITLE
Add coverage for initialization message

### DIFF
--- a/test/browser/toys.initializeInteractiveComponent.elements.test.js
+++ b/test/browser/toys.initializeInteractiveComponent.elements.test.js
@@ -11,10 +11,18 @@ describe('initializeInteractiveComponent dynamic import', () => {
     const submitButton = {};
     const outputParent = {};
     const querySelector = jest.fn((_, selector) => {
-      if (selector === 'input') {return inputElement;}
-      if (selector === 'button') {return submitButton;}
-      if (selector === 'div.output') {return outputParent;}
-      if (selector === 'select.output') {return {};}
+      if (selector === 'input') {
+        return inputElement;
+      }
+      if (selector === 'button') {
+        return submitButton;
+      }
+      if (selector === 'div.output') {
+        return outputParent;
+      }
+      if (selector === 'select.output') {
+        return {};
+      }
       return {};
     });
     const dom = {
@@ -51,5 +59,44 @@ describe('initializeInteractiveComponent dynamic import', () => {
 
     expect(dom.enable).toHaveBeenCalledWith(inputElement);
     expect(dom.enable).toHaveBeenCalledWith(submitButton);
+  });
+
+  it('sets an initializing message in the output', async () => {
+    const { initializeInteractiveComponent } = await import(
+      '../../src/browser/toys.js'
+    );
+    const dom = {
+      removeAllChildren: jest.fn(),
+      createElement: jest.fn(() => ({ textContent: '' })),
+      setTextContent: jest.fn(),
+      stopDefault: jest.fn(),
+      addWarning: jest.fn(),
+      addWarningFn: jest.fn(),
+      addEventListener: jest.fn(),
+      removeChild: jest.fn(),
+      appendChild: jest.fn(),
+      querySelector: jest.fn(() => ({})),
+      removeWarning: jest.fn(),
+      enable: jest.fn(),
+      contains: () => true,
+    };
+    const config = {
+      globalState: {},
+      createEnvFn: () => ({}),
+      errorFn: jest.fn(),
+      fetchFn: jest.fn(),
+      dom,
+      loggers: {
+        logInfo: jest.fn(),
+        logError: jest.fn(),
+        logWarning: jest.fn(),
+      },
+    };
+    const article = { id: 'post' };
+    const processingFunction = jest.fn();
+
+    initializeInteractiveComponent(article, processingFunction, config);
+
+    expect(dom.setTextContent.mock.calls[0][1]).toBe('Initialising...');
   });
 });


### PR DESCRIPTION
## Summary
- extend initializeInteractiveComponent dynamic import tests to verify the initializing message

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68419573f050832e82be989040fbef0e