### PR TITLE
Add test for container close tag

### DIFF
--- a/test/generator/containerClose.test.js
+++ b/test/generator/containerClose.test.js
@@ -1,0 +1,9 @@
+import { describe, test, expect } from '@jest/globals';
+import { generateBlogOuter } from '../../src/generator/generator.js';
+
+describe('container closing tag', () => {
+  test('generateBlogOuter closes the container div', () => {
+    const html = generateBlogOuter({ posts: [] });
+    expect(html).toContain('</div><script type="module" src="browser/main.js" defer></script>');
+  });
+});


### PR DESCRIPTION
## Summary
- add a unit test ensuring the generated blog HTML closes the container div

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841f2620b18832ea31b02f9418a81d7