### PR TITLE
Add regression test for TAG_OPEN constant

### DIFF
--- a/test/generator/html.constantSource.test.js
+++ b/test/generator/html.constantSource.test.js
@@ -1,0 +1,12 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, test, expect } from '@jest/globals';
+
+const sourcePath = path.join(process.cwd(), 'src/generator/html.js');
+
+describe('html constants source definitions', () => {
+  test('TAG_OPEN constant is defined as <', () => {
+    const src = fs.readFileSync(sourcePath, 'utf8');
+    expect(src).toMatch(/export const TAG_OPEN = '<';/);
+  });
+});


### PR DESCRIPTION
## Summary
- add test verifying TAG_OPEN definition in `html.js`

## Testing
- `npm test` *(fails: SyntaxError "parseJSONResult" export missing)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68455f2c2970832ebd67ffc2283da9ff