### PR TITLE
Add missing header generation test

### DIFF
--- a/test/generator/headerContent.noCache.test.js
+++ b/test/generator/headerContent.noCache.test.js
@@ -1,0 +1,10 @@
+import { generateBlogOuter } from '../../src/generator/generator.js';
+import { describe, test, expect } from '@jest/globals';
+
+describe('header generation without cache busting', () => {
+  test('generateBlogOuter includes banner and metadata', () => {
+    const html = generateBlogOuter({ posts: [] });
+    expect(html).toContain('aria-label="Matt Heard"');
+    expect(html).toContain('Software developer and philosopher in Berlin');
+  });
+});


### PR DESCRIPTION
## Summary
- add a test that imports the generator without cache busting and checks the header content

## Testing
- `npm test --silent`
- `npm run lint --silent`

------
https://chatgpt.com/codex/tasks/task_e_6841956f1be8832ea27ad6f5aafa11c5