### PR TITLE
Add unit test to kill header wrap mutant

### DIFF
--- a/test/generator/generator.constants.test.js
+++ b/test/generator/generator.constants.test.js
@@ -25,4 +25,9 @@ describe('generator constants usage', () => {
     const html = generateBlogOuter({ posts: [] });
     expect(html.includes('<div class="value"><div class="footer')).toBe(false);
   });
+
+  test('header content is not wrapped in an extra value div', () => {
+    const html = generateBlogOuter({ posts: [] });
+    expect(html.includes('<div class="value"><div class="value')).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- ensure header section values aren't double wrapped

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841d0899c4c832eb0495fd016302880