### PR TITLE
Improve tests for createOnRemove

### DIFF
--- a/test/browser/toys.createOnRemove.test.js
+++ b/test/browser/toys.createOnRemove.test.js
@@ -23,6 +23,12 @@ describe('createOnRemove', () => {
     handler = createOnRemove(rows, render, keyToRemove);
   });
 
+  it('returns a function that expects an event parameter', () => {
+    const onRemove = createOnRemove(rows, render, keyToRemove);
+    expect(typeof onRemove).toBe('function');
+    expect(onRemove.length).toBe(1);
+  });
+
   it('removes the specified key from the rows object', () => {
     // Verify the key exists initially
     expect(rows).toHaveProperty(keyToRemove);


### PR DESCRIPTION
## Summary
- extend `createOnRemove` tests with a return-type check

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6844787eae80832e82f63682ba7eb10f