### PR TITLE
Add test to kill mutant and fix imports

### DIFF
--- a/test/presenters/battleshipSolitaireClues.validate.test.js
+++ b/test/presenters/battleshipSolitaireClues.validate.test.js
@@ -1,5 +1,6 @@
 import { describe, test, expect } from '@jest/globals';
 import { createBattleshipCluesBoardElement } from '../../src/presenters/battleshipSolitaireClues.js';
+import { loadValidateCluesObject } from './validateCluesObject.import.test.js';
 
 function makeDom() {
   return {

--- a/test/presenters/validateCluesObject.import.test.js
+++ b/test/presenters/validateCluesObject.import.test.js
@@ -3,7 +3,7 @@ import path from 'path';
 import { pathToFileURL } from 'url';
 import { describe, it, expect } from '@jest/globals';
 
-async function loadValidateCluesObject() {
+export async function loadValidateCluesObject() {
   const srcPath = path.join(process.cwd(), 'src/presenters/battleshipSolitaireClues.js');
   let src = fs.readFileSync(srcPath, 'utf8');
   src = src.replace(/from '((?:\.\.?\/).*?)'/g, (_, p) => {

--- a/test/toys/2025-03-30/cyberpunkAdventure.test.js
+++ b/test/toys/2025-03-30/cyberpunkAdventure.test.js
@@ -203,6 +203,22 @@ describe('Cyberpunk Text Game', () => {
     expect(tempData.inventory).toEqual([]);
   });
 
+  test('preserves previously visited locations when adding new ones', () => {
+    tempData = {
+      name: 'Blaze',
+      state: 'hub',
+      inventory: ['datapad'],
+      visited: ['hacker'],
+    };
+    env.set('getData', () => ({ temporary: { CYBE1: tempData } }));
+
+    cyberpunkAdventure('transport', env);
+    cyberpunkAdventure(' ', env);
+    cyberpunkAdventure('trade datapad', env);
+
+    expect(tempData.visited).toEqual(expect.arrayContaining(['hacker', 'transport']));
+  });
+
   test("defaults name to 'Stray' if no input and no name in temporary data", () => {
     env.set('getData', () => ({ temporary: {} }));
     const result = cyberpunkAdventure('   ', env);


### PR DESCRIPTION
## Summary
- export `loadValidateCluesObject` for reuse
- fix `battleshipSolitaireClues.validate.test` to import helper
- add regression test ensuring visited locations persist in cyberpunk adventure

## Testing
- `npm test --silent`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684415d73790832ea7913e881c43abed