### PR TITLE
Add footer warning test

### DIFF
--- a/test/generator/footerWarningMessage.test.js
+++ b/test/generator/footerWarningMessage.test.js
@@ -1,0 +1,11 @@
+import { describe, test, expect } from '@jest/globals';
+import { generateBlogOuter } from '../../src/generator/generator.js';
+
+describe('footer warning message', () => {
+  test('generateBlogOuter includes copyright notice', () => {
+    const html = generateBlogOuter({ posts: [] });
+    expect(html).toContain(
+      'All content is authored by Matt Heard and is <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">CC BY-NC-SA 4.0</a>, unless otherwise noted.'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test that ensures the copyright notice is present

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68446b1a5660832e919e77102055353f