### PR TITLE
Add test for createInputDropdownHandler default case

### DIFF
--- a/test/browser/toys.test.js
+++ b/test/browser/toys.test.js
@@ -1663,6 +1663,25 @@ describe('createInputDropdownHandler', () => {
     });
   });
 
+  describe('when select value is unknown', () => {
+    it('falls back to the default handler', () => {
+      const selectValue = 'unknown';
+      const getValue = jest.fn(element =>
+        element === select ? selectValue : null
+      );
+      const dom = {
+        ...baseDom,
+        getValue,
+      };
+
+      const handler = createInputDropdownHandler(dom);
+
+      expect(() => handler(event)).not.toThrow();
+      expect(hide).toHaveBeenCalledWith(textInput);
+      expect(disable).toHaveBeenCalledWith(textInput);
+    });
+  });
+
   describe('getText', () => {
     it('should call response.text() and return its result', async () => {
       // Arrange


### PR DESCRIPTION
## Summary
- extend `createInputDropdownHandler` tests with coverage for unknown dropdown values

## Testing
- `npm test` *(fails: SyntaxError: The requested module '../../src/browser/toys.js' does not provide an export named 'parseJSONResult')*
- `npm run lint` *(warnings only)*

------
https://chatgpt.com/codex/tasks/task_e_68455f2d3a18832e9c26e53b3d015d6f