### PR TITLE
Improve tests for makeDisplayBody

### DIFF
--- a/test/browser/toys.makeDisplayBody.test.js
+++ b/test/browser/toys.makeDisplayBody.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect } from '@jest/globals';
+import { describe, it, expect, jest } from '@jest/globals';
 import { makeDisplayBody } from '../../src/browser/toys.js';
 
 describe('makeDisplayBody', () => {
@@ -19,5 +19,27 @@ describe('makeDisplayBody', () => {
 
     // Act & Assert - Invoke the result with a test body
     expect(() => result(testBody)).not.toThrow();
+  });
+
+  it('updates the DOM using setTextContent', () => {
+    const setTextContent = jest.fn();
+    const mockDom = {
+      removeAllChildren: jest.fn(),
+      appendChild: jest.fn(),
+      createElement: jest.fn(() => ({})),
+      setTextContent,
+    };
+    const mockParent = {};
+    const presenterKey = 'text';
+
+    const displayBody = makeDisplayBody(mockDom, mockParent, presenterKey);
+    const body = 'content';
+    displayBody(body);
+
+    expect(mockDom.removeAllChildren).toHaveBeenCalledWith(mockParent);
+    expect(mockDom.appendChild).toHaveBeenCalledWith(
+      mockParent,
+      expect.anything()
+    );
   });
 });


### PR DESCRIPTION
## Summary
- add assertions for DOM updates in `makeDisplayBody` tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841d8739fc8832e96cf673b0c2a1171