### PR TITLE
Add blog status transition tests

### DIFF
--- a/test/browser/data.blogStatusTransition.test.js
+++ b/test/browser/data.blogStatusTransition.test.js
@@ -1,0 +1,34 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { fetchAndCacheBlogData } from '../../src/browser/data.js';
+
+describe('BLOG_STATUS transitions', () => {
+  it('sets loading then loaded on successful fetch', async () => {
+    const state = {
+      blog: null,
+      blogStatus: 'idle',
+      blogError: null,
+      blogFetchPromise: null,
+    };
+    const fetchFn = jest.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    );
+    const loggers = { logInfo: jest.fn(), logError: jest.fn() };
+    const promise = fetchAndCacheBlogData(state, fetchFn, loggers);
+    expect(state.blogStatus).toBe('loading');
+    await promise;
+    expect(state.blogStatus).toBe('loaded');
+  });
+
+  it('sets error status on fetch failure', async () => {
+    const state = {
+      blog: null,
+      blogStatus: 'idle',
+      blogError: null,
+      blogFetchPromise: null,
+    };
+    const fetchFn = jest.fn(() => Promise.reject(new Error('fail')));
+    const loggers = { logInfo: jest.fn(), logError: jest.fn() };
+    await fetchAndCacheBlogData(state, fetchFn, loggers);
+    expect(state.blogStatus).toBe('error');
+  });
+});


### PR DESCRIPTION
## Summary
- add new tests for fetchAndCacheBlogData to verify BLOG_STATUS transitions

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684494ae91a8832ea6f6b77ecb671413