### PR TITLE
Fix Stryker survivor by exporting sourceURL in test

### DIFF
--- a/test/generator/defaultKeyExtraClasses.test.js
+++ b/test/generator/defaultKeyExtraClasses.test.js
@@ -13,6 +13,7 @@ beforeAll(async () => {
     return `from '${absolute.href}'`;
   });
   src += '\nexport { defaultKeyExtraClasses };';
+  src += `\n//# sourceURL=${generatorPath}`;
   ({ defaultKeyExtraClasses } = await import(
     `data:text/javascript,${encodeURIComponent(src)}`
   ));


### PR DESCRIPTION
## Summary
- ensure the defaultKeyExtraClasses test includes sourceURL for Stryker

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68433e455e90832e94b67b94c359bbe3