### PR TITLE
Add binding check for createUpdateTextInputValue

### DIFF
--- a/test/browser/toys.createUpdateTextInputValue.test.js
+++ b/test/browser/toys.createUpdateTextInputValue.test.js
@@ -127,4 +127,31 @@ describe('createUpdateTextInputValue', () => {
     const handler2 = createUpdateTextInputValue(textInput, mockDom);
     expect(handler1).not.toBe(handler2);
   });
+
+  it('binds the provided dom and textInput to the handler', () => {
+    const textInputA = {};
+    const textInputB = {};
+    const domA = {
+      getTargetValue: jest.fn(() => 'a'),
+      setValue: jest.fn(),
+    };
+    const domB = {
+      getTargetValue: jest.fn(() => 'b'),
+      setValue: jest.fn(),
+    };
+
+    const eventA = {};
+    const eventB = {};
+
+    const handlerA = createUpdateTextInputValue(textInputA, domA);
+    const handlerB = createUpdateTextInputValue(textInputB, domB);
+
+    handlerA(eventA);
+    handlerB(eventB);
+
+    expect(domA.getTargetValue).toHaveBeenCalledWith(eventA);
+    expect(domB.getTargetValue).toHaveBeenCalledWith(eventB);
+    expect(domA.setValue).toHaveBeenCalledWith(textInputA, 'a');
+    expect(domB.setValue).toHaveBeenCalledWith(textInputB, 'b');
+  });
 });


### PR DESCRIPTION
## Summary
- extend `createUpdateTextInputValue` unit tests to confirm the returned handler is bound to the provided DOM utilities and input element

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68454ae1f700832ebf4b071804042455