### PR TITLE
Add tests for toy UI sections

### DIFF
--- a/test/generator/toyUiSections.mutant.test.js
+++ b/test/generator/toyUiSections.mutant.test.js
@@ -1,0 +1,27 @@
+import { describe, test, expect } from '@jest/globals';
+import { generateBlog } from '../../src/generator/generator.js';
+
+const header = '<body>';
+const footer = '</body>';
+const wrapHtml = content => `<html>${content}</html>`;
+
+describe('toy UI sections mutant', () => {
+  test('toy UI includes input, submit and output sections', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'TUIS1',
+          title: 'Toy UI Post',
+          publicationDate: '2024-01-01',
+          toy: { modulePath: './toys/2024-01-01/example.js', functionName: 'example' },
+        },
+      ],
+    };
+
+    const html = generateBlog({ blog, header, footer }, wrapHtml);
+    expect(html).toContain('<div class="key">in</div>');
+    expect(html).toContain('<div class="key"></div><div class="value"><button type="submit" disabled>Submit</button></div>');
+    expect(html).toContain('<div class="key">out</div>');
+    expect(html).toContain('This toy requires Javascript to run.');
+  });
+});


### PR DESCRIPTION
## Summary
- add a regression test that checks the toy UI sections are rendered

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68454624e000832e952d968050c5d55e