### PR TITLE
Extend tests for parseJSONResult

### DIFF
--- a/test/browser/parseJSONResult.test.js
+++ b/test/browser/parseJSONResult.test.js
@@ -1,45 +1,42 @@
 import { describe, it, expect } from '@jest/globals';
-import { readFileSync, writeFileSync, promises as fsPromises } from 'fs';
-import { join, dirname } from 'path';
+import { readFileSync } from 'fs';
 import { createRequire } from 'module';
-import { pathToFileURL } from 'url';
 
 const require = createRequire(import.meta.url);
 
 const filePath = require.resolve('../../src/browser/toys.js');
 
-async function getParseJSONResult() {
+function getParseJSONResult() {
   const code = readFileSync(filePath, 'utf8');
-  const tempPath = join(dirname(filePath), `parseJSONResult.${Date.now()}.js`);
-  writeFileSync(
-    tempPath,
-    `${code}\nexport { parseJSONResult };\n//# sourceURL=${filePath}`
-  );
-  const module = await import(`${pathToFileURL(tempPath).href}`);
-  const fn = module.parseJSONResult;
-  await fsPromises.unlink(tempPath);
+  const match = code.match(/function parseJSONResult\(result\) {[^]*?\n}\n/);
+  if (!match) {
+    throw new Error('parseJSONResult not found');
+  }
+  const fn = new Function(
+    `${match[0]}\n//# sourceURL=${filePath}\nreturn parseJSONResult;`
+  )();
   return fn;
 }
 
 describe('parseJSONResult', () => {
-  it('returns null when JSON parsing fails', async () => {
-    const parseJSONResult = await getParseJSONResult();
+  it('returns null when JSON parsing fails', () => {
+    const parseJSONResult = getParseJSONResult();
     expect(parseJSONResult('not json')).toBeNull();
   });
 
-  it('does not return undefined for invalid JSON', async () => {
-    const parseJSONResult = await getParseJSONResult();
+  it('does not return undefined for invalid JSON', () => {
+    const parseJSONResult = getParseJSONResult();
     expect(parseJSONResult('not json')).not.toBeUndefined();
   });
 
-  it('parses valid JSON into an object', async () => {
-    const parseJSONResult = await getParseJSONResult();
+  it('parses valid JSON into an object', () => {
+    const parseJSONResult = getParseJSONResult();
     const result = parseJSONResult('{"a":1}');
     expect(result).toEqual({ a: 1 });
   });
 
-  it('returns null when called with undefined', async () => {
-    const parseJSONResult = await getParseJSONResult();
+  it('returns null when called with undefined', () => {
+    const parseJSONResult = getParseJSONResult();
     expect(parseJSONResult(undefined)).toBeNull();
   });
 });

--- a/test/browser/toys.processInputAndSetOutput.test.js
+++ b/test/browser/toys.processInputAndSetOutput.test.js
@@ -12,8 +12,9 @@ function getParseJSONResult() {
   if (!match) {
     throw new Error('parseJSONResult not found');
   }
-
-  return new Function(`${match[0]}; return parseJSONResult;`)();
+  return new Function(
+    `${match[0]}\n//# sourceURL=${filePath}\nreturn parseJSONResult;`
+  )();
 }
 const { processInputAndSetOutput } = toys;
 


### PR DESCRIPTION
## Summary
- ensure `parseJSONResult` is executed from its original file path
- reuse helper for `parseJSONResult` in toys tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841956fae44832e9e7d8653638f7c29