### PR TITLE
Improve generator test coverage

### DIFF
--- a/test/generator/applyLabeledSectionDefaults.keyExtraClasses.test.js
+++ b/test/generator/applyLabeledSectionDefaults.keyExtraClasses.test.js
@@ -12,7 +12,9 @@ beforeAll(async () => {
     const absolute = pathToFileURL(path.join(path.dirname(generatorPath), p));
     return `from '${absolute.href}'`;
   });
-  src += '\nexport { applyLabeledSectionDefaults };';
+  src +=
+    '\nexport { applyLabeledSectionDefaults };' +
+    `\n//# sourceURL=${pathToFileURL(generatorPath).href}`;
   ({ applyLabeledSectionDefaults } = await import(
     `data:text/javascript,${encodeURIComponent(src)}`
   ));

--- a/test/generator/applyLabeledSectionDefaults.test.js
+++ b/test/generator/applyLabeledSectionDefaults.test.js
@@ -12,8 +12,12 @@ beforeAll(async () => {
     const absolute = pathToFileURL(path.join(path.dirname(generatorPath), p));
     return `from '${absolute.href}'`;
   });
-  src += '\nexport { applyLabeledSectionDefaults };';
-  ({ applyLabeledSectionDefaults } = await import(`data:text/javascript,${encodeURIComponent(src)}`));
+  src +=
+    '\nexport { applyLabeledSectionDefaults };' +
+    `\n//# sourceURL=${pathToFileURL(generatorPath).href}`;
+  ({ applyLabeledSectionDefaults } = await import(
+    `data:text/javascript,${encodeURIComponent(src)}`
+  ));
 });
 
 describe('applyLabeledSectionDefaults', () => {


### PR DESCRIPTION
## Summary
- add sourceURL comments to generator tests so coverage tools map back to `generator.js`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6843163caebc832ebbc9efb81b1af9bc