### PR TITLE
Add footer label test

### DIFF
--- a/test/generator/generator.constants.test.js
+++ b/test/generator/generator.constants.test.js
@@ -25,4 +25,10 @@ describe('generator constants usage', () => {
     const html = generateBlogOuter({ posts: [] });
     expect(html.includes('<div class="value"><div class="footer')).toBe(false);
   });
+
+  test('footer section has an empty key label', () => {
+    const html = generateBlogOuter({ posts: [] });
+    const expected = '<div class="entry"><div class="key"></div><div class="footer value warning">';
+    expect(html).toContain(expected);
+  });
 });


### PR DESCRIPTION
## Summary
- add unit test asserting the footer section's key label is empty

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841d088cfe4832e942394d87f1ae793