### PR TITLE
Add tests for ticTacToeBoard getters

### DIFF
--- a/test/presenters/ticTacToeBoard.getters.test.js
+++ b/test/presenters/ticTacToeBoard.getters.test.js
@@ -1,0 +1,31 @@
+import fs from 'fs';
+import path from 'path';
+import { pathToFileURL } from 'url';
+import { beforeAll, describe, test, expect } from '@jest/globals';
+
+let getPlayer;
+let getPosition;
+
+beforeAll(async () => {
+  const filePath = path.join(process.cwd(), 'src/presenters/ticTacToeBoard.js');
+  let src = fs.readFileSync(filePath, 'utf8');
+  src = src.replace(/from '([^']+)'/g, (_, rel) => {
+    if (!rel.startsWith('.')) {return `from '${rel}'`;}
+    const abs = pathToFileURL(path.join(path.dirname(filePath), rel));
+    return `from '${abs.href}'`;
+  });
+  src += '\nexport { getPlayer, getPosition };';
+  ({ getPlayer, getPosition } = await import(
+    `data:text/javascript,${encodeURIComponent(src)}`
+  ));
+});
+
+describe('ticTacToeBoard getters', () => {
+  test.each([undefined, null, 42, 'foo', []])(
+    'return undefined for %p',
+    value => {
+      expect(getPlayer(value)).toBeUndefined();
+      expect(getPosition(value)).toBeUndefined();
+    }
+  );
+});


### PR DESCRIPTION
## Summary
- add tests exercising internal ticTacToeBoard helper functions

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68431645c238832ea806d8e8d2ab9f0e