### PR TITLE
Add regression test for dropdown listener

### DIFF
--- a/test/browser/toys.test.js
+++ b/test/browser/toys.test.js
@@ -48,6 +48,15 @@ describe('createAddDropdownListener', () => {
 
     expect(typeof addListener).toBe('function');
   });
+
+  it('creates a single-argument handler', () => {
+    const addListener = createAddDropdownListener(jest.fn(), {
+      addEventListener: jest.fn(),
+    });
+
+    expect(typeof addListener).toBe('function');
+    expect(addListener.length).toBe(1);
+  });
 });
 
 describe('toys', () => {


### PR DESCRIPTION
## Summary
- test the arity of the handler returned by `createAddDropdownListener`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68447c7c9eec832e855ed8dfa4e7d3a2