### PR TITLE
Add escaping tests for italics helpers

### DIFF
--- a/test/browser/parseJSONResult.global.test.js
+++ b/test/browser/parseJSONResult.global.test.js
@@ -6,8 +6,8 @@ import { pathToFileURL } from 'url';
 async function loadParseJSONResult() {
   const url = pathToFileURL('./src/browser/toys.js');
   let code = await fs.readFile(url, 'utf8');
-  code += '\nglobal.__test_parseJSONResult = parseJSONResult;';
-  const context = vm.createContext(global);
+  code += '\nglobalThis.__test_parseJSONResult = parseJSONResult;';
+  const context = vm.createContext(globalThis);
   async function linker(specifier, referencingModule) {
     const modUrl = new URL(specifier, referencingModule.identifier);
     const src = await fs.readFile(modUrl, 'utf8');
@@ -21,7 +21,7 @@ async function loadParseJSONResult() {
   const mod = new vm.SourceTextModule(code, { identifier: url.href, context });
   await mod.link(linker);
   await mod.evaluate();
-  return global.__test_parseJSONResult;
+  return globalThis.__test_parseJSONResult;
 }
 
 describe('parseJSONResult global', () => {


### PR DESCRIPTION
## Summary
- fix VM context setup in `parseJSONResult.global.test.js`
- add `regexEscape.test.js` to verify escaping of special characters in italics helpers

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68433e41a9c4832eb2e3a88e2e738c67