### PR TITLE
Add tests for processInputAndSetOutput

### DIFF
--- a/test/browser/toys.processInputAndSetOutput.test.js
+++ b/test/browser/toys.processInputAndSetOutput.test.js
@@ -1,0 +1,75 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { processInputAndSetOutput } from '../../src/browser/toys.js';
+
+describe('processInputAndSetOutput', () => {
+  it('handles valid JSON result using handleParsedResult', async () => {
+    const inputElement = { value: 'ignored' };
+    const parent = {};
+    const outputSelect = { value: 'text' };
+    const article = { id: 'a1' };
+    const elements = {
+      inputElement,
+      outputParentElement: parent,
+      outputSelect,
+      article,
+    };
+    const dom = {
+      removeAllChildren: jest.fn(),
+      appendChild: jest.fn(),
+      createElement: jest.fn(() => ({})),
+      setTextContent: jest.fn(),
+      addWarning: jest.fn(),
+    };
+    const toyEnv = { get: jest.fn(() => () => ({})) };
+    const env = {
+      createEnv: jest.fn(() => toyEnv),
+      dom,
+      errorFn: jest.fn(),
+      fetchFn: jest.fn(() =>
+        Promise.resolve({ text: () => Promise.resolve('body') })
+      ),
+    };
+    const resultObj = { request: { url: 'https://example.com' } };
+    const processingFunction = jest.fn(() => JSON.stringify(resultObj));
+
+    await processInputAndSetOutput(elements, processingFunction, env);
+
+    expect(env.fetchFn).toHaveBeenCalledWith('https://example.com');
+    expect(dom.removeAllChildren).not.toHaveBeenCalled();
+    expect(dom.appendChild).not.toHaveBeenCalled();
+  });
+
+  it('falls back to raw output when JSON is invalid', async () => {
+    const inputElement = { value: 'ignored' };
+    const parent = {};
+    const outputSelect = { value: 'text' };
+    const article = { id: 'a1' };
+    const elements = {
+      inputElement,
+      outputParentElement: parent,
+      outputSelect,
+      article,
+    };
+    const dom = {
+      removeAllChildren: jest.fn(),
+      appendChild: jest.fn(),
+      createElement: jest.fn(() => ({})),
+      setTextContent: jest.fn(),
+      addWarning: jest.fn(),
+    };
+    const toyEnv = { get: jest.fn(() => () => ({})) };
+    const env = {
+      createEnv: jest.fn(() => toyEnv),
+      dom,
+      errorFn: jest.fn(),
+      fetchFn: jest.fn(),
+    };
+    const processingFunction = jest.fn(() => 'invalid json');
+
+    await processInputAndSetOutput(elements, processingFunction, env);
+
+    expect(env.fetchFn).not.toHaveBeenCalled();
+    expect(dom.removeAllChildren).toHaveBeenCalledWith(parent);
+    expect(dom.appendChild).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- exercise `processInputAndSetOutput` with valid and invalid JSON
- verify DOM updates only happen on invalid JSON

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6841d08897b4832ea6f6b17c7acb80e6