### PR TITLE
Add test for toys getDeepStateCopy

### DIFF
--- a/test/browser/toys.getDeepStateCopy.test.js
+++ b/test/browser/toys.getDeepStateCopy.test.js
@@ -1,0 +1,15 @@
+import { describe, it, expect } from '@jest/globals';
+import { getDeepStateCopy } from '../../src/browser/toys.js';
+
+describe('getDeepStateCopy from toys.js', () => {
+  it('creates a deep clone of the provided object', () => {
+    const original = { level1: { level2: { value: 'x' } } };
+    const copy = getDeepStateCopy(original);
+    expect(copy).toEqual(original);
+    expect(copy).not.toBe(original);
+    expect(copy.level1).not.toBe(original.level1);
+    expect(copy.level1.level2).not.toBe(original.level1.level2);
+    copy.level1.level2.value = 'y';
+    expect(original.level1.level2.value).toBe('x');
+  });
+});


### PR DESCRIPTION
## Summary
- add missing coverage for the `getDeepStateCopy` helper in `toys.js`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68447882603c832e893d35fb7e81f91a