### PR TITLE
Add test for empty header keys

### DIFF
--- a/test/generator/generator.constants.test.js
+++ b/test/generator/generator.constants.test.js
@@ -30,4 +30,13 @@ describe('generator constants usage', () => {
     const html = generateBlogOuter({ posts: [] });
     expect(html.includes('<div class="value"><div class="value')).toBe(false);
   });
+
+  test('header key divs are empty', () => {
+    const html = generateBlogOuter({ posts: [] });
+    const keyDivs = [...html.matchAll(/<div class="key">([^<]*)<\/div>/g)];
+    expect(keyDivs.length).toBeGreaterThan(0);
+    keyDivs.forEach(([, content]) => {
+      expect(content).toBe('');
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- extend generator constants tests with check for empty header key divs

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841d871df3c832eb199268983b3ff8b