### PR TITLE
Add shiny bait test

### DIFF
--- a/test/toys/2025-03-29/fishingGame.test.js
+++ b/test/toys/2025-03-29/fishingGame.test.js
@@ -104,4 +104,11 @@ describe('fishingGame', () => {
     expect(output).toMatch(/glimmering trout appears/i);
     expect(output).toMatch(/warm, shimmering waves under a vibrant sun/i);
   });
+
+  test('recognizes shiny bait and applies its modifier', () => {
+    const env = createEnv(0.7, '2025-09-01T12:00:00');
+    const output = fishingGame('shiny bait', env);
+    expect(output).toMatch(/glittering lure/i);
+    expect(output).toMatch(/legendary golden fish leaps forth/i);
+  });
 });


### PR DESCRIPTION
## Summary
- add coverage for "shiny bait" in `fishingGame`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684316310768832e8bb16590a85c10b9