### PR TITLE
Add static test for normalizeContentItem

### DIFF
--- a/test/generator/normalizeContentItem.null.static.test.js
+++ b/test/generator/normalizeContentItem.null.static.test.js
@@ -1,0 +1,19 @@
+import { describe, test, expect } from '@jest/globals';
+import { generateBlogOuter } from '../../src/generator/generator.js';
+
+describe('normalizeContentItem null static import', () => {
+  test('generateBlogOuter handles null in post content array', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'NULL',
+          title: 'Null Post',
+          publicationDate: '2024-06-01',
+          content: [null],
+        },
+      ],
+    };
+    const html = generateBlogOuter(blog);
+    expect(html).toContain('<p class="value">null</p>');
+  });
+});


### PR DESCRIPTION
## Summary
- add a test that statically imports `generateBlogOuter` and verifies null
  content is handled correctly

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684494ad80b4832ebbdb6548083de437