### PR TITLE
Add failing adjacency test

### DIFF
--- a/test/toys/2025-05-08/battleshipSolitaireFleet.test.js
+++ b/test/toys/2025-05-08/battleshipSolitaireFleet.test.js
@@ -186,12 +186,18 @@ describe('generateFleet', () => {
     const lengths = fleet.ships.map(ship => ship.length);
     expect(lengths).toEqual([1, 3, 2]);
   });
-  test("does not mutate the input ship lengths array", () => {
+  test('does not mutate the input ship lengths array', () => {
     const cfg = { width: 4, height: 4, ships: [1, 2, 3] };
-    const env = new Map([["getRandomNumber", () => 0]]);
+    const env = new Map([['getRandomNumber', () => 0]]);
     const cfgCopy = { ...cfg, ships: [...cfg.ships] };
     generateFleet(JSON.stringify(cfgCopy), env);
     expect(cfgCopy.ships).toEqual([1, 2, 3]);
   });
 
+  test('noTouching prevents adjacency for mixed ship lengths', () => {
+    const cfg = { width: 4, height: 3, ships: [2, 1], noTouching: true };
+    const env = new Map([['getRandomNumber', () => 0]]);
+    const fleet = JSON.parse(generateFleet(JSON.stringify(cfg), env));
+    expect(fleet.ships.filter(Boolean).length).toBe(1);
+  });
 });


### PR DESCRIPTION
## Summary
- expand Battleship fleet tests for mixed ship lengths with `noTouching`

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684341c2a340832eb80916895b2b995b