### PR TITLE
Add test for closing container div

### DIFF
--- a/test/generator/containerClose.test.js
+++ b/test/generator/containerClose.test.js
@@ -1,0 +1,11 @@
+import { generateBlogOuter } from '../../src/generator/generator.js';
+import { describe, test, expect } from '@jest/globals';
+
+describe('container closing div', () => {
+  test('generateBlogOuter closes container before script tag', () => {
+    const html = generateBlogOuter({ posts: [] });
+    const snippet =
+      '</div><script type="module" src="browser/main.js" defer></script>';
+    expect(html).toContain(snippet);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure the generated HTML closes the container before the main script

## Testing
- `npm test --silent`
- `npm run lint --silent`

------
https://chatgpt.com/codex/tasks/task_e_6841f2550ae8832ea08bafc9ebf01df3