### PR TITLE
Add test for createDispose

### DIFF
--- a/test/browser/toys.createDispose.test.js
+++ b/test/browser/toys.createDispose.test.js
@@ -70,4 +70,17 @@ describe('createDispose', () => {
     expect(dom.removeAllChildren).toHaveBeenCalledTimes(2);
     expect(rows).toHaveLength(0);
   });
+
+  it('returns a zero argument function', () => {
+    const disposers = [];
+    const dom = {
+      removeAllChildren: jest.fn(),
+    };
+    const container = {};
+    const rows = [];
+
+    const dispose = createDispose(disposers, dom, container, rows);
+    expect(typeof dispose).toBe('function');
+    expect(dispose.length).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary
- ensure createDispose returns a zero-argument function

## Testing
- `npm test` *(fails: The requested module '../../src/browser/toys.js' does not provide an export named 'parseJSONResult')*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68455f2e1574832ebcc36aeeedc1a8c1