### PR TITLE
Add test for parseJSONResult

### DIFF
--- a/test/browser/parseJSONResult.eval.test.js
+++ b/test/browser/parseJSONResult.eval.test.js
@@ -1,0 +1,30 @@
+import fs from 'fs';
+import path from 'path';
+import { pathToFileURL } from 'url';
+import { beforeAll, describe, test, expect } from '@jest/globals';
+
+let parseJSONResult;
+
+beforeAll(async () => {
+  const srcPath = path.join(process.cwd(), 'src/browser/toys.js');
+  let src = fs.readFileSync(srcPath, 'utf8');
+  src = src.replace(/from '((?:\.\.?\/).*?)'/g, (_, p) => {
+    const abs = pathToFileURL(path.join(path.dirname(srcPath), p));
+    return `from '${abs.href}'`;
+  });
+  src += '\nexport { parseJSONResult };';
+  ({ parseJSONResult } = await import(
+    `data:text/javascript,${encodeURIComponent(src)}`
+  ));
+});
+
+describe('parseJSONResult eval import', () => {
+  test('parses valid JSON', () => {
+    const obj = { x: 1 };
+    expect(parseJSONResult(JSON.stringify(obj))).toEqual(obj);
+  });
+
+  test('returns null for invalid JSON', () => {
+    expect(parseJSONResult('{ invalid')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add a new eval-based unit test for `parseJSONResult`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684316659f34832e8f878d34a168143f