### PR TITLE
Add negative trade input test

### DIFF
--- a/test/toys/2025-03-30/cyberpunkAdventure.test.js
+++ b/test/toys/2025-03-30/cyberpunkAdventure.test.js
@@ -98,6 +98,26 @@ describe('Cyberpunk Text Game', () => {
     expect(tempData.state).toBe('transport:trade');
   });
 
+  test('shows trade prompt when input lacks trade keyword', () => {
+    tempData = {
+      name: 'Blaze',
+      state: 'transport:trade',
+      inventory: ['datapad'],
+      visited: [],
+    };
+    env.set('getData', () => ({ temporary: { CYBE1: tempData } }));
+    const result = cyberpunkAdventure('look around', env);
+    if (typeof result === 'object') {
+      expect(result.output).toMatch(/Do you want to trade/);
+      expect(result.nextState).toBe('transport:trade');
+    } else {
+      expect(result).toMatch(/Do you want to trade/);
+    }
+    expect(tempData.inventory).toContain('datapad');
+    expect(tempData.inventory).not.toContain('neural ticket');
+    expect(tempData.state).toBe('transport:trade');
+  });
+
   test('goes to Back Alley and finds stimpack (success)', () => {
     tempData = {
       name: 'Blaze',


### PR DESCRIPTION
## Summary
- add a unit test ensuring trading only happens when the input contains the `trade` keyword

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684494afaa78832ea43d0367e5bd98b0