### PR TITLE
Add test for HTML escape helper

### DIFF
--- a/test/generator/applyAllHtmlEscapeReplacements.test.js
+++ b/test/generator/applyAllHtmlEscapeReplacements.test.js
@@ -1,0 +1,18 @@
+import { describe, test, expect } from '@jest/globals';
+import {
+  applyAllHtmlEscapeReplacements,
+  HTML_ESCAPE_REPLACEMENTS,
+} from '../../src/generator/html.js';
+
+describe('applyAllHtmlEscapeReplacements', () => {
+  test('escapes all HTML special characters', () => {
+    const input = '<div>"O\'Reilly" & others</div>';
+    const result = applyAllHtmlEscapeReplacements(
+      input,
+      HTML_ESCAPE_REPLACEMENTS
+    );
+    expect(result).toBe(
+      '&lt;div&gt;&quot;O&#039;Reilly&quot; &amp; others&lt;/div&gt;'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- cover `applyAllHtmlEscapeReplacements` to ensure HTML escaping works for all characters

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684545d1a654832ea2249573f29f3328