### PR TITLE
Add test for defaultKeyExtraClasses

### DIFF
--- a/test/generator/defaultKeyExtraClasses.test.js
+++ b/test/generator/defaultKeyExtraClasses.test.js
@@ -1,0 +1,26 @@
+import fs from 'fs';
+import path from 'path';
+import { pathToFileURL } from 'url';
+import { beforeAll, describe, test, expect } from '@jest/globals';
+
+let defaultKeyExtraClasses;
+
+beforeAll(async () => {
+  const srcPath = path.join(process.cwd(), 'src/generator/generator.js');
+  let src = fs.readFileSync(srcPath, 'utf8');
+  src = src.replace(/from '\.\/(.*?)'/g, (_, p) => {
+    const abs = pathToFileURL(path.join(path.dirname(srcPath), p));
+    return `from '${abs.href}'`;
+  });
+  src += '\nexport { defaultKeyExtraClasses };';
+  ({ defaultKeyExtraClasses } = await import(
+    `data:text/javascript,${encodeURIComponent(src)}`
+  ));
+});
+
+describe('defaultKeyExtraClasses', () => {
+  test('sets keyExtraClasses to empty string when undefined', () => {
+    const result = defaultKeyExtraClasses({});
+    expect(result.keyExtraClasses).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- add a unit test exercising `defaultKeyExtraClasses`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68431640d77c832ebe616e0002ec307b