### PR TITLE
Add tests for parseJSONResult

### DIFF
--- a/test/browser/toys.parseJSONResult.test.js
+++ b/test/browser/toys.parseJSONResult.test.js
@@ -1,0 +1,18 @@
+import { describe, it, expect } from '@jest/globals';
+import fs from 'fs';
+import path from 'path';
+
+const filePath = path.join(process.cwd(), 'src/browser/toys.js');
+const source = fs.readFileSync(filePath, 'utf8');
+const match = source.match(/function parseJSONResult\(result\)[\s\S]*?\n}\n/);
+const parseJSONResult = match ? eval('(' + match[0] + ')') : undefined;
+
+describe('parseJSONResult', () => {
+  it('returns object for valid JSON', () => {
+    expect(parseJSONResult('{"a":1}')).toEqual({ a: 1 });
+  });
+
+  it('returns null for invalid JSON', () => {
+    expect(parseJSONResult('{invalid')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- extend browser tests to cover `parseJSONResult`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841f2468f9c832ea496eb300da6d2e1