### PR TITLE
Fix Clues tests to avoid parse‑eval

### DIFF
--- a/test/presenters/battleshipSolitaireClues.test.js
+++ b/test/presenters/battleshipSolitaireClues.test.js
@@ -57,6 +57,13 @@ describe('createBattleshipCluesBoardElement – error handling', () => {
     expectEmpty10x10Board(el);
   });
 
+  test('renders 10x10 empty board when JSON is a string', () => {
+    const dom = makeDom();
+    const input = '"foo"';
+    const el = createBattleshipCluesBoardElement(input, dom);
+    expectEmpty10x10Board(el);
+  });
+
   test('renders 10x10 empty board when JSON is null', () => {
     const dom = makeDom();
     const el = createBattleshipCluesBoardElement('null', dom); // null value

--- a/test/presenters/battleshipSolitaireClues.validate.test.js
+++ b/test/presenters/battleshipSolitaireClues.validate.test.js
@@ -1,28 +1,31 @@
-import fs from 'fs';
-import path from 'path';
-import { pathToFileURL } from 'url';
 import { describe, test, expect } from '@jest/globals';
+import { createBattleshipCluesBoardElement } from '../../src/presenters/battleshipSolitaireClues.js';
 
-async function loadValidateCluesObject() {
-  const presenterPath = path.join(
-    process.cwd(),
-    'src/presenters/battleshipSolitaireClues.js'
-  );
-  let src = fs.readFileSync(presenterPath, 'utf8');
-  src = src.replace(/from '\.\/(.*?)'/g, (_, p) => {
-    const absolute = pathToFileURL(path.join(path.dirname(presenterPath), p));
-    return `from '${absolute.href}'`;
-  });
-  src += '\nexport { validateCluesObject };';
-  return (
-    await import(`data:text/javascript,${encodeURIComponent(src)}`)
-  ).validateCluesObject;
+function makeDom() {
+  return {
+    created: [],
+    createElement(tag) {
+      const el = { tag, text: '' };
+      this.created.push(el);
+      return el;
+    },
+    setTextContent(el, text) {
+      el.text = text;
+    },
+  };
 }
 
-describe('validateCluesObject', () => {
-  test('returns error when input is not an object', async () => {
-    const validateCluesObject = await loadValidateCluesObject();
-    const result = validateCluesObject(42);
-    expect(result).toBe('Invalid JSON object');
+function expectEmptyBoard(el) {
+  expect(el.tag).toBe('pre');
+  const lines = el.text.trim().split('\n');
+  const gridLines = lines.filter(line => /^\s*0(\s+·){10}\s+0\s*$/.test(line));
+  expect(gridLines.length).toBe(10);
+}
+
+describe('validateCluesObject via public API', () => {
+  test('returns empty board when JSON is not an object', () => {
+    const dom = makeDom();
+    const el = createBattleshipCluesBoardElement('42', dom);
+    expectEmptyBoard(el);
   });
 });


### PR DESCRIPTION
## Summary
- refactor `battleshipSolitaireClues.validate` test to use the public API instead of dynamic eval
- add string-input case to the Clues board presenter tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6844005594b0832e8728a0a00cb8edca