### PR TITLE
Add coverage for inventory retention in trade

### DIFF
--- a/test/toys/2025-03-30/cyberpunkAdventure.test.js
+++ b/test/toys/2025-03-30/cyberpunkAdventure.test.js
@@ -59,7 +59,7 @@ describe('Cyberpunk Text Game', () => {
     tempData = {
       name: 'Blaze',
       state: 'hub',
-      inventory: ['datapad'],
+      inventory: ['datapad', 'map'],
       visited: [],
     };
     env.set('getData', () => ({ temporary: { CYBE1: tempData } }));
@@ -69,6 +69,7 @@ describe('Cyberpunk Text Game', () => {
     expect(cyberpunkAdventure(' ', env)).toMatch(/vendor offers/);
     expect(cyberpunkAdventure('trade datapad', env)).toMatch(/neural ticket/);
     expect(tempData.inventory).toContain('neural ticket');
+    expect(tempData.inventory).toContain('map');
     expect(tempData.inventory).not.toContain('datapad');
     expect(tempData.visited).toContain('transport');
   });


### PR DESCRIPTION
## Summary
- extend trade flow test to ensure other inventory items remain

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841d86bde50832ea566f6b74920412d