### PR TITLE
Add shiny bait test

### DIFF
--- a/test/presenters/battleshipSolitaireClues.validate.test.js
+++ b/test/presenters/battleshipSolitaireClues.validate.test.js
@@ -26,4 +26,19 @@ describe('validateCluesObject', () => {
     const result = validateCluesObject(42);
     expect(result).toBe('Invalid JSON object');
   });
+
+  test('detects missing clue arrays', () => {
+    const result = validateCluesObject({ rowClues: [1, 2] });
+    expect(result).toBe('Missing rowClues or colClues array');
+  });
+
+  test('detects non-numeric clue values', () => {
+    const result = validateCluesObject({ rowClues: ['x'], colClues: [1] });
+    expect(result).toBe('Clue values must be numbers');
+  });
+
+  test('detects empty clue arrays', () => {
+    const result = validateCluesObject({ rowClues: [], colClues: [] });
+    expect(result).toBe('rowClues and colClues must be non-empty');
+  });
 });

--- a/test/toys/2025-03-29/fishingGame.test.js
+++ b/test/toys/2025-03-29/fishingGame.test.js
@@ -120,4 +120,12 @@ describe('fishingGame', () => {
     // Base chance 0.3 with modifier -0.1 results in 0.2 < 0.3
     expect(output).toMatch(/water stays silent/i);
   });
+
+  test('recognizes shiny bait and applies its positive modifier', () => {
+    const env = createEnv(0.86, '2025-08-10T10:00:00');
+    const output = fishingGame('shiny bait', env);
+    expect(output).toMatch(/glittering lure/i);
+    // 0.86 base chance with 0.15 modifier → legendary outcome
+    expect(output).toMatch(/legendary golden fish leaps forth/i);
+  });
 });


### PR DESCRIPTION
## Summary
- extend fishingGame test coverage for "shiny bait"

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684341c1e92c832eb6155266d079feba