### PR TITLE
Add blockquote corner integration test

### DIFF
--- a/test/generator/createBlockquote.integration.test.js
+++ b/test/generator/createBlockquote.integration.test.js
@@ -1,0 +1,26 @@
+import { describe, test, expect } from '@jest/globals';
+import { generateBlog } from '../../src/generator/generator.js';
+
+const header = '<body>';
+const footer = '</body>';
+const wrapHtml = c => ['<html>', c, '</html>'].join('');
+
+describe('createBlockquote integration', () => {
+  test('generateBlog includes blockquote corners for quote content', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'BQ01',
+          title: 'Quote Post',
+          publicationDate: '2024-06-01',
+          content: [{ type: 'quote', content: 'Hello world' }],
+        },
+      ],
+    };
+    const html = generateBlog({ blog, header, footer }, wrapHtml);
+    expect(html).toContain('corner corner-tl');
+    expect(html).toContain('corner corner-tr');
+    expect(html).toContain('corner corner-bl');
+    expect(html).toContain('corner corner-br');
+  });
+});


### PR DESCRIPTION
## Summary
- add integration test covering blockquote corners in generated blog HTML

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6844870682b8832eb06450b433bf4bde