### PR TITLE
Add test for prefixIfPresent falsy handling

### DIFF
--- a/test/generator/prefixIfPresent.test.js
+++ b/test/generator/prefixIfPresent.test.js
@@ -1,0 +1,25 @@
+import fs from 'fs';
+import path from 'path';
+import { pathToFileURL } from 'url';
+import { beforeAll, describe, test, expect } from '@jest/globals';
+
+let prefixIfPresent;
+
+beforeAll(async () => {
+  const generatorPath = path.join(process.cwd(), 'src/generator/generator.js');
+  let src = fs.readFileSync(generatorPath, 'utf8');
+  src = src.replace(/from '\.\/(.*?)'/g, (_, p) => {
+    const absolute = pathToFileURL(path.join(path.dirname(generatorPath), p));
+    return `from '${absolute.href}'`;
+  });
+  src += '\nexport { prefixIfPresent };';
+  ({ prefixIfPresent } = await import(`data:text/javascript,${encodeURIComponent(src)}`));
+});
+
+describe('prefixIfPresent', () => {
+  test('returns empty string when value is falsy', () => {
+    expect(prefixIfPresent(' by ', '')).toBe('');
+    expect(prefixIfPresent(' by ', undefined)).toBe('');
+    expect(prefixIfPresent(' by ', null)).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- extend generator tests with coverage for prefixIfPresent when provided falsy values

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6843162e85e8832ea8f31594cf665c5c