### PR TITLE
Fix missing helper in clues validation tests

### DIFF
--- a/test/presenters/battleshipSolitaireClues.validate.test.js
+++ b/test/presenters/battleshipSolitaireClues.validate.test.js
@@ -1,5 +1,26 @@
-import { describe, test, expect } from '@jest/globals';
+import fs from 'fs';
+import path from 'path';
+import { pathToFileURL } from 'url';
+import { beforeAll, describe, test, expect } from '@jest/globals';
 import { createBattleshipCluesBoardElement } from '../../src/presenters/battleshipSolitaireClues.js';
+
+let validateCluesObject;
+
+beforeAll(async () => {
+  const presenterPath = path.join(
+    process.cwd(),
+    'src/presenters/battleshipSolitaireClues.js'
+  );
+  let src = fs.readFileSync(presenterPath, 'utf8');
+  src = src.replace(/from '\.\/(.*?)'/g, (_, p) => {
+    const absolute = pathToFileURL(path.join(path.dirname(presenterPath), p));
+    return `from '${absolute.href}'`;
+  });
+  src += '\nexport { validateCluesObject };';
+  ({ validateCluesObject } = await import(
+    `data:text/javascript,${encodeURIComponent(src)}`
+  ));
+});
 
 function makeDom() {
   return {
@@ -29,20 +50,17 @@ describe('validateCluesObject via public API', () => {
     expectEmptyBoard(el);
   });
 
-  test('returns error when rowClues or colClues arrays are missing', async () => {
-    const validateCluesObject = await loadValidateCluesObject();
+  test('returns error when rowClues or colClues arrays are missing', () => {
     const result = validateCluesObject({ rowClues: [1, 2, 3] });
     expect(result).toBe('Missing rowClues or colClues array');
   });
 
-  test('returns error when clue values are non-numeric', async () => {
-    const validateCluesObject = await loadValidateCluesObject();
+  test('returns error when clue values are non-numeric', () => {
     const result = validateCluesObject({ rowClues: [1, 'x'], colClues: [2, 3] });
     expect(result).toBe('Clue values must be numbers');
   });
 
-  test('returns error when any array is empty', async () => {
-    const validateCluesObject = await loadValidateCluesObject();
+  test('returns error when any array is empty', () => {
     const result = validateCluesObject({ rowClues: [], colClues: [] });
     expect(result).toBe('rowClues and colClues must be non-empty');
   });


### PR DESCRIPTION
## Summary
- restore the dynamic helper for `validateCluesObject`
- load helper once in `beforeAll` instead of using `async` helper

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684415da0d5c832e8f65d947f283246b