### PR TITLE
Add clue layout check

### DIFF
--- a/test/presenters/battleshipSolitaireClues.test.js
+++ b/test/presenters/battleshipSolitaireClues.test.js
@@ -116,6 +116,10 @@ describe('createBattleshipCluesBoardElement – successful render', () => {
     // column clues: maxDigits = 2 → 2 top + grid(3) + 2 bottom = 7 lines
     expect(lines.length).toBe(7);
 
+    // check top column clues tens digit line
+    const topTensLine = lines[0];
+    expect(topTensLine).toBe('       1     ');
+
     // row clue padding width = 2  (because '12' is widest)
     // Row lines should start with left clue and end with right clue
     expect(lines[2].startsWith(' 5')).toBe(true);


### PR DESCRIPTION
## Summary
- check first column clue line when rendering battleship clues

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6841f266ea28832e94a35334da61df76