### PR TITLE
Add test to kill mutation in createOnRemove

### DIFF
--- a/test/browser/toys.createOnRemove.test.js
+++ b/test/browser/toys.createOnRemove.test.js
@@ -23,6 +23,11 @@ describe('createOnRemove', () => {
     handler = createOnRemove(rows, render, keyToRemove);
   });
 
+  it('returns an event handler function', () => {
+    const result = createOnRemove(rows, render, keyToRemove);
+    expect(typeof result).toBe('function');
+  });
+
   it('removes the specified key from the rows object', () => {
     // Verify the key exists initially
     expect(rows).toHaveProperty(keyToRemove);


### PR DESCRIPTION
## Summary
- ensure `createOnRemove` returns a function

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6844787bfee0832eba5688f9864cfa4c