### PR TITLE
Add test for escapeRelatedLinkFields

### DIFF
--- a/test/generator/escapeRelatedLinkFields.test.js
+++ b/test/generator/escapeRelatedLinkFields.test.js
@@ -1,0 +1,31 @@
+import fs from 'fs';
+import path from 'path';
+import { pathToFileURL } from 'url';
+import { beforeAll, describe, test, expect } from '@jest/globals';
+
+let escapeRelatedLinkFields;
+
+beforeAll(async () => {
+  const generatorPath = path.join(process.cwd(), 'src/generator/generator.js');
+  let src = fs.readFileSync(generatorPath, 'utf8');
+  src = src.replace(/from '\.\/(.*?)'/g, (_, p) => {
+    const absolute = pathToFileURL(path.join(path.dirname(generatorPath), p));
+    return `from '${absolute.href}'`;
+  });
+  src += '\nexport { escapeRelatedLinkFields };';
+  ({ escapeRelatedLinkFields } = await import(`data:text/javascript,${encodeURIComponent(src)}`));
+});
+
+describe('escapeRelatedLinkFields', () => {
+  test('fills in empty strings for missing fields', () => {
+    const result = escapeRelatedLinkFields({ url: 'https://example.com', type: 'article' });
+    expect(result).toEqual({
+      type: 'article',
+      url: 'https://example.com',
+      title: '',
+      author: '',
+      source: '',
+      quote: '',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test covering escapeRelatedLinkFields with missing fields

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6841feef77fc832e9cc75c74998b35d5