### PR TITLE
Add missing HTML escaping test

### DIFF
--- a/test/generator/generator.test.js
+++ b/test/generator/generator.test.js
@@ -284,6 +284,31 @@ describe('Blog Generator', () => {
     expect(html).not.toMatch('related-links');
   });
 
+  test('should escape related link fields when optional values are missing', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'MISS1',
+          title: 'Missing Fields',
+          publicationDate: '2024-07-01',
+          content: ['hi'],
+          relatedLinks: [
+            {
+              url: 'https://example.com',
+              type: 'article',
+            },
+          ],
+        },
+      ],
+    };
+
+    const html = generateBlog({ blog, header, footer }, wrapHtml);
+    expect(html).toContain(
+      '<li><a href="https://example.com" target="_blank" rel="noopener">""</a></li>'
+    );
+    expect(html).not.toContain('undefined');
+  });
+
   test('should contain a YouTube video for a post', () => {
     const blog = {
       posts: [


### PR DESCRIPTION
## Summary
- ensure related links with missing fields are escaped

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6843163de58c832e92b1dd1550cb3cd3