### PR TITLE
Add test to cover undefined move case

### DIFF
--- a/test/presenters/applyMove.undefined.test.js
+++ b/test/presenters/applyMove.undefined.test.js
@@ -1,0 +1,29 @@
+import fs from 'fs';
+import path from 'path';
+import { pathToFileURL } from 'url';
+import { beforeAll, describe, test, expect } from '@jest/globals';
+
+let applyMove;
+
+beforeAll(async () => {
+  const filePath = path.join(process.cwd(), 'src/presenters/ticTacToeBoard.js');
+  let src = fs.readFileSync(filePath, 'utf8');
+  src = src.replace(/from '((?:\.\.?\/)[^']*)'/g, (_, p) => {
+    const absolute = pathToFileURL(path.join(path.dirname(filePath), p));
+    return `from '${absolute.href}'`;
+  });
+  src += '\nexport { applyMove };';
+  ({ applyMove } = await import(`data:text/javascript,${encodeURIComponent(src)}`));
+});
+
+describe('applyMove', () => {
+  test('handles undefined move without throwing', () => {
+    const board = Array.from({ length: 3 }, () => Array(3).fill(' '));
+    expect(() => applyMove(undefined, board)).not.toThrow();
+    expect(board).toEqual([
+      [' ', ' ', ' '],
+      [' ', ' ', ' '],
+      [' ', ' ', ' ']
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- reproduce internal `applyMove` from ticTacToeBoard with dynamic import
- verify `applyMove` handles `undefined` move without throwing

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684316347070832e8fe8577f81faf933