### PR TITLE
Add tests for tic-tac-toe helper functions

### DIFF
--- a/test/presenters/ticTacToeBoard.getters.test.js
+++ b/test/presenters/ticTacToeBoard.getters.test.js
@@ -1,0 +1,27 @@
+import fs from 'fs';
+import path from 'path';
+import { pathToFileURL } from 'url';
+import { beforeAll, describe, test, expect } from '@jest/globals';
+
+let getPlayer;
+let getPosition;
+
+beforeAll(async () => {
+  const filePath = path.join(process.cwd(), 'src/presenters/ticTacToeBoard.js');
+  let src = fs.readFileSync(filePath, 'utf8');
+  src = src.replace(/from '\.\.(.*?)'/g, (_, p) => {
+    const absolute = pathToFileURL(path.join(path.dirname(filePath), '..' + p));
+    return `from '${absolute.href}'`;
+  });
+  src += '\nexport { getPlayer, getPosition };';
+  ({ getPlayer, getPosition } = await import(`data:text/javascript,${encodeURIComponent(src)}`));
+});
+
+describe('getPlayer/getPosition', () => {
+  test('return undefined for undefined or null move without throwing', () => {
+    expect(getPlayer(undefined)).toBeUndefined();
+    expect(getPlayer(null)).toBeUndefined();
+    expect(getPosition(undefined)).toBeUndefined();
+    expect(getPosition(null)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for `getPlayer` and `getPosition` helper functions

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6843163abb14832e8392db784fc4d3ad