### PR TITLE
Add coverage for parseJSONResult error case

### DIFF
--- a/test/browser/toys.parseJSONResult.mutant.test.js
+++ b/test/browser/toys.parseJSONResult.mutant.test.js
@@ -1,13 +1,32 @@
 import { describe, it, expect } from '@jest/globals';
-import fs from 'fs';
-import path from 'path';
+import fs from 'fs/promises';
+import vm from 'vm';
+import { pathToFileURL } from 'url';
+
+async function loadParseJSONResult() {
+  const mainUrl = pathToFileURL('./src/browser/toys.js');
+  let code = await fs.readFile(mainUrl, 'utf8');
+  code += '\nglobalThis.__test_parseJSONResult = parseJSONResult;';
+  const context = vm.createContext(globalThis);
+  async function linker(specifier, referencingModule) {
+    const url = new URL(specifier, referencingModule.identifier);
+    const src = await fs.readFile(url, 'utf8');
+    const m = new vm.SourceTextModule(src, { identifier: url.href, context });
+    await m.link(linker);
+    return m;
+  }
+  const mod = new vm.SourceTextModule(code, {
+    identifier: mainUrl.href,
+    context,
+  });
+  await mod.link(linker);
+  await mod.evaluate();
+  return context.__test_parseJSONResult;
+}
 
 describe('parseJSONResult mutant', () => {
-  it('returns null when JSON parsing fails', () => {
-    const filePath = path.join(process.cwd(), 'src/browser/toys.js');
-    const fileContents = fs.readFileSync(filePath, 'utf8');
-    const match = fileContents.match(/function parseJSONResult\([^]*?\n\}/);
-    const parseJSONResult = eval('(' + match[0] + ')');
+  it('returns null when JSON parsing fails', async () => {
+    const parseJSONResult = await loadParseJSONResult();
     expect(parseJSONResult('not json')).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- cover `parseJSONResult` when JSON parsing fails

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6843162ec5c0832e8d751e97b0a901e7