### PR TITLE
Add tests for headElement constant

### DIFF
--- a/test/generator/headElement.test.js
+++ b/test/generator/headElement.test.js
@@ -8,4 +8,13 @@ describe('headElement', () => {
       '<link rel="manifest" href="/site.webmanifest">'
     );
   });
+
+  test('includes style and script sections', () => {
+    expect(headElement.startsWith('<head>')).toBe(true);
+    expect(headElement).toContain('<style>');
+    expect(headElement).toContain('</style>');
+    expect(headElement).toContain('<script type="module">');
+    expect(headElement).toContain('window.addComponent');
+    expect(headElement.trim().endsWith('</head>')).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- extend headElement tests to check style and script sections

## Testing
- `npm test --silent`
- `npm run lint --silent`

------
https://chatgpt.com/codex/tasks/task_e_6844689b2220832ebbb4a2ad2cfff095