### PR TITLE
Add static import to kill surviving mutant

### DIFF
--- a/test/generator/generator.mutant.test.js
+++ b/test/generator/generator.mutant.test.js
@@ -1,14 +1,12 @@
-import { describe, test, expect, beforeAll } from '@jest/globals';
-
-let generateBlogOuter;
-
-beforeAll(async () => {
-  ({ generateBlogOuter } = await import('../../src/generator/generator.js'));
-});
+import { describe, test, expect } from '@jest/globals';
+import { generateBlogOuter } from '../../src/generator/generator.js';
 
 describe('generator mutants', () => {
   test('output does not contain mutation marker', () => {
     const html = generateBlogOuter({ posts: [] });
     expect(html.includes('Stryker was here!')).toBe(false);
+    expect(html).toContain(
+      '</div></div></div><script type="module" src="browser/main.js" defer></script></body>'
+    );
   });
 });


### PR DESCRIPTION
## Summary
- revise `generator.mutant.test.js` to use a static import
- check closing container tags to ensure footer is complete

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841f25434dc832ead0eccf50c0113da