### PR TITLE
Add header key div count test

### DIFF
--- a/test/generator/headerContent.countKeyDivs.test.js
+++ b/test/generator/headerContent.countKeyDivs.test.js
@@ -1,0 +1,10 @@
+import { describe, test, expect } from '@jest/globals';
+import { getBlogGenerationArgs } from '../../src/generator/generator.js';
+
+describe('header content key divs', () => {
+  test('getBlogGenerationArgs header has two empty key divs', () => {
+    const { header } = getBlogGenerationArgs();
+    const matches = header.match(/<div class="key"><\/div>/g) || [];
+    expect(matches.length).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- extend header tests to check number of empty key divs

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841d86d8c8c832e9e18763c8b1e2188