### PR TITLE
Improve coverage for styles constant

### DIFF
--- a/test/generator/styles.test.js
+++ b/test/generator/styles.test.js
@@ -6,4 +6,8 @@ describe('styles constant', () => {
     expect(styles).toContain('background-color: #121212;');
     expect(styles).toContain('.article-title');
   });
+
+  test('starts with body selector', () => {
+    expect(styles.startsWith('\n  body {')).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- add regression test for the `styles` constant to ensure it starts with the body selector

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841f25f1bdc832ebed89c8926dff484