### PR TITLE
Add coverage for closing tag helpers

### DIFF
--- a/test/generator/html.test.js
+++ b/test/generator/html.test.js
@@ -5,6 +5,11 @@ import {
   escapeHtml,
   createHtmlTag,
   wrapHtml,
+  getClosingTagParts,
+  createClosingTag,
+  TAG_OPEN,
+  SLASH,
+  TAG_CLOSE,
 } from '../../src/generator/html.js';
 
 describe('html utilities', () => {
@@ -38,5 +43,18 @@ describe('html utilities', () => {
 
   test('wrapHtml adds doctype and html tag', () => {
     expect(wrapHtml('hi')).toBe('<!DOCTYPE html><html lang="en">hi</html>');
+  });
+
+  test('getClosingTagParts returns correct parts', () => {
+    expect(getClosingTagParts('div')).toEqual([
+      TAG_OPEN,
+      SLASH,
+      'div',
+      TAG_CLOSE,
+    ]);
+  });
+
+  test('createClosingTag returns closing tag', () => {
+    expect(createClosingTag('span')).toBe('</span>');
   });
 });


### PR DESCRIPTION
## Summary
- extend html tests with getClosingTagParts and createClosingTag checks

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6841d86f1588832eb7fd3489aeeaed67