### PR TITLE
Add test to kill fullWidthElement mutant

### DIFF
--- a/test/generator/fullWidthElement.test.js
+++ b/test/generator/fullWidthElement.test.js
@@ -1,0 +1,25 @@
+import { describe, test, expect } from '@jest/globals';
+import { generateBlog } from '../../src/generator/generator.js';
+import { fullWidthElement } from '../../src/generator/full-width.js';
+
+const header = '<body>';
+const footer = '</body>';
+const wrapHtml = content => ['<html>', content, '</html>'].join('');
+
+describe('fullWidthElement integration', () => {
+  test('blog articles include the full width element', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'FW1',
+          title: 'Full Width Test',
+          publicationDate: '2024-01-01',
+          content: ['Paragraph'],
+        },
+      ],
+    };
+
+    const html = generateBlog({ blog, header, footer }, wrapHtml);
+    expect(html).toContain(fullWidthElement);
+  });
+});


### PR DESCRIPTION
## Summary
- add integration test that checks blog articles include the `fullWidthElement` markup

## Testing
- `npm test --silent`
- `npm run lint --silent`


------
https://chatgpt.com/codex/tasks/task_e_68446b183f6c832eb57a4e412f872cd1