### PR TITLE
Add runtime test for getDeepStateCopy

### DIFF
--- a/test/browser/getDeepStateCopy.runtime.test.js
+++ b/test/browser/getDeepStateCopy.runtime.test.js
@@ -1,0 +1,13 @@
+import { test, expect } from '@jest/globals';
+
+// Dynamically import to ensure coverage at runtime
+let getDeepStateCopy;
+
+test('getDeepStateCopy makes a deep clone when imported at runtime', async () => {
+  ({ getDeepStateCopy } = await import('../../src/browser/data.js'));
+  const original = { nested: { value: 'x' } };
+  const copy = getDeepStateCopy(original);
+  expect(copy).toEqual(original);
+  expect(copy).not.toBe(original);
+  expect(copy.nested).not.toBe(original.nested);
+});


### PR DESCRIPTION
## Summary
- add a runtime import test for `getDeepStateCopy`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684468985f80832eae3cd173b0be9e5c