### PR TITLE
Add test for unique handler creation

### DIFF
--- a/test/browser/toys.createOutputDropdownHandler.test.js
+++ b/test/browser/toys.createOutputDropdownHandler.test.js
@@ -126,6 +126,12 @@ describe('createOutputDropdownHandler', () => {
     expect(result).toBe(expected);
   });
 
+  test('returns a new handler instance on each call', () => {
+    const handler1 = createOutputDropdownHandler(jest.fn(), jest.fn(), {});
+    const handler2 = createOutputDropdownHandler(jest.fn(), jest.fn(), {});
+    expect(handler1).not.toBe(handler2);
+  });
+
   test('expects three arguments and returns a unary function', () => {
     const handler = createOutputDropdownHandler(jest.fn(), jest.fn(), {});
     expect(createOutputDropdownHandler.length).toBe(3);


### PR DESCRIPTION
## Summary
- extend createOutputDropdownHandler tests with unique instance check

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68454addc754832e92e788af5cd96d28