### PR TITLE
Extend tests for markdown constants

### DIFF
--- a/test/constants/markdown.mutant.test.js
+++ b/test/constants/markdown.mutant.test.js
@@ -1,5 +1,10 @@
 import { describe, test, expect } from '@jest/globals';
-import { CSS_CLASSES } from '../../src/constants/markdown.js';
+import {
+  CSS_CLASSES,
+  HTML_TAGS,
+  MARKDOWN_MARKERS,
+  DEFAULT_OPTIONS,
+} from '../../src/constants/markdown.js';
 
 // Additional coverage to kill Stryker mutants around CSS_CLASSES values
 
@@ -18,5 +23,27 @@ describe('markdown constants mutants', () => {
       IMAGE: 'markdown-image',
       HORIZONTAL_RULE: 'markdown-hr',
     });
+  });
+
+  test('constant objects are frozen', () => {
+    expect(Object.isFrozen(MARKDOWN_MARKERS)).toBe(true);
+    expect(Object.isFrozen(HTML_TAGS)).toBe(true);
+    expect(Object.isFrozen(CSS_CLASSES)).toBe(true);
+    expect(Object.isFrozen(DEFAULT_OPTIONS)).toBe(true);
+  });
+
+  test('constant objects cannot be modified', () => {
+    expect(() => {
+      MARKDOWN_MARKERS.ASTERISK = 'changed';
+    }).toThrow();
+    expect(() => {
+      HTML_TAGS.EMPHASIS = 'changed';
+    }).toThrow();
+    expect(() => {
+      CSS_CLASSES.CONTAINER = 'changed';
+    }).toThrow();
+    expect(() => {
+      DEFAULT_OPTIONS.gfm = false;
+    }).toThrow();
   });
 });


### PR DESCRIPTION
## Summary
- ensure markdown constant objects are frozen and immutable

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841d872dd7c832eb19f31e234aaf35f