### PR TITLE
Add test for createUpdateTextInputValue mutant

### DIFF
--- a/test/browser/createUpdateTextInputValue.mutant.test.js
+++ b/test/browser/createUpdateTextInputValue.mutant.test.js
@@ -1,0 +1,20 @@
+import { test, expect, jest } from '@jest/globals';
+import { createUpdateTextInputValue } from '../../src/browser/toys.js';
+
+test('createUpdateTextInputValue returns unary handler and updates value', () => {
+  const textInput = {};
+  const dom = {
+    getTargetValue: jest.fn(() => 'hello'),
+    setValue: jest.fn(),
+  };
+
+  const handler = createUpdateTextInputValue(textInput, dom);
+  expect(typeof handler).toBe('function');
+  expect(handler.length).toBe(1);
+
+  const event = {};
+  handler(event);
+
+  expect(dom.getTargetValue).toHaveBeenCalledWith(event);
+  expect(dom.setValue).toHaveBeenCalledWith(textInput, 'hello');
+});


### PR DESCRIPTION
## Summary
- add a focused test ensuring `createUpdateTextInputValue` returns a unary handler and updates the input value

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684494adfec0832eac400926ecd794b9