### PR TITLE
Improve coverage for related link attributes

### DIFF
--- a/test/generator/defaultRelatedLinkAttrs.test.js
+++ b/test/generator/defaultRelatedLinkAttrs.test.js
@@ -15,15 +15,39 @@ describe('DEFAULT_RELATED_LINK_ATTRS usage', () => {
           publicationDate: '2024-01-01',
           content: ['Test'],
           relatedLinks: [
-            { url: 'https://example.com', type: 'article', title: 'Example' }
-          ]
-        }
-      ]
+            { url: 'https://example.com', type: 'article', title: 'Example' },
+          ],
+        },
+      ],
     };
     const html = generateBlog({ blog, header, footer }, wrapHtml);
     expect(html).toContain('target="_blank" rel="noopener"');
     expect(html).toContain(
       '<a href="https://example.com" target="_blank" rel="noopener">"Example"</a>'
     );
+  });
+
+  test('only one set of default attributes appears', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'LINK2',
+          title: 'Example2',
+          publicationDate: '2024-01-02',
+          content: ['Test2'],
+          relatedLinks: [
+            {
+              url: 'https://example.com/2',
+              type: 'article',
+              title: 'Example2',
+            },
+          ],
+        },
+      ],
+    };
+
+    const html = generateBlog({ blog, header, footer }, wrapHtml);
+    const matches = html.match(/target="_blank" rel="noopener"/g) || [];
+    expect(matches).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary
- add test ensuring a single occurrence of default related link attributes

## Testing
- `npm run lint`
- `npm test` *(fails: The requested module '../../src/browser/toys.js' does not provide an export named 'parseJSONResult')*

------
https://chatgpt.com/codex/tasks/task_e_68455f26ed44832eb76cad41b4746a1d