### PR TITLE
Add test for styles constant

### DIFF
--- a/test/generator/styles.test.js
+++ b/test/generator/styles.test.js
@@ -1,0 +1,9 @@
+import { describe, test, expect } from '@jest/globals';
+import { styles } from '../../src/generator/styles.js';
+
+describe('styles constant', () => {
+  test('contains expected CSS rules', () => {
+    expect(styles).toContain('background-color: #121212;');
+    expect(styles).toContain('.article-title');
+  });
+});


### PR DESCRIPTION
## Summary
- add test for `styles` constant used by the HTML generator

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841d87352b0832e97b5f6104d909fe6