### PR TITLE
Add test for negative row start in battleship fleet

### DIFF
--- a/test/presenters/battleshipSolitaireFleet.test.js
+++ b/test/presenters/battleshipSolitaireFleet.test.js
@@ -184,6 +184,19 @@ describe('createBattleshipFleetBoardElement', () => {
     expect(lines).toEqual(['· · ·', '# · ·', '· · ·']);
   });
 
+  test('ignores ships with negative start row', () => {
+    const fleet = {
+      width: 3,
+      height: 3,
+      ships: [{ start: { x: 1, y: -1 }, length: 2, direction: 'V' }],
+    };
+    const input = JSON.stringify(fleet);
+    const el = createBattleshipFleetBoardElement(input, dom);
+    expect(el.tag).toBe('pre');
+    const lines = el.text.trim().split('\n');
+    expect(lines).toEqual(['· # ·', '· · ·', '· · ·']);
+  });
+
   test('skips ships with invalid direction', () => {
     const fleet = {
       width: 3,


### PR DESCRIPTION
## Summary
- ensure battleshipSolitaireFleet handles negative row coordinates

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841f2480f24832ea48cc829c8cc99a8