### PR TITLE
Add null move test for ticTacToe helpers

### DIFF
--- a/test/presenters/ticTacToeBoard.internal.test.js
+++ b/test/presenters/ticTacToeBoard.internal.test.js
@@ -27,4 +27,11 @@ describe('ticTacToeBoard internal functions', () => {
   it('getPosition returns undefined for undefined move', () => {
     expect(getPosition(undefined)).toBeUndefined();
   });
+
+  it('handles null move without throwing', () => {
+    expect(() => getPlayer(null)).not.toThrow();
+    expect(() => getPosition(null)).not.toThrow();
+    expect(getPlayer(null)).toBeUndefined();
+    expect(getPosition(null)).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary
- test that `getPlayer` and `getPosition` handle a null move without throwing

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68433e436d7c832e9cd1919568b1c788