### PR TITLE
Add arity check for createOnRemove

### DIFF
--- a/test/browser/toys.createOnRemove.test.js
+++ b/test/browser/toys.createOnRemove.test.js
@@ -17,10 +17,17 @@ describe('createOnRemove', () => {
     rows = {
       [keyToRemove]: 'value1',
       key2: 'value2',
-      key3: 'value3'
+      key3: 'value3',
     };
     render = jest.fn();
     handler = createOnRemove(rows, render, keyToRemove);
+  });
+
+  it('exposes expected arity for factory and handler', () => {
+    expect(createOnRemove.length).toBe(3);
+    const fn = createOnRemove(rows, render, keyToRemove);
+    expect(typeof fn).toBe('function');
+    expect(fn.length).toBe(1);
   });
 
   it('returns an event handler function', () => {
@@ -39,7 +46,7 @@ describe('createOnRemove', () => {
     expect(rows).not.toHaveProperty(keyToRemove);
     expect(rows).toEqual({
       key2: 'value2',
-      key3: 'value3'
+      key3: 'value3',
     });
   });
 
@@ -70,7 +77,7 @@ describe('createOnRemove', () => {
     expect(rows).toEqual({
       [keyToRemove]: 'value1',
       key2: 'value2',
-      key3: 'value3'
+      key3: 'value3',
     });
 
     // Should still call preventDefault and render


### PR DESCRIPTION
## Summary
- add test asserting createOnRemove exposes the expected arity

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68454ae66f0c832ea892e36adba7078a