### PR TITLE
Add diagonal win tests for ticTacToe

### DIFF
--- a/test/toys/2025-04-06/ticTacToe.test.js
+++ b/test/toys/2025-04-06/ticTacToe.test.js
@@ -158,6 +158,37 @@ test('detects win for O and returns no additional move', () => {
   expect(output.moves).toEqual(input.moves); // game is over, no extra move
 });
 
+test('detects diagonal win for X from top left', () => {
+  const env = new Map();
+  const input = {
+    moves: [
+      { player: 'X', position: { row: 0, column: 0 } },
+      { player: 'O', position: { row: 0, column: 1 } },
+      { player: 'X', position: { row: 1, column: 1 } },
+      { player: 'O', position: { row: 2, column: 1 } },
+      { player: 'X', position: { row: 2, column: 2 } }, // diagonal win
+    ],
+  };
+  const result = ticTacToeMove(JSON.stringify(input), env);
+  const output = JSON.parse(result);
+  expect(output.moves).toEqual(input.moves);
+});
+
+test('detects diagonal win for X from top right', () => {
+  const env = new Map();
+  const input = {
+    moves: [
+      { player: 'X', position: { row: 0, column: 2 } },
+      { player: 'O', position: { row: 0, column: 0 } },
+      { player: 'X', position: { row: 1, column: 1 } },
+      { player: 'O', position: { row: 1, column: 0 } },
+      { player: 'X', position: { row: 2, column: 0 } }, // diagonal win
+    ],
+  };
+  const result = ticTacToeMove(JSON.stringify(input), env);
+  const output = JSON.parse(result);
+  expect(output.moves).toEqual(input.moves);
+});
 test('adds ninth move to result in a tie', () => {
   const env = new Map();
   const input = {


### PR DESCRIPTION
## Summary
- extend ticTacToe tests with diagonal win scenarios

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6841f2535df8832e8aaaf6d1a701535c