### PR TITLE
Add test for parseJSONResult

### DIFF
--- a/test/browser/parseJSONResult.realImport.test.js
+++ b/test/browser/parseJSONResult.realImport.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect } from '@jest/globals';
+import fs from 'fs';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+
+function loadParseJSONResult() {
+  const id = require.resolve('../../src/browser/toys.js');
+  require(id); // ensure module is loaded (mutated path when running under Stryker)
+  const filename = require.cache[id].filename; // path to file (mutated by Stryker)
+  const code = fs.readFileSync(filename, 'utf8');
+  const match = code.match(/function parseJSONResult\([^]*?\n\}/);
+  return eval('(' + match[0] + ')');
+}
+
+describe('parseJSONResult real import', () => {
+  it('returns null for invalid JSON', () => {
+    const parseJSONResult = loadParseJSONResult();
+    expect(parseJSONResult('not json')).toBeNull();
+  });
+
+  it('parses valid JSON', () => {
+    const parseJSONResult = loadParseJSONResult();
+    const obj = { foo: 'bar' };
+    expect(parseJSONResult(JSON.stringify(obj))).toEqual(obj);
+  });
+});


### PR DESCRIPTION
## Summary
- add a new test `parseJSONResult.realImport.test.js` that loads `parseJSONResult` from the toys module using its real module path

## Testing
- `npm test`
- `npm run lint`
- `npx stryker run --mutate src/browser/toys.js` *(fails to kill mutant)*

------
https://chatgpt.com/codex/tasks/task_e_684341ee21a8832ea70899b32a6460ff