### PR TITLE
Add test for removeAddListener cleanup

### DIFF
--- a/test/browser/toys.setupAddButton.test.js
+++ b/test/browser/toys.setupAddButton.test.js
@@ -118,4 +118,24 @@ describe('setupAddButton', () => {
 
     expect(mockDom.removeEventListener).toHaveBeenCalledTimes(2);
   });
+
+  it('cleanup removes the same handler that was added', () => {
+    let addedHandler;
+    mockDom.addEventListener.mockImplementation((_, eventType, handler) => {
+      if (eventType === 'click') {
+        addedHandler = handler;
+      }
+    });
+
+    setupAddButton(mockDom, button, rows, render, disposers);
+
+    const cleanup = disposers[0];
+    cleanup();
+
+    expect(mockDom.removeEventListener).toHaveBeenCalledWith(
+      button,
+      'click',
+      addedHandler
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- extend `setupAddButton` tests to ensure the cleanup removes the same handler that was added

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684545c7c590832eb1da33d6f392900a