### PR TITLE
Improve coverage for generator defaults

### DIFF
--- a/test/generator/applyLabeledSectionDefaults.keyExtraClasses.test.js
+++ b/test/generator/applyLabeledSectionDefaults.keyExtraClasses.test.js
@@ -13,6 +13,7 @@ beforeAll(async () => {
     return `from '${absolute.href}'`;
   });
   src += '\nexport { applyLabeledSectionDefaults };';
+  src += `\n//# sourceURL=${generatorPath}`;
   ({ applyLabeledSectionDefaults } = await import(
     `data:text/javascript,${encodeURIComponent(src)}`
   ));

--- a/test/generator/applyLabeledSectionDefaults.test.js
+++ b/test/generator/applyLabeledSectionDefaults.test.js
@@ -13,6 +13,7 @@ beforeAll(async () => {
     return `from '${absolute.href}'`;
   });
   src += '\nexport { applyLabeledSectionDefaults };';
+  src += `\n//# sourceURL=${generatorPath}`;
   ({ applyLabeledSectionDefaults } = await import(`data:text/javascript,${encodeURIComponent(src)}`));
 });
 


### PR DESCRIPTION
## Summary
- add `sourceURL` hints when importing generator for tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68431673f770832e811390b229e16696