### PR TITLE
Replace dynamic import with static import in test

### DIFF
--- a/test/browser/processInputAndSetOutput.dynamic.test.js
+++ b/test/browser/processInputAndSetOutput.dynamic.test.js
@@ -1,12 +1,10 @@
 import { describe, it, expect, jest } from '@jest/globals';
+import { processInputAndSetOutput } from '../../src/browser/toys.js';
 
-// Dynamically import processInputAndSetOutput so coverage maps to this test
+// Validate setOutput behavior using a static import
 
-describe('processInputAndSetOutput dynamic setOutput', () => {
-  it('stores the result keyed by article id', async () => {
-    const { processInputAndSetOutput } = await import(
-      '../../src/browser/toys.js'
-    );
+describe('processInputAndSetOutput setOutput', () => {
+  it('stores the result keyed by article id', () => {
 
     const inputElement = { value: 'input' };
     const parent = {};


### PR DESCRIPTION
## Summary
- use a static import in `processInputAndSetOutput.dynamic.test.js`

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684545ca8d00832ea30d7adb76b7d7aa