### PR TITLE
Add missing test for ticTacToe null positions

### DIFF
--- a/test/toys/2025-04-06/ticTacToe.test.js
+++ b/test/toys/2025-04-06/ticTacToe.test.js
@@ -420,6 +420,20 @@ test('handles position as non-object', () => {
   });
 });
 
+test('handles null position gracefully', () => {
+  const env = new Map();
+  const input = {
+    moves: [{ player: 'X', position: null }],
+  };
+  const result = ticTacToeMove(JSON.stringify(input), env);
+  const output = JSON.parse(result);
+  expect(output.moves).toHaveLength(1);
+  expect(output.moves[0]).toEqual({
+    player: 'X',
+    position: { row: 1, column: 1 },
+  });
+});
+
 test('forces minimax to score a tie at max depth', () => {
   const env = new Map();
   const input = {


### PR DESCRIPTION
## Summary
- extend ticTacToe tests to handle null positions

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68448700c1d0832e84306c745f9fa866