### PR TITLE
Add tests for processInputAndSetOutput

### DIFF
--- a/test/browser/processInputAndSetOutput.test.js
+++ b/test/browser/processInputAndSetOutput.test.js
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
+import { processInputAndSetOutput } from '../../src/browser/toys.js';
+
+let elements;
+let env;
+let toyEnv;
+let processingFunction;
+
+beforeEach(() => {
+  elements = {
+    inputElement: { value: 'input' },
+    outputParentElement: {},
+    outputSelect: { value: 'text' },
+    article: { id: 'post1' }
+  };
+  toyEnv = new Map([
+    ['getData', () => ({ output: {} })],
+    ['setData', jest.fn()]
+  ]);
+  env = {
+    createEnv: jest.fn(() => toyEnv),
+    fetchFn: jest.fn(() => Promise.resolve({ text: jest.fn(() => Promise.resolve('')) })),
+    dom: {
+      setTextContent: jest.fn(),
+      removeAllChildren: jest.fn(),
+      appendChild: jest.fn(),
+      createElement: jest.fn(() => ({})),
+      addWarning: jest.fn(),
+      removeWarning: jest.fn()
+    },
+    errorFn: jest.fn(),
+    loggers: {
+      logInfo: jest.fn(),
+      logError: jest.fn(),
+      logWarning: jest.fn()
+    }
+  };
+  processingFunction = jest.fn();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('processInputAndSetOutput', () => {
+  it('does not set text when handleParsedResult returns true', () => {
+    const json = '{"request":{"url":"https://example.com"}}';
+    processingFunction.mockReturnValue(json);
+    const parseSpy = jest.spyOn(JSON, 'parse');
+
+    processInputAndSetOutput(elements, processingFunction, env);
+
+    expect(parseSpy).toHaveBeenCalledWith(json);
+    expect(env.dom.appendChild).not.toHaveBeenCalled();
+
+    parseSpy.mockRestore();
+  });
+
+  it('sets text content when parsed result is invalid', () => {
+    const invalid = 'not json';
+    processingFunction.mockReturnValue(invalid);
+
+    processInputAndSetOutput(elements, processingFunction, env);
+
+    expect(env.dom.appendChild).toHaveBeenCalledWith(
+      elements.outputParentElement,
+      expect.anything()
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for `processInputAndSetOutput`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841d08a15c0832eb7b0a4f76864ba41