### PR TITLE
Add argument length test for update handler

### DIFF
--- a/test/browser/toys.createUpdateTextInputValue.test.js
+++ b/test/browser/toys.createUpdateTextInputValue.test.js
@@ -14,18 +14,22 @@ describe('createUpdateTextInputValue', () => {
     // Create a mock DOM utilities object
     mockDom = {
       getTargetValue: jest.fn(),
-      setValue: jest.fn()
+      setValue: jest.fn(),
     };
 
     // Create a mock event
     mockEvent = {
       target: {},
-      preventDefault: jest.fn()
+      preventDefault: jest.fn(),
     };
   });
 
   afterEach(() => {
     jest.clearAllMocks();
+  });
+
+  it('expects two arguments (textInput and dom)', () => {
+    expect(createUpdateTextInputValue.length).toBe(2);
   });
 
   it('returns a handler function that expects an event parameter', () => {
@@ -101,12 +105,12 @@ describe('createUpdateTextInputValue', () => {
     inputElement.value = testValue;
 
     // Mock getTargetValue to return the input's value
-    mockDom.getTargetValue.mockImplementation((event) => event.target.value);
+    mockDom.getTargetValue.mockImplementation(event => event.target.value);
 
     // Create a custom event with a target property
     const inputEvent = {
       target: inputElement,
-      preventDefault: jest.fn()
+      preventDefault: jest.fn(),
     };
 
     // Act


### PR DESCRIPTION
## Summary
- extend `createUpdateTextInputValue` tests to verify argument count

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684545d28f9c832eb4d9a009073b24ba