### PR TITLE
Add direct import test for placeAllShips

### DIFF
--- a/public/2025-05-08/battleshipSolitaireFleet.js
+++ b/public/2025-05-08/battleshipSolitaireFleet.js
@@ -358,4 +358,4 @@ function getFleetResultOrError(fleetResult) {
   return fleetRetryError();
 }
 
-export { generateFleet };
+export { generateFleet, placeAllShips };

--- a/src/toys/2025-05-08/battleshipSolitaireFleet.js
+++ b/src/toys/2025-05-08/battleshipSolitaireFleet.js
@@ -358,4 +358,4 @@ function getFleetResultOrError(fleetResult) {
   return fleetRetryError();
 }
 
-export { generateFleet };
+export { generateFleet, placeAllShips };

--- a/test/toys/2025-05-08/placeAllShips.mutant.test.js
+++ b/test/toys/2025-05-08/placeAllShips.mutant.test.js
@@ -1,0 +1,12 @@
+import { describe, test, expect } from '@jest/globals';
+import { placeAllShips } from '../../../src/toys/2025-05-08/battleshipSolitaireFleet.js';
+
+describe('placeAllShips mutation', () => {
+  test('does not mutate config ships array', () => {
+    const cfg = { width: 3, height: 3, ships: [1, 2] };
+    const env = new Map([['getRandomNumber', () => 0]]);
+    const original = [...cfg.ships];
+    placeAllShips(cfg, env);
+    expect(cfg.ships).toEqual(original);
+  });
+});


### PR DESCRIPTION
## Summary
- export `placeAllShips` from the Battleship Solitaire fleet generator
- rewrite the mutation test to import the function directly

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68440059ccb8832e99d5244be66e7823