### PR TITLE
Improve coverage for blog footer

### DIFF
--- a/test/generator/footerScript.test.js
+++ b/test/generator/footerScript.test.js
@@ -6,4 +6,9 @@ describe('footer script tag', () => {
     const html = generateBlogOuter({ posts: [] });
     expect(html).toContain('<script type="module" src="browser/main.js" defer></script>');
   });
+
+  test('generateBlogOuter closes the container before the script tag', () => {
+    const html = generateBlogOuter({ posts: [] });
+    expect(html).toContain('</div></div><script type="module" src="browser/main.js" defer></script>');
+  });
 });


### PR DESCRIPTION
## Summary
- add test ensuring the container div closes before the script tag

## Testing
- `npm test --silent`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841f2655c24832e97dcae8e8743ab06