### PR TITLE
Add callback test for createAddDropdownListener

### DIFF
--- a/test/browser/createAddDropdownListener.callback.test.js
+++ b/test/browser/createAddDropdownListener.callback.test.js
@@ -1,0 +1,28 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { createAddDropdownListener } from '../../src/browser/toys.js';
+
+describe('createAddDropdownListener callback behavior', () => {
+  it('invokes onChange when the event fires', () => {
+    const onChange = jest.fn();
+    const dropdown = {};
+    const dom = {
+      addEventListener: jest.fn((el, event, handler) => {
+        // Immediately invoke the handler to simulate event dispatch
+        handler({ currentTarget: el });
+      }),
+    };
+
+    const addListener = createAddDropdownListener(onChange, dom);
+    expect(addListener.length).toBe(1);
+
+    addListener(dropdown);
+
+    expect(dom.addEventListener).toHaveBeenCalledWith(
+      dropdown,
+      'change',
+      onChange
+    );
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith({ currentTarget: dropdown });
+  });
+});


### PR DESCRIPTION
## Summary
- add regression test ensuring createAddDropdownListener invokes the callback when the event is triggered

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68454adf296c832e90f9442113ac6b3f