### PR TITLE
Add test to kill parseJSONResult mutant

### DIFF
--- a/test/browser/parseJSONResult.global.test.js
+++ b/test/browser/parseJSONResult.global.test.js
@@ -1,0 +1,32 @@
+import { describe, it, expect } from '@jest/globals';
+import fs from 'fs/promises';
+import vm from 'vm';
+import { pathToFileURL } from 'url';
+
+async function loadParseJSONResult() {
+  const url = pathToFileURL('./src/browser/toys.js');
+  let code = await fs.readFile(url, 'utf8');
+  code += '\nglobal.__test_parseJSONResult = parseJSONResult;';
+  const context = vm.createContext(global);
+  async function linker(specifier, referencingModule) {
+    const modUrl = new URL(specifier, referencingModule.identifier);
+    const src = await fs.readFile(modUrl, 'utf8');
+    const m = new vm.SourceTextModule(src, {
+      identifier: modUrl.href,
+      context,
+    });
+    await m.link(linker);
+    return m;
+  }
+  const mod = new vm.SourceTextModule(code, { identifier: url.href, context });
+  await mod.link(linker);
+  await mod.evaluate();
+  return global.__test_parseJSONResult;
+}
+
+describe('parseJSONResult global', () => {
+  it('returns null for invalid JSON', async () => {
+    const parseJSONResult = await loadParseJSONResult();
+    expect(parseJSONResult('not json')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add `parseJSONResult.global.test.js` to verify error handling

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68431674dd50832eb457c77eaf7a59fc