### PR TITLE
Add dynamic test for createOnRemove

### DIFF
--- a/test/browser/createOnRemove.dynamic.test.js
+++ b/test/browser/createOnRemove.dynamic.test.js
@@ -1,0 +1,15 @@
+import { describe, it, expect, jest } from '@jest/globals';
+
+describe('createOnRemove dynamic import', () => {
+  it('removes the key and calls render', async () => {
+    const { createOnRemove } = await import('../../src/browser/toys.js');
+    const rows = { a: 1 };
+    const render = jest.fn();
+    const event = { preventDefault: jest.fn() };
+    const handler = createOnRemove(rows, render, 'a');
+    handler(event);
+    expect(rows).toEqual({});
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(render).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add a dynamic import test for `createOnRemove`

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684545cb846c832e8771050587eb4725