### PR TITLE
Add return function test for dropdown listener

### DIFF
--- a/test/browser/toys.test.js
+++ b/test/browser/toys.test.js
@@ -39,6 +39,14 @@ describe('createAddDropdownListener', () => {
       mockOnChange
     );
   });
+
+  it('returns a listener function', () => {
+    const addListener = createAddDropdownListener(jest.fn(), {
+      addEventListener: jest.fn(),
+    });
+
+    expect(typeof addListener).toBe('function');
+  });
 });
 
 describe('toys', () => {


### PR DESCRIPTION
## Summary
- extend `createAddDropdownListener` tests to verify the returned value is a function

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6844787db22c832e8060b29db0a62715