### PR TITLE
Add new handler instance test

### DIFF
--- a/test/browser/toys.createOutputDropdownHandler.test.js
+++ b/test/browser/toys.createOutputDropdownHandler.test.js
@@ -132,4 +132,10 @@ describe('createOutputDropdownHandler', () => {
     expect(typeof handler).toBe('function');
     expect(handler.length).toBe(1);
   });
+
+  test('returns a new handler instance on each invocation', () => {
+    const handler1 = createOutputDropdownHandler(jest.fn(), jest.fn(), {});
+    const handler2 = createOutputDropdownHandler(jest.fn(), jest.fn(), {});
+    expect(handler1).not.toBe(handler2);
+  });
 });


### PR DESCRIPTION
## Summary
- extend tests for `createOutputDropdownHandler` to check each call returns a new handler instance

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68454ae46660832e8349b8cf4396b8db