### PR TITLE
Add tic-tac-toe test to kill surviving mutant

### DIFF
--- a/test/presenters/ticTacToeBoard.test.js
+++ b/test/presenters/ticTacToeBoard.test.js
@@ -117,6 +117,23 @@ describe('createTicTacToeBoardElement', () => {
     );
   });
 
+  it('does not allow a later move to overwrite an earlier one', () => {
+    const input = JSON.stringify({
+      moves: [
+        { player: 'X', position: { row: 0, column: 0 } },
+        { player: 'O', position: { row: 0, column: 0 } },
+      ],
+    });
+    const el = createTicTacToeBoardElement(input, mockDom());
+    expect(el.textContent).toBe(
+      ' X |   |   \n' +
+      '---+---+---\n' +
+      '   |   |   \n' +
+      '---+---+---\n' +
+      '   |   |   '
+    );
+  });
+
   it('ignores moves with missing row/column', () => {
     const input = JSON.stringify({
       moves: [


### PR DESCRIPTION
## Summary
- extend ticTacToeBoard tests to check that a later move cannot overwrite an earlier move

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841d86e7b40832e878653375f61d867