### PR TITLE
Add test for fetchAndCacheBlogData status transitions

### DIFF
--- a/test/browser/fetchAndCacheBlogData.status.additional.test.js
+++ b/test/browser/fetchAndCacheBlogData.status.additional.test.js
@@ -1,0 +1,21 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { fetchAndCacheBlogData } from '../../src/browser/data.js';
+
+describe('fetchAndCacheBlogData status transitions', () => {
+  it('sets status to loading then loaded on success', async () => {
+    const state = {
+      blog: null,
+      blogStatus: 'idle',
+      blogError: null,
+      blogFetchPromise: null,
+    };
+    const fetchFn = jest.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    );
+    const loggers = { logInfo: jest.fn(), logError: jest.fn() };
+    const promise = fetchAndCacheBlogData(state, fetchFn, loggers);
+    expect(state.blogStatus).toBe('loading');
+    await promise;
+    expect(state.blogStatus).toBe('loaded');
+  });
+});


### PR DESCRIPTION
## Summary
- add a unit test ensuring `fetchAndCacheBlogData` transitions the blog status
  from `idle` to `loading` and finally `loaded`

## Testing
- `npm test` *(fails: The requested module '../../src/browser/toys.js' does not provide an export named 'parseJSONResult')*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68455f289094832eaca018a5f1b5a7df