### PR TITLE
Add tests for createAddDropdownListener

### DIFF
--- a/test/browser/createAddDropdownListener.additional.test.js
+++ b/test/browser/createAddDropdownListener.additional.test.js
@@ -1,0 +1,32 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { createAddDropdownListener } from '../../src/browser/toys.js';
+
+describe('createAddDropdownListener additional cases', () => {
+  it('attaches the change event and returns undefined', () => {
+    const onChange = jest.fn();
+    const dom = { addEventListener: jest.fn() };
+    const dropdown = {};
+    const addListener = createAddDropdownListener(onChange, dom);
+
+    const result = addListener(dropdown);
+
+    expect(result).toBeUndefined();
+    expect(dom.addEventListener).toHaveBeenCalledTimes(1);
+    expect(dom.addEventListener).toHaveBeenCalledWith(dropdown, 'change', onChange);
+  });
+
+  it('can attach the same handler to multiple dropdowns', () => {
+    const onChange = jest.fn();
+    const dom = { addEventListener: jest.fn() };
+    const dropdownA = {};
+    const dropdownB = {};
+    const addListener = createAddDropdownListener(onChange, dom);
+
+    addListener(dropdownA);
+    addListener(dropdownB);
+
+    expect(dom.addEventListener).toHaveBeenCalledTimes(2);
+    expect(dom.addEventListener).toHaveBeenNthCalledWith(1, dropdownA, 'change', onChange);
+    expect(dom.addEventListener).toHaveBeenNthCalledWith(2, dropdownB, 'change', onChange);
+  });
+});


### PR DESCRIPTION
## Summary
- extend coverage for `createAddDropdownListener`

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684494ae9198832e967101dddae2c874