### PR TITLE
Add failing test for formatDecimal edge case

### DIFF
--- a/test/toys/2025-03-26/prettyFloat.test.js
+++ b/test/toys/2025-03-26/prettyFloat.test.js
@@ -10,6 +10,14 @@ describe('formatDecimal', () => {
     // formatDecimal should return the same string, as there is no . or trailing zeros to strip
     expect(formatDecimal(value)).toBe('12345678901234568');
   });
+
+  test('keeps integers ending in zeros unchanged', () => {
+    const bigInt = 10000000000000000;
+    const asPrecision = bigInt.toPrecision(17);
+    expect(asPrecision).toBe('10000000000000000');
+    expect(asPrecision.includes('.')).toBe(false);
+    expect(formatDecimal(bigInt)).toBe('10000000000000000');
+  });
 });
 
 describe('decomposeFloat', () => {


### PR DESCRIPTION
## Summary
- add coverage for `formatDecimal` when integers end with zeros

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6843163293d4832e9e1158571979111f