### PR TITLE
Add media label test

### DIFF
--- a/test/generator/mediaLabels.test.js
+++ b/test/generator/mediaLabels.test.js
@@ -1,0 +1,27 @@
+import { describe, test, expect } from '@jest/globals';
+import { generateBlog } from '../../src/generator/generator.js';
+
+const header = '<body>';
+const footer = '</body>';
+const wrapHtml = content => ['<html>', content, '</html>'].join('');
+
+describe('MEDIA_CONFIG labels', () => {
+  test('generateBlog uses expected labels for media sections', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'MEDIA',
+          title: 'Media Labels',
+          publicationDate: '2024-01-01',
+          illustration: { fileType: 'png', altText: 'Alt' },
+          audio: { fileType: 'mp3' },
+          youtube: { id: 'abc', timestamp: 0, title: 'Video' },
+        },
+      ],
+    };
+    const html = generateBlog({ blog, header, footer }, wrapHtml);
+    expect(html).toContain('<div class="key media">illus</div>');
+    expect(html).toContain('<div class="key media">audio</div>');
+    expect(html).toContain('<div class="key media">video</div>');
+  });
+});


### PR DESCRIPTION
## Summary
- add regression test for media section labels used by blog generator

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684487034ae0832e962b684fc1e130e8