### PR TITLE
Add newline bold test

### DIFF
--- a/test/toys/2025-03-21/italics.test.js
+++ b/test/toys/2025-03-21/italics.test.js
@@ -101,4 +101,9 @@ describe('italics function', () => {
     const expected = '**bold\ntext** and <em>_italic_</em>';
     expect(italics(input)).toBe(expected);
   });
+
+  test('preserves bold text with a newline and no italics', () => {
+    const input = '**multi\nline**';
+    expect(italics(input)).toBe(input);
+  });
 });


### PR DESCRIPTION
## Summary
- extend italics tests to cover bold segments containing a newline without italics

## Testing
- `npm test --silent`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68431651e150832ebf9c04684f8ad14a