### PR TITLE
Add test for fleet invalid length

### DIFF
--- a/test/presenters/battleshipSolitaireFleet.test.js
+++ b/test/presenters/battleshipSolitaireFleet.test.js
@@ -135,6 +135,24 @@ describe('createBattleshipFleetBoardElement', () => {
     expect(lines[2].replace(/ /g, '')).toBe('···');
   });
 
+  test('skips ships with non-number length', () => {
+    const fleet = {
+      width: 3,
+      height: 3,
+      ships: [
+        { start: { x: 0, y: 0 }, length: '2', direction: 'H' },
+        { start: { x: 1, y: 1 }, length: 2, direction: 'V' },
+      ],
+    };
+    const input = JSON.stringify(fleet);
+    const el = createBattleshipFleetBoardElement(input, dom);
+    expect(el.tag).toBe('pre');
+    const lines = el.text.trim().split('\n');
+    expect(lines[0].replace(/ /g, '')).toBe('···');
+    expect(lines[1].replace(/ /g, '')).toBe('·#·');
+    expect(lines[2].replace(/ /g, '')).toBe('·#·');
+  });
+
   test('skips ships missing the start property', () => {
     const fleet = {
       width: 3,


### PR DESCRIPTION
## Summary
- add unit test covering non-number ship length for battleship fleet presenter

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841f24fef54832ea9e15f7c3846950d