### PR TITLE
Improve createDispose tests

### DIFF
--- a/test/browser/toys.createDispose.test.js
+++ b/test/browser/toys.createDispose.test.js
@@ -4,18 +4,25 @@ import { createDispose } from '../../src/browser/toys.js';
 describe('createDispose', () => {
   it('can be called and disposed', () => {
     // Mock the required parameters
-    const disposers = [];
+    const disposer = jest.fn();
+    const disposers = [disposer];
     const dom = {
       removeAllChildren: jest.fn()
     };
     const container = {};
-    const rows = [];
+    const rows = ['row'];
 
     // Create and call dispose
     const dispose = createDispose(disposers, dom, container, rows);
+
+    // Ensure a function was returned
+    expect(typeof dispose).toBe('function');
+
     dispose();
 
     // Verify the cleanup was performed
+    expect(disposer).toHaveBeenCalled();
+    expect(disposers).toHaveLength(0);
     expect(dom.removeAllChildren).toHaveBeenCalledWith(container);
     expect(rows).toHaveLength(0);
   });


### PR DESCRIPTION
## Summary
- expand `createDispose` unit test to assert a function is returned and that each disposer is called

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68446897268c832e87f8d50e8f26ff49