### PR TITLE
Improve tests for createOutputDropdownHandler

### DIFF
--- a/test/browser/toys.createOutputDropdownHandler.test.js
+++ b/test/browser/toys.createOutputDropdownHandler.test.js
@@ -29,6 +29,12 @@ describe('createOutputDropdownHandler', () => {
     );
   });
 
+  test('returns a function that accepts an event object', () => {
+    const handler = createOutputDropdownHandler(jest.fn(), jest.fn(), {});
+    expect(typeof handler).toBe('function');
+    expect(handler.length).toBe(1);
+  });
+
   test('should work with different event targets', () => {
     const mockHandleDropdownChange = jest.fn();
     const mockGetData = jest.fn().mockReturnValue({});


### PR DESCRIPTION
## Summary
- extend tests for `createOutputDropdownHandler` to verify it returns a function

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684473c628e0832ebdef4c00d11ee540