### PR TITLE
Add extra parseJSONResult tests

### DIFF
--- a/test/browser/parseJSONResult.additional.test.js
+++ b/test/browser/parseJSONResult.additional.test.js
@@ -1,0 +1,29 @@
+import fs from 'fs';
+import path from 'path';
+import { pathToFileURL } from 'url';
+import { beforeAll, describe, it, expect } from '@jest/globals';
+
+let parseJSONResult;
+
+beforeAll(async () => {
+  const srcPath = path.join(process.cwd(), 'src/browser/toys.js');
+  let src = fs.readFileSync(srcPath, 'utf8');
+  src = src.replace(/from '((?:\.\.?\/).*?)'/g, (_, p) => {
+    const abs = pathToFileURL(path.join(path.dirname(srcPath), p));
+    return `from '${abs.href}'`;
+  });
+  src += '\nexport { parseJSONResult };';
+  ({ parseJSONResult } = await import(`data:text/javascript,${encodeURIComponent(src)}`));
+});
+
+describe('parseJSONResult additional cases', () => {
+  it('returns null for JSON with extra characters', () => {
+    expect(parseJSONResult('{"a":1} trailing')).toBeNull();
+  });
+
+  it('parses valid JSON with surrounding whitespace', () => {
+    const obj = { foo: 'bar' };
+    const json = `\n  ${JSON.stringify(obj)}  \n`;
+    expect(parseJSONResult(json)).toEqual(obj);
+  });
+});


### PR DESCRIPTION
## Summary
- add more scenarios for `parseJSONResult`

## Testing
- `npm test` *(fails: npm not found)*
- `npm run lint` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_e_68431669e310832e85fa4511e0ce311d