### PR TITLE
Add unit test for dropdown handler creation

### DIFF
--- a/test/browser/toys.createOutputDropdownHandler.test.js
+++ b/test/browser/toys.createOutputDropdownHandler.test.js
@@ -132,4 +132,10 @@ describe('createOutputDropdownHandler', () => {
     expect(typeof handler).toBe('function');
     expect(handler.length).toBe(1);
   });
+
+  test('returns a new handler instance on each call', () => {
+    const handler1 = createOutputDropdownHandler(jest.fn(), jest.fn(), {});
+    const handler2 = createOutputDropdownHandler(jest.fn(), jest.fn(), {});
+    expect(handler1).not.toBe(handler2);
+  });
 });


### PR DESCRIPTION
## Summary
- add coverage for createOutputDropdownHandler by ensuring new handler instances are created

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68454ae71af0832eaa60aba47d3b4d01