### PR TITLE
Refactor parseJSONResult test

### DIFF
--- a/test/browser/parseJSONResult.realImport.test.js
+++ b/test/browser/parseJSONResult.realImport.test.js
@@ -1,23 +1,88 @@
-import { describe, it, expect } from '@jest/globals';
 import fs from 'fs';
 import path from 'path';
+import { pathToFileURL } from 'url';
+import { describe, it, expect } from '@jest/globals';
 
-function loadParseJSONResult() {
-  const filename = path.join(process.cwd(), 'src/browser/toys.js');
-  const code = fs.readFileSync(filename, 'utf8');
-  const match = code.match(/function parseJSONResult\([^]*?\n\}/);
-  return eval('(' + match[0] + ')');
+async function loadModuleWithCapture() {
+  const srcPath = path.join(process.cwd(), 'src/browser/toys.js');
+  let code = fs.readFileSync(srcPath, 'utf8');
+  code = code.replace(/from '((?:\.\.?\/).*?)'/g, (_, p) => {
+    const abs = pathToFileURL(path.join(path.dirname(srcPath), p));
+    return `from '${abs.href}'`;
+  });
+  code = code.replace(
+    'function handleParsedResult(parsed, env, options) {',
+    'function handleParsedResult(parsed, env, options) {\n  globalThis.__captured = parsed;'
+  );
+  return import(`data:text/javascript,${encodeURIComponent(code)}`);
 }
 
-describe('parseJSONResult real import', () => {
-  it('returns null for invalid JSON', () => {
-    const parseJSONResult = loadParseJSONResult();
-    expect(parseJSONResult('not json')).toBeNull();
+describe('processInputAndSetOutput via dynamic import', () => {
+  it('captures parsed result from invalid JSON', async () => {
+    const mod = await loadModuleWithCapture();
+    const { processInputAndSetOutput } = mod;
+    const elements = {
+      inputElement: { value: 'x' },
+      outputParentElement: {},
+      outputSelect: { value: 'text' },
+      article: { id: 'a1' },
+    };
+    const toyEnv = new Map([
+      ['getData', () => ({ output: {} })],
+      ['setData', () => {}],
+    ]);
+    const env = {
+      createEnv: () => toyEnv,
+      fetchFn: () => Promise.resolve({ text: () => Promise.resolve('') }),
+      dom: {
+        setTextContent: () => {},
+        removeAllChildren: () => {},
+        appendChild: () => {},
+        createElement: () => ({}),
+        addWarning: () => {},
+        removeWarning: () => {},
+      },
+      errorFn: () => {},
+      loggers: { logInfo: () => {}, logError: () => {}, logWarning: () => {} },
+    };
+
+    processInputAndSetOutput(elements, () => 'not json', env);
+
+    expect(globalThis.__captured).toBeNull();
   });
 
-  it('parses valid JSON', () => {
-    const parseJSONResult = loadParseJSONResult();
-    const obj = { foo: 'bar' };
-    expect(parseJSONResult(JSON.stringify(obj))).toEqual(obj);
+  it('captures parsed object from valid JSON', async () => {
+    const mod = await loadModuleWithCapture();
+    const { processInputAndSetOutput } = mod;
+    const elements = {
+      inputElement: { value: 'x' },
+      outputParentElement: {},
+      outputSelect: { value: 'text' },
+      article: { id: 'a1' },
+    };
+    const toyEnv = new Map([
+      ['getData', () => ({ output: {} })],
+      ['setData', () => {}],
+    ]);
+    const env = {
+      createEnv: () => toyEnv,
+      fetchFn: () => Promise.resolve({ text: () => Promise.resolve('') }),
+      dom: {
+        setTextContent: () => {},
+        removeAllChildren: () => {},
+        appendChild: () => {},
+        createElement: () => ({}),
+        addWarning: () => {},
+        removeWarning: () => {},
+      },
+      errorFn: () => {},
+      loggers: { logInfo: () => {}, logError: () => {}, logWarning: () => {} },
+    };
+    const obj = { request: { url: 'u' } };
+
+    processInputAndSetOutput(elements, () => JSON.stringify(obj), env);
+
+    expect(globalThis.__captured).toEqual(obj);
   });
 });
+


### PR DESCRIPTION
## Summary
- revise `parseJSONResult.realImport.test.js` to avoid eval and check parsed values via dynamic import

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6844005a12fc832eb4dbec536f120dd6