### PR TITLE
Fix surviving createOnRemove mutant

### DIFF
--- a/test/browser/toys.createOnRemove.test.js
+++ b/test/browser/toys.createOnRemove.test.js
@@ -102,4 +102,19 @@ describe('createOnRemove', () => {
     expect(singleRow).toEqual({});
     expect(render).toHaveBeenCalledTimes(1);
   });
+
+  it('removes a key when called directly', () => {
+    const localRows = { a: 1, b: 2 };
+    const localRender = jest.fn();
+    const evt = { preventDefault: jest.fn() };
+
+    const fn = createOnRemove(localRows, localRender, 'a');
+    expect(typeof fn).toBe('function');
+
+    fn(evt);
+
+    expect(evt.preventDefault).toHaveBeenCalled();
+    expect(localRows).toEqual({ b: 2 });
+    expect(localRender).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- extend coverage of `createOnRemove` to ensure returned function is invoked

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684545ccda90832eae18c4139dd9e42c