### PR TITLE
Add test to kill header label mutant

### DIFF
--- a/test/generator/headerSection.test.js
+++ b/test/generator/headerSection.test.js
@@ -7,4 +7,14 @@ describe('header section generation', () => {
     expect(html).toContain('aria-label="Matt Heard"');
     expect(html).toContain('Software developer and philosopher in Berlin');
   });
+
+  test('header labeled sections have empty keys', async () => {
+    const { getBlogGenerationArgs } = await import('../../src/generator/generator.js');
+    const { header } = getBlogGenerationArgs();
+    const keyMatches = [...header.matchAll(/<div class="key">([^<]*)<\/div>/g)];
+    expect(keyMatches).toHaveLength(2);
+    keyMatches.forEach(([, text]) => {
+      expect(text).toBe('');
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- add coverage check for empty header key labels in generator

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841d87074b8832eb2ba89e21ce73715