### PR TITLE
Add test covering createAddDropdownListener

### DIFF
--- a/test/browser/createAddDropdownListener.length.test.js
+++ b/test/browser/createAddDropdownListener.length.test.js
@@ -1,0 +1,12 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { createAddDropdownListener } from '../../src/browser/toys.js';
+
+describe('createAddDropdownListener signature', () => {
+  it('expects two parameters and returns a unary function', () => {
+    expect(createAddDropdownListener.length).toBe(2);
+    const dom = { addEventListener: jest.fn() };
+    const listener = createAddDropdownListener(jest.fn(), dom);
+    expect(typeof listener).toBe('function');
+    expect(listener.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test verifying createAddDropdownListener takes two parameters and returns a unary function

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684545cda9d4832e837cc62c3640a923