### PR TITLE
Add direct tests for parseJSONResult

### DIFF
--- a/test/browser/parseJSONResult.direct.test.js
+++ b/test/browser/parseJSONResult.direct.test.js
@@ -1,0 +1,15 @@
+import { describe, it, expect } from '@jest/globals';
+import { parseJSONResult } from '../../src/browser/toys.js';
+
+// Simple direct import tests to ensure mutation coverage
+
+describe('parseJSONResult direct import', () => {
+  it('returns null for invalid JSON', () => {
+    expect(parseJSONResult('not valid')).toBeNull();
+  });
+
+  it('parses valid JSON', () => {
+    const obj = { foo: 1 };
+    expect(parseJSONResult(JSON.stringify(obj))).toEqual(obj);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests importing `parseJSONResult` directly

## Testing
- `npm install` *(failed: network error)*
- `npm test` *(failed: Cannot find module '/workspace/dadeto/node_modules/.bin/jest')*
- `npm run lint` *(failed: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68431667aa04832e9ba3ac91a2e24fed