### PR TITLE
Improve coverage for validateCluesObject

### DIFF
--- a/test/presenters/battleshipSolitaireClues.validate.test.js
+++ b/test/presenters/battleshipSolitaireClues.validate.test.js
@@ -1,11 +1,9 @@
 import fs from 'fs';
 import path from 'path';
 import { pathToFileURL } from 'url';
-import { beforeAll, describe, test, expect } from '@jest/globals';
+import { describe, test, expect } from '@jest/globals';
 
-let validateCluesObject;
-
-beforeAll(async () => {
+async function loadValidateCluesObject() {
   const presenterPath = path.join(
     process.cwd(),
     'src/presenters/battleshipSolitaireClues.js'
@@ -16,13 +14,14 @@ beforeAll(async () => {
     return `from '${absolute.href}'`;
   });
   src += '\nexport { validateCluesObject };';
-  ({ validateCluesObject } = await import(
-    `data:text/javascript,${encodeURIComponent(src)}`
-  ));
-});
+  return (
+    await import(`data:text/javascript,${encodeURIComponent(src)}`)
+  ).validateCluesObject;
+}
 
 describe('validateCluesObject', () => {
-  test('returns error when input is not an object', () => {
+  test('returns error when input is not an object', async () => {
+    const validateCluesObject = await loadValidateCluesObject();
     const result = validateCluesObject(42);
     expect(result).toBe('Invalid JSON object');
   });

--- a/test/presenters/validateCluesObject.import.test.js
+++ b/test/presenters/validateCluesObject.import.test.js
@@ -1,11 +1,9 @@
 import fs from 'fs';
 import path from 'path';
 import { pathToFileURL } from 'url';
-import { beforeAll, describe, it, expect } from '@jest/globals';
+import { describe, it, expect } from '@jest/globals';
 
-let validateCluesObject;
-
-beforeAll(async () => {
+async function loadValidateCluesObject() {
   const srcPath = path.join(process.cwd(), 'src/presenters/battleshipSolitaireClues.js');
   let src = fs.readFileSync(srcPath, 'utf8');
   src = src.replace(/from '((?:\.\.?\/).*?)'/g, (_, p) => {
@@ -13,11 +11,14 @@ beforeAll(async () => {
     return `from '${abs.href}'`;
   });
   src += '\nexport { validateCluesObject };';
-  ({ validateCluesObject } = await import(`data:text/javascript,${encodeURIComponent(src)}`));
-});
+  return (
+    await import(`data:text/javascript,${encodeURIComponent(src)}`)
+  ).validateCluesObject;
+}
 
 describe('validateCluesObject dynamic import', () => {
-  it('returns Invalid JSON object when input is not an object', () => {
+  it('returns Invalid JSON object when input is not an object', async () => {
+    const validateCluesObject = await loadValidateCluesObject();
     expect(validateCluesObject(42)).toBe('Invalid JSON object');
   });
 });


### PR DESCRIPTION
## Summary
- update `battleshipSolitaireClues.validate.test.js` to load the module in each test
- update `validateCluesObject.import.test.js` similarly

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684341c19e64832ea7f2505040cf5f7d