### PR TITLE
Add unit test for processInputAndSetOutput output storage

### DIFF
--- a/test/browser/processInputAndSetOutput.test.js
+++ b/test/browser/processInputAndSetOutput.test.js
@@ -1,4 +1,11 @@
-import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  jest,
+} from '@jest/globals';
 import { processInputAndSetOutput } from '../../src/browser/toys.js';
 
 let elements;
@@ -11,29 +18,31 @@ beforeEach(() => {
     inputElement: { value: 'input' },
     outputParentElement: {},
     outputSelect: { value: 'text' },
-    article: { id: 'post1' }
+    article: { id: 'post1' },
   };
   toyEnv = new Map([
     ['getData', () => ({ output: {} })],
-    ['setData', jest.fn()]
+    ['setData', jest.fn()],
   ]);
   env = {
     createEnv: jest.fn(() => toyEnv),
-    fetchFn: jest.fn(() => Promise.resolve({ text: jest.fn(() => Promise.resolve('')) })),
+    fetchFn: jest.fn(() =>
+      Promise.resolve({ text: jest.fn(() => Promise.resolve('')) })
+    ),
     dom: {
       setTextContent: jest.fn(),
       removeAllChildren: jest.fn(),
       appendChild: jest.fn(),
       createElement: jest.fn(() => ({})),
       addWarning: jest.fn(),
-      removeWarning: jest.fn()
+      removeWarning: jest.fn(),
     },
     errorFn: jest.fn(),
     loggers: {
       logInfo: jest.fn(),
       logError: jest.fn(),
-      logWarning: jest.fn()
-    }
+      logWarning: jest.fn(),
+    },
   };
   processingFunction = jest.fn();
 });
@@ -66,5 +75,16 @@ describe('processInputAndSetOutput', () => {
       elements.outputParentElement,
       expect.anything()
     );
+  });
+
+  it('stores the result using the article id', () => {
+    const result = 'value';
+    processingFunction.mockReturnValue(result);
+
+    processInputAndSetOutput(elements, processingFunction, env);
+
+    const setData = toyEnv.get('setData');
+    const callArg = setData.mock.calls[0][0];
+    expect(callArg.output).toMatchObject({ [elements.article.id]: result });
   });
 });


### PR DESCRIPTION
## Summary
- extend `processInputAndSetOutput` tests to verify the result is stored under the article id

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6841d86fe774832ea88893b63e3dd9f2