### PR TITLE
Add test for occupied cell scenario

### DIFF
--- a/test/presenters/ticTacToeBoard.test.js
+++ b/test/presenters/ticTacToeBoard.test.js
@@ -117,6 +117,23 @@ describe('createTicTacToeBoardElement', () => {
     );
   });
 
+  it('ignores a second move to an occupied cell', () => {
+    const input = JSON.stringify({
+      moves: [
+        { player: 'X', position: { row: 0, column: 0 } },
+        { player: 'O', position: { row: 0, column: 0 } }
+      ]
+    });
+    const el = createTicTacToeBoardElement(input, mockDom());
+    expect(el.textContent).toBe(
+      ' X |   |   \n' +
+      '---+---+---\n' +
+      '   |   |   \n' +
+      '---+---+---\n' +
+      '   |   |   '
+    );
+  });
+
   it('ignores moves with missing row/column', () => {
     const input = JSON.stringify({
       moves: [


### PR DESCRIPTION
## Summary
- increase coverage of ticTacToeBoard presenter
- ensure a second move to an already used cell is ignored

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6841d8753c14832ea7a603191f51f143