### PR TITLE
Add test for multi-digit ship parsing

### DIFF
--- a/test/toys/2025-05-08/battleshipSolitaireFleet.test.js
+++ b/test/toys/2025-05-08/battleshipSolitaireFleet.test.js
@@ -128,6 +128,14 @@ describe('generateFleet', () => {
     expect(lengths).toEqual([1, 2, 3]);
   });
 
+  test('parses multi-digit ship lengths in comma-separated string', () => {
+    const cfg = { width: 12, height: 12, ships: '10,11' };
+    const result = generateFleet(JSON.stringify(cfg), env);
+    const fleet = JSON.parse(result);
+    const lengths = fleet.ships.map(ship => ship.length).sort((a, b) => a - b);
+    expect(lengths).toEqual([10, 11]);
+  });
+
   test('parses string width and height into numbers', () => {
     const cfg = { width: '5', height: '5', ships: [2] };
     const result = generateFleet(JSON.stringify(cfg), env);


### PR DESCRIPTION
## Summary
- test battleshipSolitaireFleet.parseConfig with multi-digit ships

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68431636a72c832e90e2dea890269440