### PR TITLE
Add test for createDispose export

### DIFF
--- a/test/browser/createDispose.export.test.js
+++ b/test/browser/createDispose.export.test.js
@@ -1,0 +1,11 @@
+import { describe, it, expect } from '@jest/globals';
+
+// Import the module within the test to ensure coverage of the export line
+
+describe('createDispose export', () => {
+  it('is a function that expects four parameters', async () => {
+    const { createDispose } = await import('../../src/browser/toys.js');
+    expect(typeof createDispose).toBe('function');
+    expect(createDispose.length).toBe(4);
+  });
+});


### PR DESCRIPTION
## Summary
- add a test to load `createDispose` at runtime and verify its arity

## Testing
- `npm test` *(fails: SyntaxError: The requested module '../../src/browser/toys.js' does not provide an export named 'parseJSONResult')*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68455f25a2ac832e8536f9450d2d37a4