### PR TITLE
Add test to cover bread bait modifier

### DIFF
--- a/test/toys/2025-03-29/fishingGame.test.js
+++ b/test/toys/2025-03-29/fishingGame.test.js
@@ -39,6 +39,14 @@ describe('fishingGame', () => {
     expect(output).toMatch(/warm, shimmering waves under a vibrant sun/i);
   });
 
+  test('negative modifier can reduce chance below silent threshold', () => {
+    const env = createEnv(0.25, '2025-06-10T14:00:00');
+    const output = fishingGame('bread', env);
+    // With base chance 0.25 and modifier -0.05, effective chance is 0.2 < 0.3
+    expect(output).toMatch(/slice of bread/i);
+    expect(output).toMatch(/water stays silent/i);
+  });
+
   test('applies positive modifier for good bait (e.g., cheese, modifier 0.1)', () => {
     const env = createEnv(0.75, '2025-09-05T19:00:00'); // fall evening
     const output = fishingGame('cheese', env);


### PR DESCRIPTION
## Summary
- extend fishingGame tests for bread bait with a case where the negative modifier drops the chance below the silent threshold

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684337d3c638832e9116e02fc1129aa0