### PR TITLE
Add test for fleet string parsing

### DIFF
--- a/test/toys/2025-05-08/battleshipSolitaireFleet.test.js
+++ b/test/toys/2025-05-08/battleshipSolitaireFleet.test.js
@@ -128,6 +128,15 @@ describe('generateFleet', () => {
     expect(lengths).toEqual([1, 2, 3]);
   });
 
+  test('ignores non-numeric entries when parsing ships string', () => {
+    const cfg = { width: 4, height: 4, ships: '2, foo, , 3' };
+    const result = generateFleet(JSON.stringify(cfg), env);
+    const fleet = JSON.parse(result);
+    expect(Array.isArray(fleet.ships)).toBe(true);
+    const lengths = fleet.ships.map(ship => ship.length).sort((a, b) => a - b);
+    expect(lengths).toEqual([2, 3]);
+  });
+
   test('parses string width and height into numbers', () => {
     const cfg = { width: '5', height: '5', ships: [2] };
     const result = generateFleet(JSON.stringify(cfg), env);


### PR DESCRIPTION
## Summary
- add unit test ensuring non-numeric values in `ships` string are ignored when parsing Battleship fleet config

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843166c34f8832eb80f230639301d90