### PR TITLE
Add separated ships test for noTouching fleet

### DIFF
--- a/test/toys/2025-05-08/battleshipSolitaireFleet.test.js
+++ b/test/toys/2025-05-08/battleshipSolitaireFleet.test.js
@@ -135,6 +135,17 @@ describe('generateFleet', () => {
     });
   });
 
+  test('noTouching allows placement when ships are separated', () => {
+    const cfg = { width: 3, height: 3, ships: [1, 1], noTouching: true };
+    const result = JSON.parse(generateFleet(JSON.stringify(cfg), env));
+    expect(Array.isArray(result.ships)).toBe(true);
+    expect(result.ships.length).toBe(2);
+    const [s1, s2] = result.ships;
+    const dx = Math.abs(s1.start.x - s2.start.x);
+    const dy = Math.abs(s1.start.y - s2.start.y);
+    expect(dx > 1 || dy > 1).toBe(true);
+  });
+
   test('shuffles ship order based on RNG', () => {
     const cfg = { width: 4, height: 4, ships: [1, 2, 3] };
     const env = new Map([['getRandomNumber', () => 0]]);


### PR DESCRIPTION
## Summary
- extend Battleship Solitare fleet tests to cover no-touching success case

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841f24c2c00832e9a22f258453f49aa