### PR TITLE
Add test for minimax terminal state

### DIFF
--- a/test/toys/2025-04-06/minimax.earlyreturn.mutant.test.js
+++ b/test/toys/2025-04-06/minimax.earlyreturn.mutant.test.js
@@ -1,0 +1,25 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, test, expect } from '@jest/globals';
+
+async function loadMinimax() {
+  const filePath = path.join(process.cwd(), 'src/toys/2025-04-06/ticTacToe.js');
+  let src = fs.readFileSync(filePath, 'utf8');
+  src += '\nexport { minimax };';
+  const mod = await import(`data:text/javascript,${encodeURIComponent(src)}`);
+  return mod.minimax;
+}
+
+describe('minimax early return', () => {
+  test('returns terminal score when player has already won', async () => {
+    const minimax = await loadMinimax();
+    const board = [
+      ['X', 'X', 'X'],
+      [null, null, null],
+      [null, null, null]
+    ];
+    const params = { board, player: 'X', moves: [] };
+    const score = minimax(0, true, params);
+    expect(score).toBe(10);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test targeting `minimax` early return to kill a Stryker survivor

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684337d6088c832e942694d108747434