### PR TITLE
Add test for parseJSONResult edge case

### DIFF
--- a/test/browser/parseJSONResult.eval.test.js
+++ b/test/browser/parseJSONResult.eval.test.js
@@ -27,4 +27,8 @@ describe('parseJSONResult eval import', () => {
   test('returns null for invalid JSON', () => {
     expect(parseJSONResult('{ invalid')).toBeNull();
   });
+
+  test('returns null for undefined input', () => {
+    expect(parseJSONResult(undefined)).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- extend `parseJSONResult.eval` test to cover `undefined` input

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684337d4d770832e859dbb6f73af5e02