### PR TITLE
Add coverage for header body tag

### DIFF
--- a/test/generator/getBlogGenerationArgs.test.js
+++ b/test/generator/getBlogGenerationArgs.test.js
@@ -43,6 +43,11 @@ describe('getBlogGenerationArgs', () => {
     expect(header).toContain('<div id="container">');
   });
 
+  it('includes the opening body tag in the header HTML', () => {
+    const { header } = getBlogGenerationArgs();
+    expect(header).toContain('<body>');
+  });
+
   it('includes the copyright warning message in the footer HTML', () => {
     const { footer } = getBlogGenerationArgs();
     expect(footer).toContain('All content is authored by Matt Heard and is');


### PR DESCRIPTION
## Summary
- add regression test covering the `<body>` tag in the generated header

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68419572ca08832e98d22dfc08a521cd