### PR TITLE
Add test for media labels

### DIFF
--- a/test/generator/mediaConfig.count.test.js
+++ b/test/generator/mediaConfig.count.test.js
@@ -1,0 +1,30 @@
+import { describe, test, expect } from '@jest/globals';
+import { generateBlog } from '../../src/generator/generator.js';
+
+const header = '<body>';
+const footer = '</body>';
+const wrapHtml = c => ['<html>', c, '</html>'].join('');
+
+describe('MEDIA_CONFIG completeness', () => {
+  test('generateBlog outputs labels for all media types', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'ALLMEDIA',
+          title: 'All Media',
+          publicationDate: '2024-06-01',
+          illustration: { fileType: 'png', altText: 'Alt' },
+          audio: { fileType: 'mp3' },
+          youtube: { id: 'abc', timestamp: 0, title: 'Video' },
+        },
+      ],
+    };
+    const html = generateBlog({ blog, header, footer }, wrapHtml);
+    const matches = html.match(/<div class="key media">[^<]+<\/div>/g);
+    expect(matches).toEqual([
+      '<div class="key media">illus</div>',
+      '<div class="key media">audio</div>',
+      '<div class="key media">video</div>',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add a unit test verifying media labels are generated for all media types

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68454ae28340832ea98923f7986c575c