### PR TITLE
Add test to kill optional chaining mutant

### DIFF
--- a/test/toys/2025-03-21/isEmptyText.test.js
+++ b/test/toys/2025-03-21/isEmptyText.test.js
@@ -1,0 +1,23 @@
+import fs from 'fs';
+import path from 'path';
+import { beforeAll, describe, test, expect } from '@jest/globals';
+
+let isEmptyText;
+
+beforeAll(async () => {
+  const filePath = path.join(process.cwd(), 'src/toys/2025-03-21/italics.js');
+  let src = fs.readFileSync(filePath, 'utf8');
+  src += '\nexport { isEmptyText };';
+  ({ isEmptyText } = await import(`data:text/javascript,${encodeURIComponent(src)}`));
+});
+
+describe('isEmptyText', () => {
+  test.each([
+    [undefined, true],
+    [null, true],
+    ['   ', true],
+    ['content', false],
+  ])('given %p returns %p', (input, expected) => {
+    expect(isEmptyText(input)).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Summary
- add a unit test for `isEmptyText`

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843163983cc832e9927955ecb4286fc