### PR TITLE
Add locale test for blog date formatting

### DIFF
--- a/test/generator/dateFormatting.test.js
+++ b/test/generator/dateFormatting.test.js
@@ -1,4 +1,4 @@
-import { test, expect } from '@jest/globals';
+import { test, expect, jest } from '@jest/globals';
 import { generateBlog } from '../../src/generator/generator.js';
 
 const header = '<body>';
@@ -19,4 +19,21 @@ test('generateBlog formats publication dates with year included', () => {
 
   const html = generateBlog({ blog, header, footer }, wrapHtml);
   expect(html).toContain('4 May 2022');
+});
+
+test('generateBlog formats dates using en-GB locale', () => {
+  const blog = {
+    posts: [
+      {
+        key: 'DATE2',
+        title: 'Another Post',
+        publicationDate: '2022-12-25',
+        content: ['Example'],
+      },
+    ],
+  };
+  const spy = jest.spyOn(Date.prototype, 'toLocaleDateString');
+  generateBlog({ blog, header, footer }, wrapHtml);
+  expect(spy).toHaveBeenCalledWith('en-GB', expect.any(Object));
+  spy.mockRestore();
 });


### PR DESCRIPTION
## Summary
- add test covering date locale usage in `generateBlog`

## Testing
- `npm test --silent`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684545cfffd0832e86e4f684317f0784