### PR TITLE
Add test for createAddDropdownListener

### DIFF
--- a/test/browser/createAddDropdownListener.unit.test.js
+++ b/test/browser/createAddDropdownListener.unit.test.js
@@ -1,0 +1,21 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { createAddDropdownListener } from '../../src/browser/toys.js';
+
+describe('createAddDropdownListener (unit)', () => {
+  it('returns a listener that registers on change', () => {
+    const onChange = jest.fn();
+    const dom = { addEventListener: jest.fn() };
+    const dropdown = {};
+
+    const addListener = createAddDropdownListener(onChange, dom);
+    expect(typeof addListener).toBe('function');
+
+    addListener(dropdown);
+
+    expect(dom.addEventListener).toHaveBeenCalledWith(
+      dropdown,
+      'change',
+      onChange
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- ensure `createAddDropdownListener` returns a function and registers the listener

## Testing
- `npm test --silent`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684494ac01d4832ea6d419e7f58bae15