### PR TITLE
Add test to kill cyberpunkAdventure mutant

### DIFF
--- a/test/toys/2025-03-30/cyberpunkAdventure.test.js
+++ b/test/toys/2025-03-30/cyberpunkAdventure.test.js
@@ -201,4 +201,16 @@ describe('Cyberpunk Text Game', () => {
     const result = cyberpunkAdventure('   ', env);
     expect(result).toMatch(/Stray/);
   });
+
+  test('unknown state resets the player state to intro', () => {
+    tempData = {
+      name: 'Blaze',
+      state: 'glitch',
+      inventory: [],
+      visited: [],
+    };
+    env.set('getData', () => ({ temporary: { CYBE1: tempData } }));
+    cyberpunkAdventure('whatever', env);
+    expect(tempData.state).toBe('intro');
+  });
 });


### PR DESCRIPTION
## Summary
- extend cyberpunkAdventure tests to assert the player state resets to `intro` when an unknown state is encountered

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68431655651c832e979bcb98710bf7f2