### PR TITLE
Add test for ticTacToe terminal evaluation

### DIFF
--- a/test/toys/2025-04-06/ticTacToe.test.js
+++ b/test/toys/2025-04-06/ticTacToe.test.js
@@ -547,3 +547,20 @@ test('triggers minimax tie return at full depth without win', () => {
     position: { row: 2, column: 2 },
   });
 });
+
+test('computes best response from bottom-left opening', () => {
+  const env = new Map();
+  const input = {
+    moves: [
+      { player: 'X', position: { row: 2, column: 0 } },
+      { player: 'O', position: { row: 1, column: 1 } },
+    ],
+  };
+  const result = ticTacToeMove(JSON.stringify(input), env);
+  const output = JSON.parse(result);
+  expect(output.moves).toHaveLength(3);
+  expect(output.moves[2]).toEqual({
+    player: 'X',
+    position: { row: 1, column: 0 },
+  });
+});


### PR DESCRIPTION
## Summary
- extend ticTacToe tests with a scenario starting from bottom-left
- ensure minimax handles non-terminal evaluation correctly

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684473c666f0832e870dc7c588d07ebe