### PR TITLE
Add test to ensure hacker door state unchanged on bad password

### DIFF
--- a/test/toys/2025-03-30/cyberpunkAdventure.test.js
+++ b/test/toys/2025-03-30/cyberpunkAdventure.test.js
@@ -55,6 +55,8 @@ describe('Cyberpunk Text Game', () => {
     } else {
       expect(result).toMatch(/Hint: the password is a number and a name/);
     }
+    // State should remain on the hacker door when password is incorrect
+    expect(tempData.state).toBe('hacker:door');
   });
 
   test('goes to Transport Hub and trades datapad', () => {


### PR DESCRIPTION
## Summary
- extend cyberpunk adventure test to assert that the player state remains on the hacker door when the wrong password is entered

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684400590f2c832e849ceacd2a636382