### PR TITLE
Add coverage for storing toy results

### DIFF
--- a/test/browser/processInputAndSetOutput.test.js
+++ b/test/browser/processInputAndSetOutput.test.js
@@ -67,4 +67,15 @@ describe('processInputAndSetOutput', () => {
       expect.anything()
     );
   });
+
+  it('stores the result keyed by article id', () => {
+    const result = 'ok';
+    processingFunction.mockReturnValue(result);
+
+    processInputAndSetOutput(elements, processingFunction, env);
+
+    const setData = toyEnv.get('setData');
+    const callArg = setData.mock.calls[0][0];
+    expect(callArg.output).toEqual({ [elements.article.id]: result });
+  });
 });


### PR DESCRIPTION
## Summary
- add a unit test to check that `processInputAndSetOutput` stores the result keyed by the article id

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6841d8710ce4832e8f0f3cefa79f1f79