### PR TITLE
Add parseJSONResult coverage

### DIFF
--- a/test/browser/processInputAndSetOutput.parse.test.js
+++ b/test/browser/processInputAndSetOutput.parse.test.js
@@ -1,0 +1,30 @@
+import fs from 'fs';
+import path from 'path';
+import { pathToFileURL } from 'url';
+import { beforeAll, describe, it, expect } from '@jest/globals';
+
+let parseJSONResult;
+
+beforeAll(async () => {
+  const filePath = path.join(process.cwd(), 'src/browser/toys.js');
+  let code = fs.readFileSync(filePath, 'utf8');
+  code = code.replace(/from '((?:\.\.?\/).*?)'/g, (_, p) => {
+    const abs = pathToFileURL(path.join(path.dirname(filePath), p));
+    return `from '${abs.href}'`;
+  });
+  code += '\nexport { parseJSONResult };';
+  ({ parseJSONResult } = await import(
+    `data:text/javascript,${encodeURIComponent(code)}`
+  ));
+});
+
+describe('parseJSONResult via dynamic import', () => {
+  it('returns null for invalid JSON', () => {
+    expect(parseJSONResult('not json')).toBeNull();
+  });
+
+  it('parses valid JSON', () => {
+    const obj = { a: 1 };
+    expect(parseJSONResult(JSON.stringify(obj))).toEqual(obj);
+  });
+});


### PR DESCRIPTION
## Summary
- add dynamic import test to verify `parseJSONResult`

## Testing
- `npm test --silent`
- `npm run lint --silent`

------
https://chatgpt.com/codex/tasks/task_e_68431650c168832ebc00de90e59b2ca2