### PR TITLE
Add test for bread negative modifier

### DIFF
--- a/test/toys/2025-03-29/fishingGame.test.js
+++ b/test/toys/2025-03-29/fishingGame.test.js
@@ -104,4 +104,11 @@ describe('fishingGame', () => {
     expect(output).toMatch(/glimmering trout appears/i);
     expect(output).toMatch(/warm, shimmering waves under a vibrant sun/i);
   });
+
+  test('bread bait negative modifier keeps result in common carp range', () => {
+    const env = createEnv(0.6, '2025-06-15T10:00:00');
+    const output = fishingGame('bread', env);
+    expect(output).toMatch(/slice of bread/i);
+    expect(output).toMatch(/common carp surfaces gently/i);
+  });
 });


### PR DESCRIPTION
## Summary
- extend `fishingGame.test.js` with a case where bread bait uses a higher base chance

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6843164358a8832ea4988050a400f1be