### PR TITLE
Add test for length-one ship clues

### DIFF
--- a/test/toys/2025-05-11/battleshipSolitaireClues.test.js
+++ b/test/toys/2025-05-11/battleshipSolitaireClues.test.js
@@ -143,6 +143,17 @@ describe('generateClues', () => {
     expect(output.colClues).toEqual(expectedCol);
   });
 
+  it('computes correct clues for a single length-one ship', () => {
+    const fleet = {
+      width: 2,
+      height: 2,
+      ships: [{ start: { x: 1, y: 0 }, length: 1, direction: 'H' }],
+    };
+    const output = JSON.parse(generateClues(JSON.stringify(fleet)));
+    expect(output.rowClues).toEqual([1, 0]);
+    expect(output.colClues).toEqual([0, 1]);
+  });
+
   it('returns an error when the fleet is null', () => {
     const output = JSON.parse(generateClues('null'));
     expect(output).toEqual({ error: 'Invalid fleet structure' });


### PR DESCRIPTION
## Summary
- add a test case for `generateClues` that checks a single length-one ship

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684411e12604832eb1fbf593e917d170