### PR TITLE
Add test for blog status transitions

### DIFF
--- a/test/browser/data.blogStatusConstants.test.js
+++ b/test/browser/data.blogStatusConstants.test.js
@@ -1,0 +1,24 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { fetchAndCacheBlogData } from '../../src/browser/data.js';
+
+describe('BLOG_STATUS constants integration', () => {
+  it('fetchAndCacheBlogData transitions status from loading to loaded', async () => {
+    const state = {
+      blog: null,
+      blogStatus: 'idle',
+      blogError: null,
+      blogFetchPromise: null,
+    };
+    const fetchFn = jest.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    );
+    const loggers = { logInfo: jest.fn(), logError: jest.fn() };
+
+    const promise = fetchAndCacheBlogData(state, fetchFn, loggers);
+    expect(state.blogStatus).toBe('loading');
+
+    await promise;
+
+    expect(state.blogStatus).toBe('loaded');
+  });
+});


### PR DESCRIPTION
## Summary
- add integration test ensuring blog status transitions from loading to loaded

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68447c7b88ac832e96e9a257a19c5944