### PR TITLE
Add test for remove button cleanup

### DIFF
--- a/test/browser/toys.setupRemoveButton.test.js
+++ b/test/browser/toys.setupRemoveButton.test.js
@@ -89,6 +89,17 @@ describe('setupRemoveButton', () => {
     );
   });
 
+  it('cleanup can be called multiple times', () => {
+    setupRemoveButton(mockDom, button, rows, render, rowKey, disposers);
+
+    const cleanup = disposers[0];
+
+    cleanup();
+    cleanup();
+
+    expect(mockDom.removeEventListener).toHaveBeenCalledTimes(2);
+  });
+
   it('handles clicking when the key does not exist in rows', () => {
     const nonExistentKey = 'nonExistent';
 


### PR DESCRIPTION
## Summary
- verify remove button cleanup can be called multiple times

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68454ae36db8832eb365ae2ccd8057fc