### PR TITLE
Improve createOnRemove tests

### DIFF
--- a/test/browser/toys.createOnRemove.additional.test.js
+++ b/test/browser/toys.createOnRemove.additional.test.js
@@ -21,4 +21,8 @@ describe('createOnRemove additional tests', () => {
     expect(typeof handler).toBe('function');
     expect(handler.length).toBe(1);
   });
+
+  it('createOnRemove expects three arguments', () => {
+    expect(createOnRemove.length).toBe(3);
+  });
 });


### PR DESCRIPTION
## Summary
- extend `createOnRemove` tests to verify argument count

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68454ae64c44832eb69ae789b2b5a088