### PR TITLE
Extend generator tests for missing link sections

### DIFF
--- a/test/generator/generator.test.js
+++ b/test/generator/generator.test.js
@@ -259,6 +259,7 @@ describe('Blog Generator', () => {
     expect(htmlNoLinks).toContain('<article class="entry" id="NOL2">');
     expect(htmlNoLinks).not.toMatch('<div class="key">links</div>');
     expect(htmlNoLinks).not.toMatch('related-links');
+    expect(htmlNoLinks).not.toContain('undefined');
   });
 
   test('should omit related links section when value is not an array', () => {
@@ -278,6 +279,7 @@ describe('Blog Generator', () => {
     expect(html).toContain('<article class="entry" id="STRL">');
     expect(html).not.toMatch('<div class="key">links</div>');
     expect(html).not.toMatch('related-links');
+    expect(html).not.toContain('undefined');
   });
 
   test('should escape related link fields when optional values are missing', () => {


### PR DESCRIPTION
## Summary
- add assertions to ensure related link sections never include `'undefined'`

## Testing
- `npm run lint`
- `npm test` *(fails: SyntaxError for missing `parseJSONResult` export)*

------
https://chatgpt.com/codex/tasks/task_e_68455f253094832e8332480e535fa02d