### PR TITLE
Fix surviving mutant in parseJSONResult tests

### DIFF
--- a/test/browser/parseJSONResult.import.test.js
+++ b/test/browser/parseJSONResult.import.test.js
@@ -1,11 +1,9 @@
 import fs from 'fs';
 import path from 'path';
 import { pathToFileURL } from 'url';
-import { beforeAll, describe, it, expect } from '@jest/globals';
+import { describe, it, expect } from '@jest/globals';
 
-let parseJSONResult;
-
-beforeAll(async () => {
+async function loadParseJSONResult() {
   const srcPath = path.join(process.cwd(), 'src/browser/toys.js');
   let src = fs.readFileSync(srcPath, 'utf8');
   src = src.replace(/from '((?:\.\.?\/).*?)'/g, (_, p) => {
@@ -13,16 +11,17 @@ beforeAll(async () => {
     return `from '${abs.href}'`;
   });
   src += '\nexport { parseJSONResult };';
-  ({ parseJSONResult } = await import(
-    `data:text/javascript,${encodeURIComponent(src)}`
-  ));
-});
+  const mod = await import(`data:text/javascript,${encodeURIComponent(src)}`);
+  return mod.parseJSONResult;
+}
 
 describe('parseJSONResult dynamic import', () => {
-  it('returns null for invalid JSON', () => {
+  it('returns null for invalid JSON', async () => {
+    const parseJSONResult = await loadParseJSONResult();
     expect(parseJSONResult('invalid')).toBeNull();
   });
-  it('parses valid JSON', () => {
+  it('parses valid JSON', async () => {
+    const parseJSONResult = await loadParseJSONResult();
     const obj = { a: 1 };
     expect(parseJSONResult(JSON.stringify(obj))).toEqual(obj);
   });


### PR DESCRIPTION
## Summary
- update `parseJSONResult.import.test.js` to dynamically load the helper in each test

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6843163da2c8832e8474dce88b104c45