### PR TITLE
Add array cloning test for getDeepStateCopy

### DIFF
--- a/test/browser/getDeepStateCopy.additional.test.js
+++ b/test/browser/getDeepStateCopy.additional.test.js
@@ -12,4 +12,15 @@ describe('getDeepStateCopy nested cloning', () => {
     expect(copy.level1).not.toBe(original.level1);
     expect(copy.level1.level2).not.toBe(original.level1.level2);
   });
+
+  it('creates independent array copies', () => {
+    const original = { items: [{ id: 1 }, { id: 2 }] };
+    const copy = getDeepStateCopy(original);
+    expect(copy).toEqual(original);
+    expect(copy).not.toBe(original);
+    expect(copy.items).not.toBe(original.items);
+    expect(copy.items[0]).not.toBe(original.items[0]);
+    copy.items[0].id = 3;
+    expect(original.items[0].id).toBe(1);
+  });
 });


### PR DESCRIPTION
## Summary
- extend `getDeepStateCopy` tests to check array cloning

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68446b195cfc832e9f2363489d034879