### PR TITLE
Add dynamic test for validateCluesObject

### DIFF
--- a/test/presenters/validateCluesObject.import.test.js
+++ b/test/presenters/validateCluesObject.import.test.js
@@ -1,0 +1,23 @@
+import fs from 'fs';
+import path from 'path';
+import { pathToFileURL } from 'url';
+import { beforeAll, describe, it, expect } from '@jest/globals';
+
+let validateCluesObject;
+
+beforeAll(async () => {
+  const srcPath = path.join(process.cwd(), 'src/presenters/battleshipSolitaireClues.js');
+  let src = fs.readFileSync(srcPath, 'utf8');
+  src = src.replace(/from '((?:\.\.?\/).*?)'/g, (_, p) => {
+    const abs = pathToFileURL(path.join(path.dirname(srcPath), p));
+    return `from '${abs.href}'`;
+  });
+  src += '\nexport { validateCluesObject };';
+  ({ validateCluesObject } = await import(`data:text/javascript,${encodeURIComponent(src)}`));
+});
+
+describe('validateCluesObject dynamic import', () => {
+  it('returns Invalid JSON object when input is not an object', () => {
+    expect(validateCluesObject(42)).toBe('Invalid JSON object');
+  });
+});


### PR DESCRIPTION
## Summary
- ensure `validateCluesObject` returns the expected error for non-object input

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6843163fb978832eba35abd1bdcddde8