### PR TITLE
Add test to kill media section mutant

### DIFF
--- a/test/generator/mediaSections.mutant.test.js
+++ b/test/generator/mediaSections.mutant.test.js
@@ -1,0 +1,20 @@
+import { describe, test, expect } from '@jest/globals';
+import { generateBlogOuter } from '../../src/generator/generator.js';
+
+describe('media sections mutant', () => {
+  test('blog html should not contain undefined when media present', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'VIDE1',
+          title: 'Video Post',
+          publicationDate: '2024-01-01',
+          youtube: { id: 'abc123', timestamp: 0, title: 'Example' },
+        },
+      ],
+    };
+    const html = generateBlogOuter(blog);
+    expect(html.includes('undefined')).toBe(false);
+    expect(html).toContain('<iframe');
+  });
+});


### PR DESCRIPTION
## Summary
- add a regression test ensuring media sections generate valid HTML

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684478818498832e905297fdaaac2bac