### PR TITLE
Add test covering internal state removal

### DIFF
--- a/test/browser/data.internalKeys.mutant.test.js
+++ b/test/browser/data.internalKeys.mutant.test.js
@@ -1,0 +1,28 @@
+import { describe, it, expect, jest } from '@jest/globals';
+
+/**
+ * Dynamically import getData so mutation testing covers module initialization.
+ */
+
+describe('getData dynamic import', () => {
+  it('omits internal state fields', async () => {
+    const { getData } = await import('../../src/browser/data.js');
+    const state = {
+      blogStatus: 'loaded',
+      blogError: new Error('e'),
+      blogFetchPromise: Promise.resolve(),
+      blog: { title: 't' },
+    };
+    const fetchFn = jest.fn();
+    const loggers = {
+      logInfo: jest.fn(),
+      logError: jest.fn(),
+      logWarning: jest.fn(),
+    };
+    const result = getData(state, fetchFn, loggers);
+    expect(result).toEqual({ blog: { title: 't' } });
+    expect(result).not.toHaveProperty('blogStatus');
+    expect(result).not.toHaveProperty('blogError');
+    expect(result).not.toHaveProperty('blogFetchPromise');
+  });
+});


### PR DESCRIPTION
## Summary
- add a test that dynamically imports `getData` and asserts that internal blog state fields are removed

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6844689bb26c832eb50deaadb96d049e