### PR TITLE
Add test for container closing div

### DIFF
--- a/test/generator/containerClose.test.js
+++ b/test/generator/containerClose.test.js
@@ -1,0 +1,10 @@
+import { describe, test, expect } from '@jest/globals';
+import { generateBlogOuter } from '../../src/generator/generator.js';
+
+describe('container closing div', () => {
+  test('generateBlogOuter closes container before script tag', () => {
+    const html = generateBlogOuter({ posts: [] });
+    expect(html).toContain('</div><script type="module" src="browser/main.js" defer></script>');
+    expect(html).not.toContain('undefined');
+  });
+});


### PR DESCRIPTION
## Summary
- ensure blog generator outputs closing container `<div>` before script tag

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841f2574c6c832eba7b3a8be7bb3c16