### PR TITLE
Add test for shiny bait

### DIFF
--- a/test/toys/2025-03-29/fishingGame.test.js
+++ b/test/toys/2025-03-29/fishingGame.test.js
@@ -120,4 +120,11 @@ describe('fishingGame', () => {
     // Base chance 0.3 with modifier -0.1 results in 0.2 < 0.3
     expect(output).toMatch(/water stays silent/i);
   });
+
+  test('recognizes shiny bait and applies its modifier', () => {
+    const env = createEnv(0.7, '2025-07-04T12:00:00');
+    const output = fishingGame('shiny bait', env);
+    expect(output).toMatch(/glittering lure/i);
+    expect(output).toMatch(/legendary golden fish leaps forth/i);
+  });
 });


### PR DESCRIPTION
## Summary
- cover shiny bait outcome in the fishing game tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684341c3d684832e985b0b67fb1a9696