### PR TITLE
Add tests for TicTacToe getters

### DIFF
--- a/test/presenters/ticTacToeBoard.getters.test.js
+++ b/test/presenters/ticTacToeBoard.getters.test.js
@@ -1,0 +1,35 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, test, expect } from '@jest/globals';
+
+function loadFunction(name) {
+  const filePath = path.join(process.cwd(), 'src/presenters/ticTacToeBoard.js');
+  const source = fs.readFileSync(filePath, 'utf8');
+  const start = source.indexOf(`function ${name}`);
+  let braceCount = 0;
+  let end = start;
+  for (; end < source.length; end++) {
+    const char = source[end];
+    if (char === '{') {braceCount++;}
+    if (char === '}') {
+      braceCount--;
+      if (braceCount === 0) { end++; break; }
+    }
+  }
+  const fnSource = source.slice(start, end);
+  return eval(`(${fnSource})`);
+}
+
+describe('ticTacToeBoard getters', () => {
+  test('getPlayer handles null input', () => {
+    const getPlayer = loadFunction('getPlayer');
+    expect(() => getPlayer(null)).not.toThrow();
+    expect(getPlayer(null)).toBeUndefined();
+  });
+
+  test('getPosition handles undefined input', () => {
+    const getPosition = loadFunction('getPosition');
+    expect(() => getPosition(undefined)).not.toThrow();
+    expect(getPosition(undefined)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for `getPlayer` and `getPosition`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684316765a30832eaf1b48fabcbe021a