### PR TITLE
Add test for FULL_WIDTH constant

### DIFF
--- a/test/generator/fullWidth.constant.test.js
+++ b/test/generator/fullWidth.constant.test.js
@@ -1,0 +1,12 @@
+import { describe, test, expect } from '@jest/globals';
+import fs from 'fs';
+import path from 'path';
+
+const generatorPath = path.join(process.cwd(), 'src/generator/generator.js');
+
+describe('generator FULL_WIDTH constant', () => {
+  test('FULL_WIDTH class is defined correctly', () => {
+    const source = fs.readFileSync(generatorPath, 'utf8');
+    expect(source).toMatch("FULL_WIDTH: 'full-width'");
+  });
+});


### PR DESCRIPTION
## Summary
- add test to assert `FULL_WIDTH` constant value in `generator.js`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6841d872b108832eb007df2ac992de65