### PR TITLE
Add test for parseJSONResult error handling

### DIFF
--- a/test/browser/toys.parseJSONResult.test.js
+++ b/test/browser/toys.parseJSONResult.test.js
@@ -1,0 +1,15 @@
+import { describe, it, expect } from '@jest/globals';
+import fs from 'fs';
+import path from 'path';
+
+const filePath = path.resolve('src/browser/toys.js');
+const source = fs.readFileSync(filePath, 'utf8');
+const match = source.match(/function parseJSONResult\([^]*?\}\n\}/);
+const parseJSONResult = eval(`(${match[0]})`);
+
+describe('parseJSONResult', () => {
+  it('returns null when JSON parsing fails', () => {
+    const result = parseJSONResult('invalid json');
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- ensure `parseJSONResult` returns `null` for invalid JSON

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841f24e1910832eb027e36b33602659