### PR TITLE
Fix surviving mutation by stricter link test

### DIFF
--- a/test/generator/defaultRelatedLinkAttrs.test.js
+++ b/test/generator/defaultRelatedLinkAttrs.test.js
@@ -22,5 +22,8 @@ describe('DEFAULT_RELATED_LINK_ATTRS usage', () => {
     };
     const html = generateBlog({ blog, header, footer }, wrapHtml);
     expect(html).toContain('target="_blank" rel="noopener"');
+    expect(html).toContain(
+      '<a href="https://example.com" target="_blank" rel="noopener">"Example"</a>'
+    );
   });
 });


### PR DESCRIPTION
## Summary
- enhance `DEFAULT_RELATED_LINK_ATTRS` test to check full anchor markup

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68454ae144d8832e82273829d1a26f19