### PR TITLE
Fix surviving parseJSONResult mutant

### DIFF
--- a/test/browser/parseJSONResult.test.js
+++ b/test/browser/parseJSONResult.test.js
@@ -1,45 +1,43 @@
-import { describe, it, expect } from '@jest/globals';
-import { readFileSync, writeFileSync, promises as fsPromises } from 'fs';
-import { join, dirname } from 'path';
-import { createRequire } from 'module';
-import { pathToFileURL } from 'url';
+import { describe, it, expect } from "@jest/globals";
+import { readFileSync } from "fs";
+import { createRequire } from "module";
+import vm from "vm";
 
 const require = createRequire(import.meta.url);
 
-const filePath = require.resolve('../../src/browser/toys.js');
+const filePath = require.resolve("../../src/browser/toys.js");
 
-async function getParseJSONResult() {
-  const code = readFileSync(filePath, 'utf8');
-  const tempPath = join(dirname(filePath), `parseJSONResult.${Date.now()}.js`);
-  writeFileSync(
-    tempPath,
-    `${code}\nexport { parseJSONResult };\n//# sourceURL=${filePath}`
-  );
-  const module = await import(`${pathToFileURL(tempPath).href}`);
-  const fn = module.parseJSONResult;
-  await fsPromises.unlink(tempPath);
-  return fn;
+function getParseJSONResult() {
+  const code = readFileSync(filePath, "utf8");
+  const match = code.match(/function parseJSONResult\(result\) {[^]*?\n}\n/);
+  if (!match) {
+    throw new Error("parseJSONResult not found");
+  }
+  const script = new vm.Script(`${match[0]}; parseJSONResult`, {
+    filename: filePath,
+  });
+  return script.runInNewContext();
 }
 
-describe('parseJSONResult', () => {
-  it('returns null when JSON parsing fails', async () => {
-    const parseJSONResult = await getParseJSONResult();
-    expect(parseJSONResult('not json')).toBeNull();
+describe("parseJSONResult", () => {
+  it("returns null when JSON parsing fails", () => {
+    const parseJSONResult = getParseJSONResult();
+    expect(parseJSONResult("not json")).toBeNull();
   });
 
-  it('does not return undefined for invalid JSON', async () => {
-    const parseJSONResult = await getParseJSONResult();
-    expect(parseJSONResult('not json')).not.toBeUndefined();
+  it("does not return undefined for invalid JSON", () => {
+    const parseJSONResult = getParseJSONResult();
+    expect(parseJSONResult("not json")).not.toBeUndefined();
   });
 
-  it('parses valid JSON into an object', async () => {
-    const parseJSONResult = await getParseJSONResult();
+  it("parses valid JSON into an object", () => {
+    const parseJSONResult = getParseJSONResult();
     const result = parseJSONResult('{"a":1}');
     expect(result).toEqual({ a: 1 });
   });
 
-  it('returns null when called with undefined', async () => {
-    const parseJSONResult = await getParseJSONResult();
+  it("returns null when called with undefined", () => {
+    const parseJSONResult = getParseJSONResult();
     expect(parseJSONResult(undefined)).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- load `parseJSONResult` using Node's `vm` with filename
- keep all tests passing with lint warnings

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6841957095cc832ebdaa168e4ca7c7c9