### PR TITLE
Add test to kill parseJSONResult mutant

### DIFF
--- a/test/browser/toys.parseJSONResult.test.js
+++ b/test/browser/toys.parseJSONResult.test.js
@@ -1,0 +1,35 @@
+import { describe, it, expect } from '@jest/globals';
+import fs from 'fs';
+import path from 'path';
+
+const srcPath = path.join(process.cwd(), 'src/browser/toys.js');
+const source = fs.readFileSync(srcPath, 'utf8');
+const start = source.indexOf('function parseJSONResult');
+let braceCount = 0;
+let end = start;
+for (; end < source.length; end++) {
+  const char = source[end];
+  if (char === '{') {braceCount++;}
+  if (char === '}') {
+    braceCount--;
+    if (braceCount === 0) {
+      end++; // include closing brace
+      break;
+    }
+  }
+}
+const fnSource = source.slice(start, end);
+const parseJSONResult = eval(`(${fnSource})`);
+
+describe('parseJSONResult', () => {
+  it('returns parsed object for valid JSON', () => {
+    const obj = { a: 1 };
+    const result = parseJSONResult(JSON.stringify(obj));
+    expect(result).toEqual(obj);
+  });
+
+  it('returns null for invalid JSON', () => {
+    const result = parseJSONResult('{ invalid');
+    expect(result).toBeNull();
+  });
+});

--- a/test/browser/toys.processInputAndSetOutput.test.js
+++ b/test/browser/toys.processInputAndSetOutput.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, jest } from '@jest/globals';
-import { processInputAndSetOutput } from '../../src/browser/toys.js';
+import * as toys from '../../src/browser/toys.js';
+const { processInputAndSetOutput } = toys;
 
 describe('processInputAndSetOutput', () => {
   it('handles valid JSON result using handleParsedResult', async () => {


### PR DESCRIPTION
## Summary
- add regression test for `parseJSONResult`
- refactor import in `toys.processInputAndSetOutput.test.js` to namespace import

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841f25d7164832e989fec60b1e3e8b5