### PR TITLE
Add mutant-killing test

### DIFF
--- a/test/toys/2025-05-08/battleshipSolitaireFleet.test.js
+++ b/test/toys/2025-05-08/battleshipSolitaireFleet.test.js
@@ -178,4 +178,12 @@ describe('generateFleet', () => {
     const lengths = fleet.ships.map(ship => ship.length);
     expect(lengths).toEqual([1, 3, 2]);
   });
+  test("does not mutate the input ship lengths array", () => {
+    const cfg = { width: 4, height: 4, ships: [1, 2, 3] };
+    const env = new Map([["getRandomNumber", () => 0]]);
+    const cfgCopy = { ...cfg, ships: [...cfg.ships] };
+    generateFleet(JSON.stringify(cfgCopy), env);
+    expect(cfgCopy.ships).toEqual([1, 2, 3]);
+  });
+
 });


### PR DESCRIPTION
## Summary
- ensure ship length arrays remain unchanged after fleet generation

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68431632812c832e9169be9727e46bc6