### PR TITLE
Add static import test for toys deep copy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ The following Jest features cause issues with Stryker mutation testing and must 
 - Do not load unexported functions by reading their source and using `eval`.
 - Prefer testing internal logic through an exported function that calls the function under test.
 - If direct testing is necessary, export the function instead of using the parse-eval method.
-- Avoid using dynamic asynchronous `import()` to load source modules in tests.
+- Do not use dynamic `import()` to load source modules. Use static imports instead.
 
 ## Code Style
 

--- a/test/browser/getDeepStateCopy.toys.runtime.test.js
+++ b/test/browser/getDeepStateCopy.toys.runtime.test.js
@@ -1,0 +1,10 @@
+import { test, expect } from '@jest/globals';
+import { getDeepStateCopy } from '../../src/browser/toys.js';
+
+test('getDeepStateCopy from toys module clones deeply when imported', () => {
+  const original = { nested: { value: 'a' } };
+  const copy = getDeepStateCopy(original);
+  expect(copy).toEqual(original);
+  expect(copy).not.toBe(original);
+  expect(copy.nested).not.toBe(original.nested);
+});


### PR DESCRIPTION
## Summary
- switch `getDeepStateCopy.toys.runtime.test.js` to use a static import
- clarify in `AGENTS.md` that dynamic imports should not be used

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684473c6c4e8832e8df402378ecabc4a