### PR TITLE
Add test for container closing in generator

### DIFF
--- a/test/generator/getBlogGenerationArgs.test.js
+++ b/test/generator/getBlogGenerationArgs.test.js
@@ -22,6 +22,15 @@ describe('generateBlogOuter', () => {
     expect(result).toContain('aria-label="Matt Heard"');
     expect(result).toContain('Software developer and philosopher in Berlin');
   });
+
+  it('closes the container before loading the browser script', () => {
+    const result = generateBlogOuter({ posts: [] });
+    expect(
+      result.includes(
+        '</div></div></div><script type="module" src="browser/main.js" defer></script>'
+      )
+    ).toBe(true);
+  });
 });
 
 describe('getBlogGenerationArgs', () => {


### PR DESCRIPTION
## Summary
- ensure the HTML container is closed before the browser script loads

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841f264b1d4832ea36d01f07d26db0a