### PR TITLE
Add test covering full-width element markup

### DIFF
--- a/test/generator/fullWidthElement.test.js
+++ b/test/generator/fullWidthElement.test.js
@@ -23,6 +23,23 @@ describe('fullWidthElement integration', () => {
     expect(html).toContain(fullWidthElement);
   });
 
+  test('blog articles include full width markup', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'FW1',
+          title: 'Full Width Test',
+          publicationDate: '2024-01-01',
+          content: ['Paragraph'],
+        },
+      ],
+    };
+
+    const html = generateBlog({ blog, header, footer }, wrapHtml);
+    expect(html).toContain('<div class="key full-width">');
+    expect(html).toContain('<div class="value full-width">');
+  });
+
   test('fullWidthElement has expected structure', () => {
     expect(fullWidthElement).not.toHaveLength(0);
     expect(fullWidthElement).toContain('class="key full-width"');


### PR DESCRIPTION
## Summary
- extend fullWidthElement tests to check for markup in generated HTML

## Testing
- `npm run lint`
- `npm test test/generator/fullWidthElement.test.js`
- `npm test` *(fails: SyntaxError: The requested module '../../src/browser/toys.js' does not provide an export named 'parseJSONResult')*

------
https://chatgpt.com/codex/tasks/task_e_68455f27cbc4832e93fa98912ddf132d