### PR TITLE
Add test for parseJSONResult

### DIFF
--- a/test/browser/toys.parseJSONResult.mutant.test.js
+++ b/test/browser/toys.parseJSONResult.mutant.test.js
@@ -1,0 +1,13 @@
+import { describe, it, expect } from '@jest/globals';
+import fs from 'fs';
+import path from 'path';
+
+describe('parseJSONResult mutant', () => {
+  it('returns null when JSON parsing fails', () => {
+    const filePath = path.join(process.cwd(), 'src/browser/toys.js');
+    const fileContents = fs.readFileSync(filePath, 'utf8');
+    const match = fileContents.match(/function parseJSONResult\([^]*?\n\}/);
+    const parseJSONResult = eval('(' + match[0] + ')');
+    expect(parseJSONResult('not json')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add mutation test for parseJSONResult when JSON.parse throws

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841f2603d08832e91e10becf903e5d9