### PR TITLE
Add length test for createOnRemove

### DIFF
--- a/test/browser/createOnRemove.length.test.js
+++ b/test/browser/createOnRemove.length.test.js
@@ -1,0 +1,13 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { createOnRemove } from '../../src/browser/toys.js';
+
+describe('createOnRemove argument length', () => {
+  it('expects three parameters and returns a unary function', () => {
+    expect(createOnRemove.length).toBe(3);
+    const rows = {};
+    const render = jest.fn();
+    const handler = createOnRemove(rows, render, 'key');
+    expect(typeof handler).toBe('function');
+    expect(handler.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add missing unit test for `createOnRemove`

## Testing
- `npm install`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68454ae8a59c832e94a8a8802af641b4