### PR TITLE
Add unit test for createDispose

### DIFF
--- a/test/browser/toys.createDispose.test.js
+++ b/test/browser/toys.createDispose.test.js
@@ -26,4 +26,26 @@ describe('createDispose', () => {
     expect(dom.removeAllChildren).toHaveBeenCalledWith(container);
     expect(rows).toHaveLength(0);
   });
+
+  it('clears all registered disposers', () => {
+    const disposer1 = jest.fn();
+    const disposer2 = jest.fn();
+    const disposers = [disposer1, disposer2];
+    const dom = {
+      removeAllChildren: jest.fn(),
+    };
+    const container = {};
+    const rows = ['a', 'b'];
+
+    const dispose = createDispose(disposers, dom, container, rows);
+    expect(typeof dispose).toBe('function');
+
+    dispose();
+
+    expect(disposer1).toHaveBeenCalled();
+    expect(disposer2).toHaveBeenCalled();
+    expect(disposers).toHaveLength(0);
+    expect(rows).toHaveLength(0);
+    expect(dom.removeAllChildren).toHaveBeenCalledWith(container);
+  });
 });


### PR DESCRIPTION
## Summary
- enhance tests for `createDispose` to ensure all disposers are cleared

## Testing
- `npm install` (failed due to network error)
- `npm test` (failed: Error: Cannot find module '/workspace/dadeto/node_modules/.bin/jest')
- `npm run lint` (failed: needed to install eslint)


------
https://chatgpt.com/codex/tasks/task_e_68447c7d9b40832e89fd468ac3abe273