### PR TITLE
Add test to kill defaultKeyExtraClasses mutant

### DIFF
--- a/test/generator/defaultKeyExtraClasses.imported.test.js
+++ b/test/generator/defaultKeyExtraClasses.imported.test.js
@@ -1,0 +1,34 @@
+import { describe, test, expect } from '@jest/globals';
+import { readFileSync, writeFileSync, unlinkSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const filePath = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../src/generator/generator.js'
+);
+
+async function loadDefaultKeyExtraClasses() {
+  const code = readFileSync(filePath, 'utf8');
+  const injectedPath = path.join(
+    path.dirname(filePath),
+    `__dkec_${process.pid}.js`
+  );
+  writeFileSync(
+    injectedPath,
+    `${code}\nexport { defaultKeyExtraClasses as __dkec };`
+  );
+  const module = await import(injectedPath);
+  unlinkSync(injectedPath);
+  return module.__dkec;
+}
+
+describe('defaultKeyExtraClasses imported', () => {
+  test('sets keyExtraClasses to empty string when undefined', async () => {
+    const defaultKeyExtraClasses = await loadDefaultKeyExtraClasses();
+    const args = {};
+    const result = defaultKeyExtraClasses(args);
+    expect(result.keyExtraClasses).toBe('');
+    expect(args.keyExtraClasses).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- add import-based test for `defaultKeyExtraClasses`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841956eb06c832ebee364627af7ad02