### PR TITLE
Add test for battleship clue spacing

### DIFF
--- a/test/presenters/battleshipSolitaireClues.test.js
+++ b/test/presenters/battleshipSolitaireClues.test.js
@@ -127,5 +127,9 @@ describe('createBattleshipCluesBoardElement – successful render', () => {
     // check column clue stacking: ones digits should be in last top‑clue line
     const topOnesLine = lines[1]; // second of top two clue lines
     expect(topOnesLine.trim()).toBe('1 9 1 2');
+
+    // ensure tens digits line preserves spaces for single‑digit clues
+    const topTensLine = lines[0];
+    expect(topTensLine).toBe('       1     ');
   });
 });


### PR DESCRIPTION
## Summary
- ensure `createBattleshipCluesBoardElement` preserves spaces in stacked column clue lines

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6841f2472b98832e809f9ce864cd5d5e