### PR TITLE
Add test for negative tic tac toe moves

### DIFF
--- a/test/presenters/ticTacToeBoard.test.js
+++ b/test/presenters/ticTacToeBoard.test.js
@@ -220,6 +220,24 @@ describe('createTicTacToeBoardElement', () => {
     );
   });
 
+  it('ignores moves with negative row or column', () => {
+    const input = JSON.stringify({
+      moves: [
+        { player: 'X', position: { row: -1, column: 0 } },
+        { player: 'O', position: { row: 0, column: -1 } },
+        { player: 'X', position: { row: 1, column: 1 } }
+      ]
+    });
+    const el = createTicTacToeBoardElement(input, mockDom());
+    expect(el.textContent).toBe(
+      '   |   |   \n' +
+      '---+---+---\n' +
+      '   | X |   \n' +
+      '---+---+---\n' +
+      '   |   |   '
+    );
+  });
+
   it('renders an empty board for empty string input', () => {
     const el = createTicTacToeBoardElement('', mockDom());
     expect(el.tagName).toBe('pre');


### PR DESCRIPTION
## Summary
- add regression test verifying negative tic tac toe moves are ignored

## Testing
- `npm test` *(fails: SyntaxError: The requested module '../../src/browser/toys.js' does not provide an export named 'parseJSONResult')*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68455f2a81a8832ea0da34468933699a