### PR TITLE
Add tests to kill surviving mutant

### DIFF
--- a/test/presenters/ticTacToeBoard.internal.test.js
+++ b/test/presenters/ticTacToeBoard.internal.test.js
@@ -1,0 +1,30 @@
+import fs from 'fs';
+import path from 'path';
+import { pathToFileURL } from 'url';
+import { beforeAll, describe, it, expect } from '@jest/globals';
+
+let getPlayer;
+let getPosition;
+
+beforeAll(async () => {
+  const srcPath = path.join(process.cwd(), 'src/presenters/ticTacToeBoard.js');
+  let src = fs.readFileSync(srcPath, 'utf8');
+  src = src.replace(/from '((?:\.\.?\/).*?)'/g, (_, p) => {
+    const abs = pathToFileURL(path.join(path.dirname(srcPath), p));
+    return `from '${abs.href}'`;
+  });
+  src += '\nexport { getPlayer, getPosition };';
+  ({ getPlayer, getPosition } = await import(
+    `data:text/javascript,${encodeURIComponent(src)}`
+  ));
+});
+
+describe('ticTacToeBoard internal functions', () => {
+  it('getPlayer returns undefined for undefined move', () => {
+    expect(getPlayer(undefined)).toBeUndefined();
+  });
+
+  it('getPosition returns undefined for undefined move', () => {
+    expect(getPosition(undefined)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add a focused Jest test for ticTacToeBoard internal helpers

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684316359074832ebd339413af739b0c