### PR TITLE
Add test to cover getDeepStateCopy arrays

### DIFF
--- a/test/browser/getDeepStateCopy.toys.array.test.js
+++ b/test/browser/getDeepStateCopy.toys.array.test.js
@@ -1,0 +1,13 @@
+import { describe, it, expect } from '@jest/globals';
+import { getDeepStateCopy } from '../../src/browser/toys.js';
+
+describe('getDeepStateCopy arrays from toys.js', () => {
+  it('creates a deep copy of objects containing arrays', () => {
+    const original = { arr: [1, 2, { x: 3 }] };
+    const copy = getDeepStateCopy(original);
+    expect(copy).toEqual(original);
+    expect(copy).not.toBe(original);
+    expect(copy.arr).not.toBe(original.arr);
+    expect(copy.arr[2]).not.toBe(original.arr[2]);
+  });
+});


### PR DESCRIPTION
## Summary
- add missing array copy test for `getDeepStateCopy` in `toys.js`

## Testing
- `npm run lint`
- `npm test` *(fails: SyntaxError: The requested module '../../src/browser/toys.js' does not provide an export named 'parseJSONResult')*

------
https://chatgpt.com/codex/tasks/task_e_68455f252af4832e936d7b64cfface4e