### PR TITLE
Improve fleet parsing tests

### DIFF
--- a/test/toys/2025-05-08/battleshipSolitaireFleet.test.js
+++ b/test/toys/2025-05-08/battleshipSolitaireFleet.test.js
@@ -136,6 +136,14 @@ describe('generateFleet', () => {
     expect(lengths).toEqual([2, 10]);
   });
 
+  test('parses ships string ignoring empty entries', () => {
+    const cfg = { width: 4, height: 4, ships: '2,,3' };
+    const result = generateFleet(JSON.stringify(cfg), env);
+    const fleet = JSON.parse(result);
+    const lengths = fleet.ships.map(ship => ship.length).sort((a, b) => a - b);
+    expect(lengths).toEqual([2, 3]);
+  });
+
   test('parses string width and height into numbers', () => {
     const cfg = { width: '5', height: '5', ships: [2] };
     const result = generateFleet(JSON.stringify(cfg), env);


### PR DESCRIPTION
## Summary
- add coverage for parseConfig handling empty ship entries

## Testing
- `npm test`
- `npm run lint`
- `npm run stryker` *(failed: error: unknown option '--testFilter')*

------
https://chatgpt.com/codex/tasks/task_e_6843455f5fc8832ebf07f7c56f8252a8