### PR TITLE
Add test for createValueDiv falsy classes

### DIFF
--- a/test/generator/createValueDiv.filter.test.js
+++ b/test/generator/createValueDiv.filter.test.js
@@ -1,0 +1,24 @@
+import fs from 'fs';
+import path from 'path';
+import { pathToFileURL } from 'url';
+import { beforeAll, describe, test, expect } from '@jest/globals';
+
+let createValueDiv;
+
+beforeAll(async () => {
+  const generatorPath = path.join(process.cwd(), 'src/generator/generator.js');
+  let src = fs.readFileSync(generatorPath, 'utf8');
+  src = src.replace(/from '\.\/(.*?)'/g, (_, p) => {
+    const absolute = pathToFileURL(path.join(path.dirname(generatorPath), p));
+    return `from '${absolute.href}'`;
+  });
+  src += '\nexport { createValueDiv };';
+  ({ createValueDiv } = await import(`data:text/javascript,${encodeURIComponent(src)}`));
+});
+
+describe('createValueDiv falsey classes', () => {
+  test('filters out falsey additional classes', () => {
+    const html = createValueDiv('content', ['', undefined, 'extra']);
+    expect(html).toBe('<div class="value extra">content</div>');
+  });
+});


### PR DESCRIPTION
## Summary
- add a unit test that exposes private createValueDiv with falsy classes
- ensure additional classes are filtered

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841f2612ae8832e8b9e6852ff0e803e