### PR TITLE
Add missing check for container close

### DIFF
--- a/test/generator/footerScript.test.js
+++ b/test/generator/footerScript.test.js
@@ -4,6 +4,15 @@ import { generateBlogOuter } from '../../src/generator/generator.js';
 describe('footer script tag', () => {
   test('generateBlogOuter includes main script tag', () => {
     const html = generateBlogOuter({ posts: [] });
-    expect(html).toContain('<script type="module" src="browser/main.js" defer></script>');
+    expect(html).toContain(
+      '<script type="module" src="browser/main.js" defer></script>'
+    );
+  });
+
+  test('generateBlogOuter closes the container before the script tag', () => {
+    const html = generateBlogOuter({ posts: [] });
+    expect(html).toContain(
+      '</div></div></div><script type="module" src="browser/main.js" defer></script>'
+    );
   });
 });


### PR DESCRIPTION
## Summary
- add a test ensuring the generated blog closes the container div before loading the script

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841f24c4148832e924c53440a3c45c2