### PR TITLE
Extend generator mutant test

### DIFF
--- a/test/generator/generator.mutant.test.js
+++ b/test/generator/generator.mutant.test.js
@@ -1,10 +1,5 @@
-import { describe, test, expect, beforeAll } from '@jest/globals';
-
-let generateBlogOuter;
-
-beforeAll(async () => {
-  ({ generateBlogOuter } = await import('../../src/generator/generator.js'));
-});
+import { describe, test, expect } from '@jest/globals';
+import { generateBlogOuter } from '../../src/generator/generator.js';
 
 describe('generator mutants', () => {
   test('output does not contain mutation marker', () => {


### PR DESCRIPTION
## Summary
- import generator utility statically for mutation test

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841f2564280832ebba5735ebc2d925a