### PR TITLE
Add mutation-killing test for placeAllShips

### DIFF
--- a/test/toys/2025-05-08/placeAllShips.shuffle.test.js
+++ b/test/toys/2025-05-08/placeAllShips.shuffle.test.js
@@ -1,0 +1,12 @@
+import { describe, test, expect } from '@jest/globals';
+import { placeAllShips } from '../../../src/toys/2025-05-08/battleshipSolitaireFleet.js';
+
+describe('placeAllShips input mutation', () => {
+  test('shuffling does not alter cfg.ships array', () => {
+    const cfg = { width: 3, height: 3, ships: [1, 2, 3] };
+    const env = new Map([['getRandomNumber', () => 0.5]]);
+    const original = [...cfg.ships];
+    placeAllShips(cfg, env);
+    expect(cfg.ships).toEqual(original);
+  });
+});


### PR DESCRIPTION
## Summary
- add a new test verifying that `placeAllShips` does not mutate the ships array when shuffling

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684411dfaf34832eb8b9afcf8cc807aa