### PR TITLE
Add static test for media sections

### DIFF
--- a/test/generator/mediaContentConfig.static.test.js
+++ b/test/generator/mediaContentConfig.static.test.js
@@ -1,0 +1,37 @@
+import { describe, test, expect } from '@jest/globals';
+import { generateBlog } from '../../src/generator/generator.js';
+
+const header = '<body>';
+const footer = '</body>';
+const wrapHtml = c => ['<html>', c, '</html>'].join('');
+
+describe('MEDIA_CONTENT_CONFIG via generateBlog', () => {
+  test('generates media sections for youtube, audio and illustration', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'YT01',
+          title: 'Video',
+          publicationDate: '2024-01-01',
+          youtube: { id: 'abc123', timestamp: 0, title: 'Example' },
+        },
+        {
+          key: 'AU01',
+          title: 'Audio',
+          publicationDate: '2024-01-02',
+          audio: { fileType: 'mp3' },
+        },
+        {
+          key: 'IMG1',
+          title: 'Image',
+          publicationDate: '2024-01-03',
+          illustration: { fileType: 'png', altText: 'Alt' },
+        },
+      ],
+    };
+    const html = generateBlog({ blog, header, footer }, wrapHtml);
+    expect(html).toContain('<iframe');
+    expect(html).toContain('<audio');
+    expect(html).toContain('<img');
+  });
+});


### PR DESCRIPTION
## Summary
- add a static-import test covering generation of youtube, audio and illustration sections

## Testing
- `npm test --silent`
- `npm run lint --silent`


------
https://chatgpt.com/codex/tasks/task_e_68447c7eeab8832ebabfb5f638102820