### PR TITLE
Add footer start test

### DIFF
--- a/test/generator/footerStart.test.js
+++ b/test/generator/footerStart.test.js
@@ -1,0 +1,9 @@
+import { describe, test, expect } from '@jest/globals';
+import { getBlogGenerationArgs } from '../../src/generator/generator.js';
+
+describe('footer start', () => {
+  test('getBlogGenerationArgs footer starts with entry div', () => {
+    const { footer } = getBlogGenerationArgs();
+    expect(footer.startsWith('<div class="entry">')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add a regression test ensuring the blog footer starts with the entry div

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841f25827ac832eb6efe2fb7459fea0