### PR TITLE
Add tests for createOnRemove

### DIFF
--- a/test/browser/toys.createOnRemove.additional.test.js
+++ b/test/browser/toys.createOnRemove.additional.test.js
@@ -1,0 +1,24 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { createOnRemove } from '../../src/browser/toys.js';
+
+describe('createOnRemove additional tests', () => {
+  it('removes the key and returns undefined', () => {
+    const rows = { a: '1', b: '2' };
+    const render = jest.fn();
+    const event = { preventDefault: jest.fn() };
+    const handler = createOnRemove(rows, render, 'a');
+
+    const result = handler(event);
+
+    expect(result).toBeUndefined();
+    expect(rows).toEqual({ b: '2' });
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(render).toHaveBeenCalledTimes(1);
+  });
+
+  it('returned handler accepts one argument', () => {
+    const handler = createOnRemove({}, jest.fn(), 'x');
+    expect(typeof handler).toBe('function');
+    expect(handler.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests ensuring createOnRemove returns a handler that removes entries

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684545c80514832ea48b383ea181f3a5