### PR TITLE
Add fishingGame maggot test

### DIFF
--- a/test/toys/2025-03-29/fishingGame.test.js
+++ b/test/toys/2025-03-29/fishingGame.test.js
@@ -104,4 +104,12 @@ describe('fishingGame', () => {
     expect(output).toMatch(/glimmering trout appears/i);
     expect(output).toMatch(/warm, shimmering waves under a vibrant sun/i);
   });
+
+  test('recognizes maggot bait and applies its modifier', () => {
+    const env = createEnv(0.4, '2025-06-10T14:00:00');
+    const output = fishingGame('maggot', env);
+    expect(output).toMatch(/squirming maggot/i);
+    expect(output).toMatch(/common carp surfaces gently/i);
+    expect(output).toMatch(/warm, shimmering waves under a vibrant sun/i);
+  });
 });


### PR DESCRIPTION
## Summary
- add missing test for maggot bait in `fishingGame`

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684316302cf4832eb41a8dd881c129e5