### PR TITLE
Add test for output handler return value

### DIFF
--- a/test/browser/toys.createOutputDropdownHandler.test.js
+++ b/test/browser/toys.createOutputDropdownHandler.test.js
@@ -99,4 +99,18 @@ describe('createOutputDropdownHandler', () => {
       })
     );
   });
+
+  test('returns the value from handleDropdownChange', () => {
+    const expected = 'result';
+    const mockHandleDropdownChange = jest.fn().mockReturnValue(expected);
+    const mockGetData = jest.fn();
+    const handler = createOutputDropdownHandler(
+      mockHandleDropdownChange,
+      mockGetData,
+      {},
+    );
+
+    const result = handler({ currentTarget: {} });
+    expect(result).toBe(expected);
+  });
 });


### PR DESCRIPTION
## Summary
- verify `createOutputDropdownHandler` returns the value from `handleDropdownChange`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6844787e8564832e897f770ebe3b3064