### PR TITLE
Add repeated-disposal test

### DIFF
--- a/test/browser/toys.createValueElement.test.js
+++ b/test/browser/toys.createValueElement.test.js
@@ -123,4 +123,22 @@ describe('createValueElement', () => {
     // Ensure removeEventListener was called with the same handler
     expect(mockDom.removeEventListener).toHaveBeenCalledWith(el, eventName, handler);
   });
+
+  it('cleanup can be called multiple times', () => {
+    valueEl = createValueElement(
+      mockDom,
+      'multi',
+      keyEl,
+      textInput,
+      rows,
+      syncHiddenField,
+      disposers
+    );
+
+    const disposer = disposers[0];
+    disposer();
+    disposer();
+
+    expect(mockDom.removeEventListener).toHaveBeenCalledTimes(2);
+  });
 });


### PR DESCRIPTION
## Summary
- improve coverage for createValueElement by testing repeated disposer calls

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684494b046fc832e85e53edac4c61801