### PR TITLE
Add mutant-killing test for isCoordNonNegative

### DIFF
--- a/test/toys/2025-05-08/isCoordNonNegative.mutant.test.js
+++ b/test/toys/2025-05-08/isCoordNonNegative.mutant.test.js
@@ -1,0 +1,27 @@
+import { describe, test, expect } from '@jest/globals';
+import fs from 'fs';
+import path from 'path';
+
+function loadIsCoordNonNegative() {
+  const filePath = path.join(
+    process.cwd(),
+    'src/toys/2025-05-08/battleshipSolitaireFleet.js'
+  );
+  const code = fs.readFileSync(filePath, 'utf8');
+  const match = code.match(/function isCoordNonNegative[^]*?\{[^]*?\}/);
+  return eval(`(${match[0]})`);
+}
+
+describe('isCoordNonNegative mutant', () => {
+  test('returns false when either coordinate is negative', () => {
+    const fn = loadIsCoordNonNegative();
+    expect(fn({ x: -1, y: 0 })).toBe(false);
+    expect(fn({ x: 0, y: -1 })).toBe(false);
+  });
+
+  test('returns true when both coordinates are non-negative', () => {
+    const fn = loadIsCoordNonNegative();
+    expect(fn({ x: 0, y: 0 })).toBe(true);
+    expect(fn({ x: 2, y: 3 })).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add a new unit test that loads `isCoordNonNegative` from `battleshipSolitaireFleet.js`
- verify behaviour for negative and positive coordinates

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684316599fa8832eaaa7a85433097c2d