### PR TITLE
Add tests for underscore regex handling

### DIFF
--- a/test/toys/2025-03-21/regexEscape.test.js
+++ b/test/toys/2025-03-21/regexEscape.test.js
@@ -31,4 +31,16 @@ describe('regex escaping for italics helpers', () => {
     expect(regex.source).toBe('\\$(.*?)\\$');
     expect('foo $bar$ baz'.replace(regex, 'X')).toBe('foo X baz');
   });
+
+  test('createBoldPatternPart leaves non-special characters unescaped', () => {
+    const part = createBoldPatternPart('_');
+    expect(part).toBe('(?:__.*?__)');
+    expect(new RegExp(part).test('__bold__')).toBe(true);
+  });
+
+  test('createItalicsPattern leaves non-special characters unescaped', () => {
+    const regex = createItalicsPattern('_');
+    expect(regex.source).toBe('_(.*?)_');
+    expect('foo _bar_ baz'.replace(regex, 'X')).toBe('foo X baz');
+  });
 });


### PR DESCRIPTION
## Summary
- extend regexEscape tests for underscore markers to check non-special character handling

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684341c0121c832ea9564b93ef488bbd