### PR TITLE
Add tests for defaultKeyExtraClasses

### DIFF
--- a/test/generator/defaultKeyExtraClasses.test.js
+++ b/test/generator/defaultKeyExtraClasses.test.js
@@ -1,0 +1,33 @@
+import fs from 'fs';
+import path from 'path';
+import { pathToFileURL } from 'url';
+import { beforeAll, describe, test, expect } from '@jest/globals';
+
+let defaultKeyExtraClasses;
+
+beforeAll(async () => {
+  const generatorPath = path.join(process.cwd(), 'src/generator/generator.js');
+  let src = fs.readFileSync(generatorPath, 'utf8');
+  src = src.replace(/from '\.\/(.*?)'/g, (_, p) => {
+    const absolute = pathToFileURL(path.join(path.dirname(generatorPath), p));
+    return `from '${absolute.href}'`;
+  });
+  src += '\nexport { defaultKeyExtraClasses };';
+  ({ defaultKeyExtraClasses } = await import(
+    `data:text/javascript,${encodeURIComponent(src)}`
+  ));
+});
+
+describe('defaultKeyExtraClasses', () => {
+  test('initializes undefined property to empty string', () => {
+    const args = {};
+    const result = defaultKeyExtraClasses(args);
+    expect(result.keyExtraClasses).toBe('');
+  });
+
+  test('preserves provided property', () => {
+    const args = { keyExtraClasses: 'existing' };
+    const result = defaultKeyExtraClasses(args);
+    expect(result.keyExtraClasses).toBe('existing');
+  });
+});


### PR DESCRIPTION
## Summary
- add new unit tests targeting `defaultKeyExtraClasses`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68431656ae24832e805827ff77f5bf3b