### PR TITLE
Add arity test for createHandleSubmit

### DIFF
--- a/test/browser/toys.createHandleSubmit.test.js
+++ b/test/browser/toys.createHandleSubmit.test.js
@@ -3,6 +3,9 @@ import * as toys from '../../src/browser/toys.js';
 const { createHandleSubmit } = toys;
 
 describe('createHandleSubmit', () => {
+  it('expects three parameters', () => {
+    expect(createHandleSubmit.length).toBe(3);
+  });
   it('should handle being called without arguments', () => {
     // This test verifies that the function can be called without throwing
     expect(() => {


### PR DESCRIPTION
## Summary
- extend `createHandleSubmit` tests to verify it takes 3 parameters

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684545cacbcc832e9468dc2226cd5066