### PR TITLE
Add test for createUpdateTextInputValue uniqueness

### DIFF
--- a/test/browser/toys.createUpdateTextInputValue.test.js
+++ b/test/browser/toys.createUpdateTextInputValue.test.js
@@ -117,4 +117,10 @@ describe('createUpdateTextInputValue', () => {
     expect(mockDom.getTargetValue).toHaveBeenCalledWith(inputEvent);
     expect(mockDom.setValue).toHaveBeenCalledWith(textInput, testValue);
   });
+
+  it('returns a new handler instance on each call', () => {
+    const handler1 = createUpdateTextInputValue(textInput, mockDom);
+    const handler2 = createUpdateTextInputValue(textInput, mockDom);
+    expect(handler1).not.toBe(handler2);
+  });
 });


### PR DESCRIPTION
## Summary
- extend createUpdateTextInputValue tests to confirm each call returns a new handler

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684487042cf0832ebab9bf2eda6a367b