### PR TITLE
Add unit test for defaultKeyExtraClasses

### DIFF
--- a/test/generator/applyLabeledSectionDefaults.keyExtraClasses.test.js
+++ b/test/generator/applyLabeledSectionDefaults.keyExtraClasses.test.js
@@ -1,0 +1,28 @@
+import fs from 'fs';
+import path from 'path';
+import { pathToFileURL } from 'url';
+import { beforeAll, describe, test, expect } from '@jest/globals';
+
+let applyLabeledSectionDefaults;
+
+beforeAll(async () => {
+  const generatorPath = path.join(process.cwd(), 'src/generator/generator.js');
+  let src = fs.readFileSync(generatorPath, 'utf8');
+  src = src.replace(/from '\.\/(.*?)'/g, (_, p) => {
+    const absolute = pathToFileURL(path.join(path.dirname(generatorPath), p));
+    return `from '${absolute.href}'`;
+  });
+  src += '\nexport { applyLabeledSectionDefaults };';
+  ({ applyLabeledSectionDefaults } = await import(
+    `data:text/javascript,${encodeURIComponent(src)}`
+  ));
+});
+
+describe('applyLabeledSectionDefaults', () => {
+  test('sets default keyExtraClasses', () => {
+    const args = { label: 'l', valueHTML: '<span>v</span>' };
+    const result = applyLabeledSectionDefaults(args);
+    expect(result.keyExtraClasses).toBe('');
+    expect(result.wrapValueDiv).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add coverage for `applyLabeledSectionDefaults` to ensure `keyExtraClasses` is initialized

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6841feebd8e0832eac38ae03f5f7f153