### PR TITLE
Add safeTrim spacing test

### DIFF
--- a/test/utils/stringUtils.test.js
+++ b/test/utils/stringUtils.test.js
@@ -62,4 +62,9 @@ describe('safeTrim', () => {
     expect(safeTrim('')).toBe('');
     expect(safeTrim('   ')).toBe('');
   });
+
+  test('preserves internal spacing', () => {
+    const str = 'te st';
+    expect(safeTrim(str)).toBe(str);
+  });
 });


### PR DESCRIPTION
## Summary
- add missing test case for `safeTrim` to cover internal spaces

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841d86e5a34832ea9a7aba96bb9cd4b