### PR TITLE
Add failing fetch status test

### DIFF
--- a/test/browser/data.fetchErrorStatus.test.js
+++ b/test/browser/data.fetchErrorStatus.test.js
@@ -1,0 +1,20 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { fetchAndCacheBlogData } from '../../src/browser/data.js';
+
+describe('fetchAndCacheBlogData error status', () => {
+  it('sets blogStatus to "error" when fetch fails', async () => {
+    const state = {
+      blog: null,
+      blogStatus: 'idle',
+      blogError: null,
+      blogFetchPromise: null,
+    };
+    const fetchFn = jest.fn(() => Promise.resolve({ ok: false, status: 500 }));
+    const loggers = { logInfo: jest.fn(), logError: jest.fn() };
+
+    await fetchAndCacheBlogData(state, fetchFn, loggers).catch(() => {});
+
+    expect(state.blogStatus).toBe('error');
+    expect(loggers.logError).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add test covering blog fetch failure to verify error status

## Testing
- `npm run lint`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68448701828c832e8aa044519a462a25