### PR TITLE
Fix surviving parseJSONResult mutant

### DIFF
--- a/test/browser/toys.parseJSONResult.mutant.test.js
+++ b/test/browser/toys.parseJSONResult.mutant.test.js
@@ -1,13 +1,23 @@
 import { describe, it, expect } from '@jest/globals';
 import fs from 'fs';
 import path from 'path';
+import { pathToFileURL } from 'url';
+
+async function loadParseJSONResult() {
+  const srcPath = path.join(process.cwd(), 'src/browser/toys.js');
+  let src = fs.readFileSync(srcPath, 'utf8');
+  src = src.replace(/from '((?:\.\.?\/).*?)'/g, (_, p) => {
+    const abs = pathToFileURL(path.join(path.dirname(srcPath), p));
+    return `from '${abs.href}'`;
+  });
+  src += '\nexport { parseJSONResult };';
+  return (await import(`data:text/javascript,${encodeURIComponent(src)}`))
+    .parseJSONResult;
+}
 
 describe('parseJSONResult mutant', () => {
-  it('returns null when JSON parsing fails', () => {
-    const filePath = path.join(process.cwd(), 'src/browser/toys.js');
-    const fileContents = fs.readFileSync(filePath, 'utf8');
-    const match = fileContents.match(/function parseJSONResult\([^]*?\n\}/);
-    const parseJSONResult = eval('(' + match[0] + ')');
+  it('returns null when JSON parsing fails', async () => {
+    const parseJSONResult = await loadParseJSONResult();
     expect(parseJSONResult('not json')).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- rewrite parseJSONResult mutant test to import the function as a module

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68431633a5b8832e8b3055334b85f573