### PR TITLE
Add missing check for container close

### DIFF
--- a/test/generator/generator.constants.test.js
+++ b/test/generator/generator.constants.test.js
@@ -39,4 +39,11 @@ describe('generator constants usage', () => {
       expect(content).toBe('');
     });
   });
+
+  test('blog output closes the container before the script tag', () => {
+    const html = generateBlogOuter({ posts: [] });
+    expect(html).toContain(
+      '</div></div></div><script type="module" src="browser/main.js" defer></script>'
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- check that the page footer closes the container div before the script tag

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841f25a1780832e9c09a2be96e74e8a