### PR TITLE
Add test to detect fishingGame modifier

### DIFF
--- a/test/toys/2025-03-29/fishingGame.modifier.test.js
+++ b/test/toys/2025-03-29/fishingGame.modifier.test.js
@@ -1,0 +1,17 @@
+import { fishingGame } from '../../../src/toys/2025-03-29/fishingGame.js';
+import { describe, test, expect } from '@jest/globals';
+
+function makeEnv(rand, current) {
+  return new Map([
+    ['getRandomNumber', () => rand],
+    ['getCurrentTime', () => current],
+  ]);
+}
+
+describe('fishingGame modifier effects', () => {
+  test('negative modifier alters outcome category', () => {
+    const env = makeEnv(0.33, 0);
+    const output = fishingGame('bread', env);
+    expect(output).toMatch(/water stays silent/i);
+  });
+});


### PR DESCRIPTION
## Summary
- add a unit test verifying that the bread bait's negative modifier lowers the effective chance in fishingGame

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68433e44c5b8832eae5e279c54d5d14a