### PR TITLE
Add coverage-driven import test

### DIFF
--- a/test/generator/headerContent.instrumented.test.js
+++ b/test/generator/headerContent.instrumented.test.js
@@ -1,0 +1,10 @@
+import { describe, it, expect, jest } from '@jest/globals';
+
+describe('header generation instrumented import', () => {
+  it('includes metadata in the generated blog HTML', async () => {
+    jest.resetModules();
+    const { generateBlogOuter } = await import('../../src/generator/generator.js');
+    const html = generateBlogOuter({ posts: [] });
+    expect(html).toContain('Software developer and philosopher in Berlin');
+  });
+});


### PR DESCRIPTION
## Summary
- add a direct import test for the generator module so Stryker can mutate `createHeaderContent`

## Testing
- `npm test --silent`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6841956bca5c832ea832e513a206b82d