### PR TITLE
Improve alley success test

### DIFF
--- a/test/toys/2025-03-30/cyberpunkAdventure.test.js
+++ b/test/toys/2025-03-30/cyberpunkAdventure.test.js
@@ -103,6 +103,7 @@ describe('Cyberpunk Text Game', () => {
     env.set('getData', () => ({ temporary: { CYBE1: tempData } }));
     expect(cyberpunkAdventure('alley', env)).toMatch(/shadows move with you./);
     expect(cyberpunkAdventure(' ', env)).toMatch(/hidden stash: a stimpack/);
+    expect(tempData.state).toBe('hub');
     expect(tempData.inventory).toContain('stimpack');
     expect(tempData.visited).toContain('alley');
   });


### PR DESCRIPTION
## Summary
- assert that the player state changes to `hub` after successfully sneaking in the alley

## Testing
- `npm test`
- `npm run lint`
- `npm run stryker -- --mutate src/toys/2025-03-30/cyberpunkAdventure.js`

------
https://chatgpt.com/codex/tasks/task_e_68434605184c832e9836b9b56ad585ea