### PR TITLE
Add failing fetch test for blog status

### DIFF
--- a/test/browser/data.blogStatusConstants.test.js
+++ b/test/browser/data.blogStatusConstants.test.js
@@ -21,4 +21,17 @@ describe('BLOG_STATUS constants integration', () => {
 
     expect(state.blogStatus).toBe('loaded');
   });
+
+  it('fetchAndCacheBlogData transitions status to error on failure', async () => {
+    const state = {
+      blog: null,
+      blogStatus: 'idle',
+      blogError: null,
+      blogFetchPromise: null,
+    };
+    const fetchFn = jest.fn(() => Promise.reject(new Error('fail')));
+    const loggers = { logInfo: jest.fn(), logError: jest.fn() };
+    await fetchAndCacheBlogData(state, fetchFn, loggers);
+    expect(state.blogStatus).toBe('error');
+  });
 });


### PR DESCRIPTION
## Summary
- extend blog status tests to cover error case on fetch failure

## Testing
- `npm test --silent`
- `npm run lint --silent`

------
https://chatgpt.com/codex/tasks/task_e_684545d1b790832eb365565cbcddb34d