### PR TITLE
Add test for media display logic

### DIFF
--- a/test/generator/mediaDisplayRules.test.js
+++ b/test/generator/mediaDisplayRules.test.js
@@ -1,0 +1,16 @@
+import { describe, test, expect } from '@jest/globals';
+import { generateBlog } from '../../src/generator/generator.js';
+
+const header = '<body>';
+const footer = '</body>';
+const wrapHtml = c => ['<html>', c, '</html>'].join('');
+
+describe('MEDIA_DISPLAY_RULES integration', () => {
+  test('generateBlog omits media sections when post has none', () => {
+    const blog = { posts: [{ key: 'NONE1', title: 'No Media', publicationDate: '2024-06-01' }] };
+    const html = generateBlog({ blog, header, footer }, wrapHtml);
+    expect(html).not.toContain('<img');
+    expect(html).not.toContain('<audio');
+    expect(html).not.toContain('<iframe');
+  });
+});


### PR DESCRIPTION
## Summary
- add a unit test covering absence of media sections when posts lack media

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68447c811988832ebf6cb72871314796