### PR TITLE
Add test to cover multi-digit ship parsing

### DIFF
--- a/test/toys/2025-05-08/battleshipSolitaireFleet.test.js
+++ b/test/toys/2025-05-08/battleshipSolitaireFleet.test.js
@@ -128,6 +128,14 @@ describe('generateFleet', () => {
     expect(lengths).toEqual([1, 2, 3]);
   });
 
+  test('parses multi-digit ship lengths from string', () => {
+    const cfg = { width: 11, height: 11, ships: '10, 2' };
+    const result = generateFleet(JSON.stringify(cfg), env);
+    const fleet = JSON.parse(result);
+    const lengths = fleet.ships.map(s => s.length).sort((a, b) => a - b);
+    expect(lengths).toEqual([2, 10]);
+  });
+
   test('parses string width and height into numbers', () => {
     const cfg = { width: '5', height: '5', ships: [2] };
     const result = generateFleet(JSON.stringify(cfg), env);


### PR DESCRIPTION
## Summary
- improve battleshipSolitaireFleet tests to cover multi-digit ship length strings

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684316799604832ebb8a9ed71345b30a