### PR TITLE
Add coverage for toy dropdown options

### DIFF
--- a/test/generator/toyOutputDropdown.test.js
+++ b/test/generator/toyOutputDropdown.test.js
@@ -1,0 +1,33 @@
+import { describe, test, expect } from '@jest/globals';
+import { generateBlog } from '../../src/generator/generator.js';
+
+const header = '<body>';
+const footer = '</body>';
+const wrapHtml = content => `<html>${content}</html>`;
+
+describe('toy output dropdown', () => {
+  test('generateBlog includes all output type options', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'TOYO1',
+          title: 'Toy Post',
+          publicationDate: '2024-01-01',
+          toy: { modulePath: './toys/2024-01-01/example.js', functionName: 'example' }
+        }
+      ]
+    };
+
+    const html = generateBlog({ blog, header, footer }, wrapHtml);
+    const options = [
+      '<option value="text">text</option>',
+      '<option value="pre">pre</option>',
+      '<option value="tic-tac-toe">tic-tac-toe</option>',
+      '<option value="battleship-solitaire-fleet">battleship-solitaire-fleet</option>',
+      '<option value="battleship-solitaire-clues-presenter">battleship-solitaire-clues-presenter</option>'
+    ];
+    options.forEach(option => {
+      expect(html).toContain(option);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a test verifying toy output dropdown contains all expected options

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68448704b8f8832eb18d4b2f34cecc4d