### PR TITLE
Add test for null fleet input in generateClues

### DIFF
--- a/test/toys/2025-05-11/battleshipSolitaireClues.test.js
+++ b/test/toys/2025-05-11/battleshipSolitaireClues.test.js
@@ -147,4 +147,8 @@ describe('generateClues', () => {
     const output = JSON.parse(generateClues('null'));
     expect(output).toEqual({ error: 'Invalid fleet structure' });
   });
+
+  it('does not throw when the fleet is null', () => {
+    expect(() => generateClues('null')).not.toThrow();
+  });
 });


### PR DESCRIPTION
## Summary
- ensure `generateClues` gracefully handles a null fleet

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841956aae9c832ea901dd53a6036222