### PR TITLE
Add parseJSONResult tests

### DIFF
--- a/test/browser/parseJSONResult.test.js
+++ b/test/browser/parseJSONResult.test.js
@@ -1,0 +1,22 @@
+import { describe, test, expect } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+
+function loadParseJSONResult() {
+  const filePath = path.join(process.cwd(), "src/browser/toys.js");
+  const code = fs.readFileSync(filePath, "utf8");
+  const match = code.match(/function parseJSONResult\(result\) {[^]*?\n}\n/);
+  return eval(`(${match[0]})`);
+}
+
+describe("parseJSONResult", () => {
+  test("returns null for invalid JSON", () => {
+    const parseJSONResult = loadParseJSONResult();
+    expect(parseJSONResult("not json")).toBeNull();
+  });
+
+  test("returns object for valid JSON", () => {
+    const parseJSONResult = loadParseJSONResult();
+    expect(parseJSONResult("{\"a\":1}")).toEqual({ a: 1 });
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for `parseJSONResult`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841f26258e0832e8ddea16b4abff59f