### PR TITLE
Improve ticTacToeBoard getter coverage

### DIFF
--- a/test/presenters/ticTacToeBoard.getters.covered.test.js
+++ b/test/presenters/ticTacToeBoard.getters.covered.test.js
@@ -1,0 +1,30 @@
+import fs from 'fs';
+import path from 'path';
+import { pathToFileURL } from 'url';
+import { beforeAll, describe, test, expect } from '@jest/globals';
+
+let getPlayer;
+let getPosition;
+
+beforeAll(async () => {
+  const filePath = path.join(process.cwd(), 'src/presenters/ticTacToeBoard.js');
+  let src = fs.readFileSync(filePath, 'utf8');
+  src = src.replace(/from '((?:\.\.?\/)[^']*)'/g, (_, p) => {
+    const abs = pathToFileURL(path.join(path.dirname(filePath), p));
+    return `from '${abs.href}'`;
+  });
+  src += `\nexport { getPlayer, getPosition };\n//# sourceURL=${pathToFileURL(filePath).href}`;
+  ({ getPlayer, getPosition } = await import(
+    `data:text/javascript,${encodeURIComponent(src)}`
+  ));
+});
+
+describe('ticTacToeBoard getters via import', () => {
+  test('getPlayer returns undefined for undefined move', () => {
+    expect(getPlayer(undefined)).toBeUndefined();
+  });
+
+  test('getPosition returns undefined for undefined move', () => {
+    expect(getPosition(undefined)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add a coverage-aware test suite for `getPlayer` and `getPosition`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68433e42598c832e81a20194915b024f