### PR TITLE
Add test for publication date formatting

### DIFF
--- a/test/generator/dateFormatting.test.js
+++ b/test/generator/dateFormatting.test.js
@@ -1,0 +1,22 @@
+import { test, expect } from '@jest/globals';
+import { generateBlog } from '../../src/generator/generator.js';
+
+const header = '<body>';
+const footer = '</body>';
+const wrapHtml = html => `<html>${html}</html>`;
+
+test('generateBlog formats publication dates with year included', () => {
+  const blog = {
+    posts: [
+      {
+        key: 'DATE1',
+        title: 'Dated Post',
+        publicationDate: '2022-05-04',
+        content: ['Example'],
+      },
+    ],
+  };
+
+  const html = generateBlog({ blog, header, footer }, wrapHtml);
+  expect(html).toContain('4 May 2022');
+});


### PR DESCRIPTION
## Summary
- add unit test verifying `generateBlog` formats publication dates using the expected locale and options

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68447c8007f4832e884249aceee6d03c