### PR TITLE
Add test for parseJSONResult

### DIFF
--- a/test/browser/parseJSONResult.test.js
+++ b/test/browser/parseJSONResult.test.js
@@ -1,0 +1,25 @@
+import { beforeAll, describe, it, expect } from '@jest/globals';
+import fs from 'fs';
+import path from 'path';
+
+let parseJSONResult;
+
+beforeAll(() => {
+  const filePath = path.join(process.cwd(), 'src/browser/toys.js');
+  const code = fs.readFileSync(filePath, 'utf8');
+  const match = code.match(/function parseJSONResult\(result\) {([\s\S]*?)}\n/);
+  // eslint-disable-next-line no-new-func
+  parseJSONResult = new Function(
+    `return function parseJSONResult(result) {${match[1]}}}`
+  )();
+});
+
+describe('parseJSONResult', () => {
+  it('returns parsed object for valid JSON', () => {
+    expect(parseJSONResult('{"a":1}')).toEqual({ a: 1 });
+  });
+
+  it('returns null for invalid JSON', () => {
+    expect(parseJSONResult('invalid')).toBeNull();
+  });
+});

--- a/test/browser/processInputAndSetOutput.test.js
+++ b/test/browser/processInputAndSetOutput.test.js
@@ -1,5 +1,21 @@
-import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
-import { processInputAndSetOutput } from '../../src/browser/toys.js';
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  beforeAll,
+  afterEach,
+  jest,
+} from '@jest/globals';
+
+let toys;
+let processInputAndSetOutput;
+let handleParsedResult;
+
+beforeAll(async () => {
+  toys = await import('../../src/browser/toys.js');
+  ({ processInputAndSetOutput, handleParsedResult } = toys);
+});
 
 let elements;
 let env;
@@ -11,29 +27,31 @@ beforeEach(() => {
     inputElement: { value: 'input' },
     outputParentElement: {},
     outputSelect: { value: 'text' },
-    article: { id: 'post1' }
+    article: { id: 'post1' },
   };
   toyEnv = new Map([
     ['getData', () => ({ output: {} })],
-    ['setData', jest.fn()]
+    ['setData', jest.fn()],
   ]);
   env = {
     createEnv: jest.fn(() => toyEnv),
-    fetchFn: jest.fn(() => Promise.resolve({ text: jest.fn(() => Promise.resolve('')) })),
+    fetchFn: jest.fn(() =>
+      Promise.resolve({ text: jest.fn(() => Promise.resolve('')) })
+    ),
     dom: {
       setTextContent: jest.fn(),
       removeAllChildren: jest.fn(),
       appendChild: jest.fn(),
       createElement: jest.fn(() => ({})),
       addWarning: jest.fn(),
-      removeWarning: jest.fn()
+      removeWarning: jest.fn(),
     },
     errorFn: jest.fn(),
     loggers: {
       logInfo: jest.fn(),
       logError: jest.fn(),
-      logWarning: jest.fn()
-    }
+      logWarning: jest.fn(),
+    },
   };
   processingFunction = jest.fn();
 });


### PR DESCRIPTION
## Summary
- add regression tests for parseJSONResult
- refactor processInputAndSetOutput tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841f250d334832eb0492b970c4380d9