### PR TITLE
Improve mutation test coverage for createValueDiv

### DIFF
--- a/test/generator/createValueDiv.filter.test.js
+++ b/test/generator/createValueDiv.filter.test.js
@@ -13,6 +13,7 @@ beforeAll(async () => {
     return `from '${absolute.href}'`;
   });
   src += '\nexport { createValueDiv };';
+  src += `\n//# sourceURL=${generatorPath}`;
   ({ createValueDiv } = await import(`data:text/javascript,${encodeURIComponent(src)}`));
 });
 


### PR DESCRIPTION
## Summary
- embed a sourceURL directive in `createValueDiv.filter.test.js` so Stryker maps coverage correctly and the associated mutant is killed

## Testing
- `npm test`
- `npm run lint`
- `npm run stryker` *(failed: process terminated due to time constraints)*

------
https://chatgpt.com/codex/tasks/task_e_6843455fbbec832eb69746c467024a8d