### PR TITLE
Add bait options test

### DIFF
--- a/test/toys/2025-03-29/getBaitOptions.test.js
+++ b/test/toys/2025-03-29/getBaitOptions.test.js
@@ -1,0 +1,24 @@
+import fs from 'fs';
+import path from 'path';
+import { pathToFileURL } from 'url';
+import { beforeAll, describe, test, expect } from '@jest/globals';
+
+let getBaitOptions;
+
+beforeAll(async () => {
+  const gamePath = path.join(process.cwd(), 'src/toys/2025-03-29/fishingGame.js');
+  let src = fs.readFileSync(gamePath, 'utf8');
+  src = src.replace(/from '\.\/(.*?)'/g, (_, p) => {
+    const abs = pathToFileURL(path.join(path.dirname(gamePath), p));
+    return `from '${abs.href}'`;
+  });
+  src += '\nexport { getBaitOptions };';
+  ({ getBaitOptions } = await import(`data:text/javascript,${encodeURIComponent(src)}`));
+});
+
+describe('getBaitOptions', () => {
+  test('contains insect with description and modifier', () => {
+    const options = getBaitOptions();
+    expect(options.insect).toEqual({ modifier: 0.05, description: 'a lively insect' });
+  });
+});


### PR DESCRIPTION
## Summary
- add a test for `getBaitOptions` in the fishing game module

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6843165dcf08832eb07648376b454e30