### PR TITLE
Add missing test for generator defaults

### DIFF
--- a/test/generator/applyLabeledSectionDefaults.test.js
+++ b/test/generator/applyLabeledSectionDefaults.test.js
@@ -1,0 +1,25 @@
+import fs from 'fs';
+import path from 'path';
+import { pathToFileURL } from 'url';
+import { beforeAll, describe, test, expect } from '@jest/globals';
+
+let applyLabeledSectionDefaults;
+
+beforeAll(async () => {
+  const generatorPath = path.join(process.cwd(), 'src/generator/generator.js');
+  let src = fs.readFileSync(generatorPath, 'utf8');
+  src = src.replace(/from '\.\/(.*?)'/g, (_, p) => {
+    const absolute = pathToFileURL(path.join(path.dirname(generatorPath), p));
+    return `from '${absolute.href}'`;
+  });
+  src += '\nexport { applyLabeledSectionDefaults };';
+  ({ applyLabeledSectionDefaults } = await import(`data:text/javascript,${encodeURIComponent(src)}`));
+});
+
+describe('applyLabeledSectionDefaults', () => {
+  test('defaults keyExtraClasses to empty string', () => {
+    const args = { wrapValueDiv: false };
+    const result = applyLabeledSectionDefaults({ ...args });
+    expect(result.keyExtraClasses).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- add applyLabeledSectionDefaults unit test targeting defaultKeyExtraClasses

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841fef33910832e8eada053147b8477