### PR TITLE
Add unit test for parseJSONResult

### DIFF
--- a/test/browser/parseJSONResult.direct.test.js
+++ b/test/browser/parseJSONResult.direct.test.js
@@ -1,0 +1,30 @@
+import fs from 'fs';
+import path from 'path';
+import { pathToFileURL } from 'url';
+import { beforeAll, describe, it, expect } from '@jest/globals';
+
+let parseJSONResult;
+
+beforeAll(async () => {
+  const srcPath = path.join(process.cwd(), 'src/browser/toys.js');
+  let src = fs.readFileSync(srcPath, 'utf8');
+  src = src.replace(/from '((?:\.\.?\/).*?)'/g, (_, p) => {
+    const abs = pathToFileURL(path.join(path.dirname(srcPath), p));
+    return `from '${abs.href}'`;
+  });
+  src += '\nexport { parseJSONResult };';
+  ({ parseJSONResult } = await import(
+    `data:text/javascript,${encodeURIComponent(src)}`
+  ));
+});
+
+describe('parseJSONResult direct import', () => {
+  it('returns null for invalid JSON', () => {
+    expect(parseJSONResult('invalid')).toBeNull();
+  });
+
+  it('parses valid JSON', () => {
+    const obj = { a: 1 };
+    expect(parseJSONResult(JSON.stringify(obj))).toEqual(obj);
+  });
+});


### PR DESCRIPTION
## Summary
- add a direct import test for `parseJSONResult`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684316475fe0832ea2813ebde30b82e3