### PR TITLE
Add test for footer warning

### DIFF
--- a/test/generator/footerWarningMessage.count.test.js
+++ b/test/generator/footerWarningMessage.count.test.js
@@ -1,0 +1,10 @@
+import { describe, test, expect } from '@jest/globals';
+import { generateBlogOuter } from '../../src/generator/generator.js';
+
+describe('footer warning message count', () => {
+  test('warning message appears exactly once', () => {
+    const html = generateBlogOuter({ posts: [] });
+    const matches = html.match(/All content is authored[^<]*/g) || [];
+    expect(matches).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure the blog footer warning appears exactly once

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684545c97a44832e95b7e7c448803a70