### PR TITLE
Add column win test

### DIFF
--- a/test/toys/2025-04-06/ticTacToe.test.js
+++ b/test/toys/2025-04-06/ticTacToe.test.js
@@ -158,6 +158,22 @@ test('detects win for O and returns no additional move', () => {
   expect(output.moves).toEqual(input.moves); // game is over, no extra move
 });
 
+test('detects column win for X and returns no additional move', () => {
+  const env = new Map();
+  const input = {
+    moves: [
+      { player: 'X', position: { row: 0, column: 0 } },
+      { player: 'O', position: { row: 0, column: 1 } },
+      { player: 'X', position: { row: 1, column: 0 } },
+      { player: 'O', position: { row: 1, column: 1 } },
+      { player: 'X', position: { row: 2, column: 0 } }, // X wins down the first column
+    ],
+  };
+  const result = ticTacToeMove(JSON.stringify(input), env);
+  const output = JSON.parse(result);
+  expect(output.moves).toEqual(input.moves); // no additional move since column win ends the game
+});
+
 test('adds ninth move to result in a tie', () => {
   const env = new Map();
   const input = {


### PR DESCRIPTION
## Summary
- add a new unit test ensuring `ticTacToeMove` handles a column win

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841f265c390832e901226c1a8bcb171