### PR TITLE
Add maggot bait test

### DIFF
--- a/test/toys/2025-03-29/fishingGame.test.js
+++ b/test/toys/2025-03-29/fishingGame.test.js
@@ -104,4 +104,11 @@ describe('fishingGame', () => {
     expect(output).toMatch(/glimmering trout appears/i);
     expect(output).toMatch(/warm, shimmering waves under a vibrant sun/i);
   });
+
+  test('recognizes maggot bait and applies its negative modifier', () => {
+    const env = createEnv(0.2, '2025-05-10T09:00:00');
+    const output = fishingGame('maggot', env);
+    expect(output).toMatch(/squirming maggot/i);
+    expect(output).toMatch(/water stays silent/i);
+  });
 });


### PR DESCRIPTION
## Summary
- extend `fishingGame` tests with a case for the `maggot` bait

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68431666d920832e9e1962e448ff0c41