### PR TITLE
Add inline import test for applyLabeledSectionDefaults

### DIFF
--- a/test/generator/applyLabeledSectionDefaults.keyExtraClasses.test.js
+++ b/test/generator/applyLabeledSectionDefaults.keyExtraClasses.test.js
@@ -1,25 +1,23 @@
 import fs from 'fs';
 import path from 'path';
 import { pathToFileURL } from 'url';
-import { beforeAll, describe, test, expect } from '@jest/globals';
+import { describe, test, expect } from '@jest/globals';
 
-let applyLabeledSectionDefaults;
-
-beforeAll(async () => {
+async function load() {
   const generatorPath = path.join(process.cwd(), 'src/generator/generator.js');
   let src = fs.readFileSync(generatorPath, 'utf8');
   src = src.replace(/from '\.\/(.*?)'/g, (_, p) => {
     const absolute = pathToFileURL(path.join(path.dirname(generatorPath), p));
     return `from '${absolute.href}'`;
   });
-  src += '\nexport { applyLabeledSectionDefaults };';
-  ({ applyLabeledSectionDefaults } = await import(
-    `data:text/javascript,${encodeURIComponent(src)}`
-  ));
-});
+  src +=
+    '\nexport { applyLabeledSectionDefaults };\n//# sourceURL=' + generatorPath;
+  return import(`data:text/javascript,${encodeURIComponent(src)}`);
+}
 
 describe('applyLabeledSectionDefaults', () => {
-  test('sets default keyExtraClasses', () => {
+  test('sets default keyExtraClasses', async () => {
+    const { applyLabeledSectionDefaults } = await load();
     const args = { label: 'l', valueHTML: '<span>v</span>' };
     const result = applyLabeledSectionDefaults(args);
     expect(result.keyExtraClasses).toBe('');


### PR DESCRIPTION
## Summary
- improve coverage around `applyLabeledSectionDefaults`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68431637fbac832e9cd3fb2970a12e46