### PR TITLE
Add test for closing container div

### DIFF
--- a/test/generator/generator.constants.test.js
+++ b/test/generator/generator.constants.test.js
@@ -21,6 +21,13 @@ describe('generator constants usage', () => {
     expect(html).toContain('</body>');
   });
 
+  test('container div closes before the footer script', () => {
+    const html = generateBlogOuter({ posts: [] });
+    const regex =
+      /<\/div><\/div><\/div><script type="module" src="browser\/main.js" defer><\/script>/;
+    expect(html).toMatch(regex);
+  });
+
   test('footer content is not wrapped in an extra value div', () => {
     const html = generateBlogOuter({ posts: [] });
     expect(html.includes('<div class="value"><div class="footer')).toBe(false);


### PR DESCRIPTION
## Summary
- verify closing container tag appears before footer script

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841f24b3608832e8d445af6a9e21efa