### PR TITLE
Add dropdown listener coverage

### DIFF
--- a/test/browser/toys.test.js
+++ b/test/browser/toys.test.js
@@ -48,6 +48,18 @@ describe('createAddDropdownListener', () => {
 
     expect(typeof addListener).toBe('function');
   });
+
+  it('invokes the attached handler and returns undefined', () => {
+    const mockOnChange = jest.fn();
+    const mockDom = {
+      addEventListener: jest.fn(),
+    };
+    const addListener = createAddDropdownListener(mockOnChange, mockDom);
+    const result = addListener({});
+
+    expect(result).toBeUndefined();
+    expect(mockDom.addEventListener).toHaveBeenCalled();
+  });
 });
 
 describe('toys', () => {


### PR DESCRIPTION
## Summary
- extend tests for `createAddDropdownListener`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68447c7e58b4832eae799451802d8dfb