### PR TITLE
Improve fetch failure test coverage

### DIFF
--- a/test/browser/blogStatus.fetchFailure.test.js
+++ b/test/browser/blogStatus.fetchFailure.test.js
@@ -1,0 +1,23 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { fetchAndCacheBlogData } from '../../src/browser/data.js';
+
+describe('BLOG_STATUS fetch failure handling', () => {
+  it('sets status to error on fetch rejection', async () => {
+    const state = {
+      blog: null,
+      blogStatus: 'idle',
+      blogError: null,
+      blogFetchPromise: null,
+    };
+    const fetchFn = jest.fn(() => Promise.reject(new Error('fail')));
+    const loggers = { logInfo: jest.fn(), logError: jest.fn() };
+
+    await fetchAndCacheBlogData(state, fetchFn, loggers);
+
+    expect(state.blogStatus).toBe('error');
+    expect(loggers.logError).toHaveBeenCalledWith(
+      'Error fetching blog data:',
+      expect.any(Error)
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test covering fetch error path to verify status update

## Testing
- `npm run lint` *(fails: cannot find module '@eslint/js')*
- `npm test` *(fails: cannot find module jest)*

------
https://chatgpt.com/codex/tasks/task_e_68454adcdef4832ea18ccd3171b1e39c