### PR TITLE
Improve test coverage for processInputAndSetOutput

### DIFF
--- a/test/browser/processInputAndSetOutput.test.js
+++ b/test/browser/processInputAndSetOutput.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
+import * as setOutputModule from '../../src/browser/setOutput.js';
 import { processInputAndSetOutput } from '../../src/browser/toys.js';
 
 let elements;
@@ -65,6 +66,20 @@ describe('processInputAndSetOutput', () => {
     expect(env.dom.appendChild).toHaveBeenCalledWith(
       elements.outputParentElement,
       expect.anything()
+    );
+  });
+
+  it('calls setData with result mapped to article id', () => {
+    const result = 'value';
+    processingFunction.mockReturnValue(result);
+
+    processInputAndSetOutput(elements, processingFunction, env);
+
+    const setData = toyEnv.get('setData');
+    expect(setData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        output: { [elements.article.id]: result },
+      })
     );
   });
 });


### PR DESCRIPTION
## Summary
- add test verifying `processInputAndSetOutput` stores results by article id

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841d86ed2d8832ea8f41dbf3ca4f397