### PR TITLE
Add coverage test for createValueDiv

### DIFF
--- a/test/generator/createValueDiv.coverageImport.test.js
+++ b/test/generator/createValueDiv.coverageImport.test.js
@@ -1,0 +1,44 @@
+import { describe, test, expect } from '@jest/globals';
+import { readFileSync, writeFileSync, unlinkSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const filePath = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../src/generator/generator.js'
+);
+
+async function loadCreateValueDiv() {
+  const code = readFileSync(filePath, 'utf8');
+  const injectedPath = path.join(
+    path.dirname(filePath),
+    `__cvd_import_${process.pid}.mjs`
+  );
+  writeFileSync(
+    injectedPath,
+    `${code}\nexport { createValueDiv as __createValueDiv };\n//# sourceURL=${filePath}`
+  );
+  const module = await import(`${injectedPath}?v=${Date.now()}`);
+  unlinkSync(injectedPath);
+  return module.__createValueDiv;
+}
+
+describe('createValueDiv imported with coverage', () => {
+  test('filters out falsy class names via import', async () => {
+    const createValueDiv = await loadCreateValueDiv();
+    const result = createValueDiv('content', [
+      'foo',
+      '',
+      undefined,
+      null,
+      'bar',
+    ]);
+    expect(result).toBe('<div class="value foo bar">content</div>');
+  });
+
+  test('handles all falsy additional classes', async () => {
+    const createValueDiv = await loadCreateValueDiv();
+    const result = createValueDiv('text', ['', false, undefined, null, 0]);
+    expect(result).toBe('<div class="value">text</div>');
+  });
+});


### PR DESCRIPTION
## Summary
- add a new unit test to load `createValueDiv` via an import wrapper
- ensure coverage is mapped back to the original file

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68419569b7b4832e917aab810d96c058