### PR TITLE
Add test for date formatting options

### DIFF
--- a/test/generator/dateFormatting.test.js
+++ b/test/generator/dateFormatting.test.js
@@ -37,3 +37,27 @@ test('generateBlog formats dates using en-GB locale', () => {
   expect(spy).toHaveBeenCalledWith('en-GB', expect.any(Object));
   spy.mockRestore();
 });
+
+test('generateBlog uses numeric day, short month, and numeric year', () => {
+  const blog = {
+    posts: [
+      {
+        key: 'DATE3',
+        title: 'Format Options',
+        publicationDate: '2022-01-02',
+        content: ['Example'],
+      },
+    ],
+  };
+  const spy = jest.spyOn(Date.prototype, 'toLocaleDateString');
+  generateBlog({ blog, header, footer }, wrapHtml);
+  expect(spy).toHaveBeenCalledWith(
+    'en-GB',
+    expect.objectContaining({
+      day: 'numeric',
+      month: 'short',
+      year: 'numeric',
+    })
+  );
+  spy.mockRestore();
+});


### PR DESCRIPTION
## Summary
- add an assertion ensuring the blog generator passes expected `toLocaleDateString` options

## Testing
- `npm test` *(fails: The requested module '../../src/browser/toys.js' does not provide an export named 'parseJSONResult')*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68455f2ab434832ebb21810d3a95c984