### PR TITLE
Add processInputAndSetOutput coverage

### DIFF
--- a/test/browser/processInputAndSetOutput.test.js
+++ b/test/browser/processInputAndSetOutput.test.js
@@ -1,4 +1,11 @@
-import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  jest,
+} from '@jest/globals';
 import { processInputAndSetOutput } from '../../src/browser/toys.js';
 
 let elements;
@@ -11,29 +18,31 @@ beforeEach(() => {
     inputElement: { value: 'input' },
     outputParentElement: {},
     outputSelect: { value: 'text' },
-    article: { id: 'post1' }
+    article: { id: 'post1' },
   };
   toyEnv = new Map([
     ['getData', () => ({ output: {} })],
-    ['setData', jest.fn()]
+    ['setData', jest.fn()],
   ]);
   env = {
     createEnv: jest.fn(() => toyEnv),
-    fetchFn: jest.fn(() => Promise.resolve({ text: jest.fn(() => Promise.resolve('')) })),
+    fetchFn: jest.fn(() =>
+      Promise.resolve({ text: jest.fn(() => Promise.resolve('')) })
+    ),
     dom: {
       setTextContent: jest.fn(),
       removeAllChildren: jest.fn(),
       appendChild: jest.fn(),
       createElement: jest.fn(() => ({})),
       addWarning: jest.fn(),
-      removeWarning: jest.fn()
+      removeWarning: jest.fn(),
     },
     errorFn: jest.fn(),
     loggers: {
       logInfo: jest.fn(),
       logError: jest.fn(),
-      logWarning: jest.fn()
-    }
+      logWarning: jest.fn(),
+    },
   };
   processingFunction = jest.fn();
 });

--- a/test/browser/toys.processInputAndSetOutput.test.js
+++ b/test/browser/toys.processInputAndSetOutput.test.js
@@ -72,4 +72,42 @@ describe('processInputAndSetOutput', () => {
     expect(dom.removeAllChildren).toHaveBeenCalledWith(parent);
     expect(dom.appendChild).toHaveBeenCalled();
   });
+
+  it('stores the result keyed by article id', async () => {
+    const inputElement = { value: 'ignored' };
+    const parent = {};
+    const outputSelect = { value: 'text' };
+    const article = { id: 'a1' };
+    const elements = {
+      inputElement,
+      outputParentElement: parent,
+      outputSelect,
+      article,
+    };
+    const dom = {
+      removeAllChildren: jest.fn(),
+      appendChild: jest.fn(),
+      createElement: jest.fn(() => ({})),
+      setTextContent: jest.fn(),
+      addWarning: jest.fn(),
+    };
+    const setData = jest.fn();
+    const toyEnv = new Map([
+      ['getData', () => ({ output: {} })],
+      ['setData', setData],
+    ]);
+    const env = {
+      createEnv: jest.fn(() => toyEnv),
+      dom,
+      errorFn: jest.fn(),
+      fetchFn: jest.fn(),
+    };
+    const result = 'ok';
+    const processingFunction = jest.fn(() => result);
+
+    await processInputAndSetOutput(elements, processingFunction, env);
+
+    const callArg = setData.mock.calls[0][0];
+    expect(callArg.output).toEqual({ [article.id]: result });
+  });
 });


### PR DESCRIPTION
## Summary
- improve `processInputAndSetOutput` coverage so it exercises `setOutput`
- add a new async test verifying stored output

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841f263caa4832e8b4628777efcd7a5