### PR TITLE
Extend validateCluesObject tests

### DIFF
--- a/test/presenters/battleshipSolitaireClues.validate.test.js
+++ b/test/presenters/battleshipSolitaireClues.validate.test.js
@@ -25,4 +25,22 @@ describe('validateCluesObject', () => {
     const result = validateCluesObject(42);
     expect(result).toBe('Invalid JSON object');
   });
+
+  test('returns error when rowClues or colClues arrays are missing', async () => {
+    const validateCluesObject = await loadValidateCluesObject();
+    const result = validateCluesObject({ rowClues: [1, 2, 3] });
+    expect(result).toBe('Missing rowClues or colClues array');
+  });
+
+  test('returns error when clue values are non-numeric', async () => {
+    const validateCluesObject = await loadValidateCluesObject();
+    const result = validateCluesObject({ rowClues: [1, 'x'], colClues: [2, 3] });
+    expect(result).toBe('Clue values must be numbers');
+  });
+
+  test('returns error when any array is empty', async () => {
+    const validateCluesObject = await loadValidateCluesObject();
+    const result = validateCluesObject({ rowClues: [], colClues: [] });
+    expect(result).toBe('rowClues and colClues must be non-empty');
+  });
 });


### PR DESCRIPTION
## Summary
- add extra checks for `validateCluesObject`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684411e20398832ebc6b3baa3f20598b