### PR TITLE
Add test for related link attributes

### DIFF
--- a/test/generator/defaultRelatedLinkAttrs.test.js
+++ b/test/generator/defaultRelatedLinkAttrs.test.js
@@ -1,0 +1,26 @@
+import { describe, test, expect } from '@jest/globals';
+import { generateBlog } from '../../src/generator/generator.js';
+
+const header = '<body>';
+const footer = '</body>';
+const wrapHtml = content => ['<html>', content, '</html>'].join('');
+
+describe('DEFAULT_RELATED_LINK_ATTRS usage', () => {
+  test('generated links contain target and rel attributes', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'LINK1',
+          title: 'Example',
+          publicationDate: '2024-01-01',
+          content: ['Test'],
+          relatedLinks: [
+            { url: 'https://example.com', type: 'article', title: 'Example' }
+          ]
+        }
+      ]
+    };
+    const html = generateBlog({ blog, header, footer }, wrapHtml);
+    expect(html).toContain('target="_blank" rel="noopener"');
+  });
+});


### PR DESCRIPTION
## Summary
- verify that generated related links include default attributes

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684468979ae8832ebad61979df7c8f14