### PR TITLE
Add coverage for toy output dropdown options

### DIFF
--- a/test/generator/generator.test.js
+++ b/test/generator/generator.test.js
@@ -481,4 +481,33 @@ describe('Blog Generator', () => {
     const expectedHtml = `<html><body><article class="entry" id="FIRS1"><div class="key full-width">▄▄▄▄▄▄▄▄▄▄</div><div class="value full-width">▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄</div><div class="key article-title">FIRS1</div><div class="value"><h2><a href="#FIRS1">First</a></h2></div><div class="key">pubAt</div><p class="value metadata">1 Jan 2024</p><div class="key">text</div><blockquote class="value"><div class="corner corner-tl"><div class="h-line"></div><div class="v-line"></div></div><div class="corner corner-tr"><div class="h-line"></div><div class="v-line"></div></div><div class="corner corner-bl"><div class="h-line"></div><div class="v-line"></div></div><div class="corner corner-br"><div class="h-line"></div><div class="v-line"></div></div><p>This is the content of the first post.</p></blockquote><div class="key"></div><blockquote class="value"><div class="corner corner-tl"><div class="h-line"></div><div class="v-line"></div></div><div class="corner corner-tr"><div class="h-line"></div><div class="v-line"></div></div><div class="corner corner-bl"><div class="h-line"></div><div class="v-line"></div></div><div class="corner corner-br"><div class="h-line"></div><div class="v-line"></div></div><p>This is a quote with multiple lines.</p><p>Here is the second one.</p></blockquote></article></body></html>`;
     expect(html).toBe(expectedHtml);
   });
+
+  test('output select includes all toy output options', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'TOYOPT',
+          title: 'Toy Options',
+          publicationDate: '2024-01-01',
+          toy: {
+            modulePath: './toys/2024-03-01/calculator.js',
+            functionName: 'calculator',
+          },
+        },
+      ],
+    };
+
+    const html = generateBlog({ blog, header, footer }, wrapHtml);
+    const options = [
+      'text',
+      'pre',
+      'tic-tac-toe',
+      'battleship-solitaire-fleet',
+      'battleship-solitaire-clues-presenter',
+    ];
+
+    options.forEach(option => {
+      expect(html).toContain(`<option value="${option}">${option}</option>`);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- extend generator tests to verify all output dropdown options

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68447c7ff2a8832e857210ebd0a0f4d5