### PR TITLE
Add test for grub bait in fishingGame

### DIFF
--- a/test/toys/2025-03-29/fishingGame.test.js
+++ b/test/toys/2025-03-29/fishingGame.test.js
@@ -83,4 +83,9 @@ describe('fishingGame', () => {
     const output = fishingGame('worm', env);
     expect(output).toMatch(/beneath a silent, starry sky/i);
   });
+  test('recognizes grub bait and mentions its description', () => {
+    const env = createEnv(0.4, '2025-07-15T10:00:00');
+    const output = fishingGame('grub', env);
+    expect(output).toMatch(/succulent grub/i);
+  });
 });


### PR DESCRIPTION
## Summary
- extend fishingGame tests to cover 'grub' bait

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841f25b3b80832eb07e3b0f63effe10