### PR TITLE
Add test for setTextContent presenter mapping

### DIFF
--- a/test/browser/toys.setTextContent.test.js
+++ b/test/browser/toys.setTextContent.test.js
@@ -1,0 +1,26 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { handleDropdownChange } from '../../src/browser/toys.js';
+
+describe('setTextContent via handleDropdownChange', () => {
+  it('uses the paragraph presenter for "text" output', () => {
+    const created = {};
+    const dom = {
+      querySelector: jest.fn(() => created),
+      removeAllChildren: jest.fn(),
+      appendChild: jest.fn(),
+      createElement: jest.fn(() => ({ tagName: 'P' })),
+      setTextContent: jest.fn(),
+    };
+    const dropdown = {
+      value: 'text',
+      closest: jest.fn(() => ({ id: 'post-id' })),
+      parentNode: { querySelector: () => created },
+    };
+    const getData = jest.fn(() => ({ output: { 'post-id': 'hello' } }));
+
+    handleDropdownChange(dropdown, getData, dom);
+
+    expect(dom.createElement).toHaveBeenCalledWith('p');
+    expect(dom.appendChild).toHaveBeenCalledWith(created, { tagName: 'P' });
+  });
+});


### PR DESCRIPTION
## Summary
- add a new unit test verifying that `handleDropdownChange` uses the correct presenter when the dropdown value is `text`
- keep branch coverage at 100%

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841d86d2adc832e828b2dfbc482f837