### PR TITLE
Add blogStatus fetch transition test

### DIFF
--- a/test/browser/data.test.js
+++ b/test/browser/data.test.js
@@ -267,6 +267,23 @@ describe('getData, setData, and getDeepStateCopy', () => {
     expect(result).toBe(state);
   });
 
+  it('getData sets status to loading then loaded when fetch completes', async () => {
+    const blogData = { title: 'blog' };
+    fetchFn = jest.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve(blogData) })
+    );
+    const loggers = { logInfo: logFn, logError: errorFn, logWarning: warnFn };
+
+    getData(state, fetchFn, loggers);
+
+    expect(state.blogStatus).toBe('loading');
+    const promise = state.blogFetchPromise;
+    await promise;
+
+    expect(state.blogStatus).toBe('loaded');
+    expect(state.blog).toEqual(blogData);
+  });
+
   it('setData preserves existing blog if incoming state omits it', () => {
     state.blog = { title: 'preserved' };
     const incomingState = { temporary: true }; // no blog field


### PR DESCRIPTION
## Summary
- ensure `getData` updates blogStatus from `loading` to `loaded`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: "parseJSONResult" export not found)*

------
https://chatgpt.com/codex/tasks/task_e_68455f2c9520832e93afa56ca0cf6a37