### PR TITLE
Add test coverage for non-numeric TicTacToe positions

### DIFF
--- a/test/presenters/ticTacToeBoard.test.js
+++ b/test/presenters/ticTacToeBoard.test.js
@@ -151,6 +151,24 @@ describe('createTicTacToeBoardElement', () => {
     );
   });
 
+  it('ignores moves where row or column are not numbers', () => {
+    const input = JSON.stringify({
+      moves: [
+        { player: 'X', position: { row: '0', column: 0 } },
+        { player: 'O', position: { row: 1, column: '1' } },
+        { player: 'X', position: { row: 1, column: 1 } }
+      ]
+    });
+    const el = createTicTacToeBoardElement(input, mockDom());
+    expect(el.textContent).toBe(
+      '   |   |   \n' +
+      '---+---+---\n' +
+      '   | X |   \n' +
+      '---+---+---\n' +
+      '   |   |   '
+    );
+  });
+
   it('ignores moves where the move is not an object (null, number, string, array)', () => {
     const input = JSON.stringify({
       moves: [null, 42, "foo", [1,2,3], { player: 'X', position: { row: 0, column: 0 } }]


### PR DESCRIPTION
## Summary
- extend TicTacToe board tests to cover moves with non-numeric row/column values

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68431636e5d8832eb1081a76b35dd27d