### PR TITLE
Add fishingGame shiny bait test

### DIFF
--- a/test/toys/2025-03-29/fishingGame.test.js
+++ b/test/toys/2025-03-29/fishingGame.test.js
@@ -104,4 +104,12 @@ describe('fishingGame', () => {
     expect(output).toMatch(/glimmering trout appears/i);
     expect(output).toMatch(/warm, shimmering waves under a vibrant sun/i);
   });
+
+  test('recognizes shiny bait and applies its modifier', () => {
+    const env = createEnv(0.75, '2025-09-05T19:00:00');
+    const output = fishingGame('shiny bait', env);
+    expect(output).toMatch(/glittering lure/i);
+    expect(output).toMatch(/legendary golden fish leaps forth/i);
+    expect(output).toMatch(/cool, reflective ponds in the glow of twilight/i);
+  });
 });


### PR DESCRIPTION
## Summary
- add unit test for `shiny bait` in fishingGame

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68431658674c832ea90debcb5c5564ae