### PR TITLE
Fix surviving mutant by asserting closing div

### DIFF
--- a/test/generator/generator.constants.test.js
+++ b/test/generator/generator.constants.test.js
@@ -39,4 +39,11 @@ describe('generator constants usage', () => {
       expect(content).toBe('');
     });
   });
+
+  test('blog output closes container before script tag', () => {
+    const html = generateBlogOuter({ posts: [] });
+    expect(html).toContain(
+      '</div><script type="module" src="browser/main.js" defer></script>'
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- add a regression test to ensure the footer closes the container div before loading the browser script

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6841f2601918832e8c7918d363b59358