### PR TITLE
Improve trade prompt test

### DIFF
--- a/test/toys/2025-03-30/cyberpunkAdventure.test.js
+++ b/test/toys/2025-03-30/cyberpunkAdventure.test.js
@@ -93,6 +93,7 @@ describe('Cyberpunk Text Game', () => {
     } else {
       expect(result).toMatch(/Do you want to trade/);
     }
+    expect(tempData.state).toBe('transport:trade');
   });
 
   test('goes to Back Alley and finds stimpack (success)', () => {


### PR DESCRIPTION
## Summary
- extend cyberpunkAdventure trade prompt test to confirm player state remains `transport:trade`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684411e0b470832ea358f948c3b26888