### PR TITLE
Add test to kill surviving Battleship fleet mutant

### DIFF
--- a/test/presenters/battleshipSolitaireFleet.test.js
+++ b/test/presenters/battleshipSolitaireFleet.test.js
@@ -201,4 +201,22 @@ describe('createBattleshipFleetBoardElement', () => {
     expect(lines[1].replace(/ /g, '')).toBe('···');
     expect(lines[2].replace(/ /g, '')).toBe('···');
   });
+
+  test('skips ships with non-number length', () => {
+    const fleet = {
+      width: 3,
+      height: 3,
+      ships: [
+        { start: { x: 0, y: 0 }, length: 2, direction: 'H' },
+        { start: { x: 1, y: 1 }, length: '2', direction: 'H' },
+      ],
+    };
+    const input = JSON.stringify(fleet);
+    const el = createBattleshipFleetBoardElement(input, dom);
+    expect(el.tag).toBe('pre');
+    const lines = el.text.trim().split('\n');
+    expect(lines[0].replace(/ /g, '')).toBe('##·');
+    expect(lines[1].replace(/ /g, '')).toBe('···');
+    expect(lines[2].replace(/ /g, '')).toBe('···');
+  });
 });


### PR DESCRIPTION
## Summary
- extend Battleship fleet presenter tests to handle ships with non‑numeric length

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841f25a8a30832e919891c06a1104b6