### PR TITLE
Add media section coverage

### DIFF
--- a/test/generator/mediaDisplayRules.test.js
+++ b/test/generator/mediaDisplayRules.test.js
@@ -13,4 +13,23 @@ describe('MEDIA_DISPLAY_RULES integration', () => {
     expect(html).not.toContain('<audio');
     expect(html).not.toContain('<iframe');
   });
+
+  test('generateBlog includes media sections when post has media', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'MEDIA1',
+          title: 'With Media',
+          publicationDate: '2024-06-01',
+          illustration: { fileName: 'img', fileType: 'png', altText: 'alt' },
+          audio: { fileType: 'mp3' },
+          youtube: { id: 'vid', timestamp: 0, title: 'Video' },
+        },
+      ],
+    };
+    const html = generateBlog({ blog, header, footer }, wrapHtml);
+    expect(html).toContain('<img');
+    expect(html).toContain('<audio');
+    expect(html).toContain('<iframe');
+  });
 });


### PR DESCRIPTION
## Summary
- add test verifying media sections render when posts contain media

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68455f28e154832ebd577b0b505c6bcd