### PR TITLE
Add runtime test to kill Stryker mutant

### DIFF
--- a/test/browser/createUpdateTextInputValue.runtime.test.js
+++ b/test/browser/createUpdateTextInputValue.runtime.test.js
@@ -1,0 +1,18 @@
+import { test, expect, jest } from '@jest/globals';
+import { createUpdateTextInputValue } from '../../src/browser/toys.js';
+
+test('createUpdateTextInputValue runtime works', () => {
+  const textInput = {};
+  const mockDom = {
+    getTargetValue: jest.fn(() => 'val'),
+    setValue: jest.fn()
+  };
+
+  const handler = createUpdateTextInputValue(textInput, mockDom);
+  expect(typeof handler).toBe('function');
+
+  handler({});
+
+  expect(mockDom.getTargetValue).toHaveBeenCalled();
+  expect(mockDom.setValue).toHaveBeenCalledWith(textInput, 'val');
+});


### PR DESCRIPTION
## Summary
- add runtime test for `createUpdateTextInputValue`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68446b1a70d4832e83a122cd38b06fd7