### PR TITLE
Add spacing test for related links

### DIFF
--- a/test/generator/relatedLinks.spacing.test.js
+++ b/test/generator/relatedLinks.spacing.test.js
@@ -1,0 +1,34 @@
+import { describe, test, expect } from '@jest/globals';
+import { generateBlog } from '../../src/generator/generator.js';
+
+const header = '<body>';
+const footer = '</body>';
+const wrap = content => ['<html>', content, '</html>'].join('');
+
+describe('generateBlog related links spacing', () => {
+  test('omits extra spaces when optional fields are missing', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'SPC1',
+          title: 'Link Post',
+          publicationDate: '2024-01-01',
+          content: ['text'],
+          relatedLinks: [
+            {
+              url: 'https://example.com',
+              type: 'article'
+            }
+          ]
+        }
+      ]
+    };
+
+    const html = generateBlog({ blog, header, footer }, wrap);
+    const match = html.match(/<li>(.*?)<\/li>/);
+    expect(match).not.toBeNull();
+    expect(match[0]).toBe(
+      '<li><a href="https://example.com" target="_blank" rel="noopener">""</a></li>'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add regression test ensuring related links omit extra spaces when optional fields are absent

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68447c7cc0e4832e9e549b442ef67b83