### PR TITLE
Improve generator tests

### DIFF
--- a/test/generator/applyLabeledSectionDefaults.keyExtraClasses.test.js
+++ b/test/generator/applyLabeledSectionDefaults.keyExtraClasses.test.js
@@ -1,22 +1,5 @@
-import fs from 'fs';
-import path from 'path';
-import { pathToFileURL } from 'url';
-import { beforeAll, describe, test, expect } from '@jest/globals';
-
-let applyLabeledSectionDefaults;
-
-beforeAll(async () => {
-  const generatorPath = path.join(process.cwd(), 'src/generator/generator.js');
-  let src = fs.readFileSync(generatorPath, 'utf8');
-  src = src.replace(/from '\.\/(.*?)'/g, (_, p) => {
-    const absolute = pathToFileURL(path.join(path.dirname(generatorPath), p));
-    return `from '${absolute.href}'`;
-  });
-  src += '\nexport { applyLabeledSectionDefaults };';
-  ({ applyLabeledSectionDefaults } = await import(
-    `data:text/javascript,${encodeURIComponent(src)}`
-  ));
-});
+import { describe, test, expect } from '@jest/globals';
+import { applyLabeledSectionDefaults } from '../../src/generator/generator.js';
 
 describe('applyLabeledSectionDefaults', () => {
   test('sets default keyExtraClasses', () => {

--- a/test/generator/applyLabeledSectionDefaults.test.js
+++ b/test/generator/applyLabeledSectionDefaults.test.js
@@ -1,20 +1,5 @@
-import fs from 'fs';
-import path from 'path';
-import { pathToFileURL } from 'url';
-import { beforeAll, describe, test, expect } from '@jest/globals';
-
-let applyLabeledSectionDefaults;
-
-beforeAll(async () => {
-  const generatorPath = path.join(process.cwd(), 'src/generator/generator.js');
-  let src = fs.readFileSync(generatorPath, 'utf8');
-  src = src.replace(/from '\.\/(.*?)'/g, (_, p) => {
-    const absolute = pathToFileURL(path.join(path.dirname(generatorPath), p));
-    return `from '${absolute.href}'`;
-  });
-  src += '\nexport { applyLabeledSectionDefaults };';
-  ({ applyLabeledSectionDefaults } = await import(`data:text/javascript,${encodeURIComponent(src)}`));
-});
+import { describe, test, expect } from '@jest/globals';
+import { applyLabeledSectionDefaults } from '../../src/generator/generator.js';
 
 describe('applyLabeledSectionDefaults', () => {
   test('defaults keyExtraClasses to empty string', () => {


### PR DESCRIPTION
## Summary
- simplify generator tests by importing the module directly

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684316449400832eb6b612f4296bf1a2