### PR TITLE
Add test to kill Stryker mutant

### DIFF
--- a/test/browser/processInputAndSetOutput.setOutput.test.js
+++ b/test/browser/processInputAndSetOutput.setOutput.test.js
@@ -1,0 +1,36 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { processInputAndSetOutput } from '../../src/browser/toys.js';
+
+describe('processInputAndSetOutput integration', () => {
+  let elements;
+  let env;
+  let toyEnv;
+  let processingFunction;
+
+  beforeEach(() => {
+    elements = {
+      inputElement: { value: 'input' },
+      outputParentElement: {},
+      outputSelect: { value: 'text' },
+      article: { id: 'post1' }
+    };
+    toyEnv = new Map([
+      ['getData', () => ({ output: {} })],
+      ['setData', jest.fn()]
+    ]);
+    env = {
+      createEnv: jest.fn(() => toyEnv),
+      dom: { setTextContent: jest.fn(), removeAllChildren: jest.fn(), appendChild: jest.fn(), createElement: jest.fn(() => ({})), addWarning: jest.fn(), removeWarning: jest.fn() },
+      fetchFn: jest.fn(),
+      errorFn: jest.fn(),
+      loggers: { logInfo: jest.fn(), logError: jest.fn(), logWarning: jest.fn() }
+    };
+    processingFunction = jest.fn().mockReturnValue('result');
+  });
+
+  it('stores result with article id key via setOutput', () => {
+    processInputAndSetOutput(elements, processingFunction, env);
+    const callArg = toyEnv.get('setData').mock.calls[0][0];
+    expect(callArg.output).toEqual({ [elements.article.id]: 'result' });
+  });
+});


### PR DESCRIPTION
## Summary
- add integration test verifying `processInputAndSetOutput` stores output keyed by article id

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6841f262b7d8832e8798b8244ca09f07