### PR TITLE
Improve mutation test for parseJSONResult

### DIFF
--- a/test/browser/toys.parseJSONResult.mutant.test.js
+++ b/test/browser/toys.parseJSONResult.mutant.test.js
@@ -1,10 +1,12 @@
 import { describe, it, expect } from '@jest/globals';
 import fs from 'fs';
-import path from 'path';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
 
 describe('parseJSONResult mutant', () => {
   it('returns null when JSON parsing fails', () => {
-    const filePath = path.join(process.cwd(), 'src/browser/toys.js');
+    const filePath = require.resolve('../../src/browser/toys.js');
     const fileContents = fs.readFileSync(filePath, 'utf8');
     const match = fileContents.match(/function parseJSONResult\([^]*?\n\}/);
     const parseJSONResult = eval('(' + match[0] + ')');


### PR DESCRIPTION
## Summary
- adjust `parseJSONResult` mutant test to use `require.resolve`

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684316343560832ea80f6cd1171a6e09