### PR TITLE
Add cleanup call count test for setupAddButton

### DIFF
--- a/test/browser/toys.setupAddButton.test.js
+++ b/test/browser/toys.setupAddButton.test.js
@@ -13,7 +13,7 @@ describe('setupAddButton', () => {
     mockDom = {
       setTextContent: jest.fn(),
       addEventListener: jest.fn(),
-      removeEventListener: jest.fn()
+      removeEventListener: jest.fn(),
     };
 
     button = {};
@@ -106,5 +106,16 @@ describe('setupAddButton', () => {
       'click',
       expect.any(Function)
     );
+  });
+
+  it('cleanup can be called multiple times', () => {
+    setupAddButton(mockDom, button, rows, render, disposers);
+
+    const cleanup = disposers[0];
+
+    cleanup();
+    cleanup();
+
+    expect(mockDom.removeEventListener).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
## Summary
- extend setupAddButton tests to ensure cleanup can be invoked multiple times

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68447c7f0bc4832eb54c9f0eac0cb6e2