### PR TITLE
Extend coverage for add button cleanup

### DIFF
--- a/test/browser/setupButtonCleanup.test.js
+++ b/test/browser/setupButtonCleanup.test.js
@@ -24,6 +24,26 @@ describe('button cleanup helpers', () => {
     );
   });
 
+  it('setupAddButton disposer removes the specific listener that was added', () => {
+    const dom = {
+      setTextContent: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    };
+    const button = {};
+    const rows = {};
+    const render = jest.fn();
+    const disposers = [];
+
+    setupAddButton(dom, button, rows, render, disposers);
+
+    const [, , onAdd] = dom.addEventListener.mock.calls[0];
+    const dispose = disposers[0];
+    dispose();
+
+    expect(dom.removeEventListener).toHaveBeenCalledWith(button, 'click', onAdd);
+  });
+
   it('setupRemoveButton disposer removes event listener', () => {
     const dom = {
       setTextContent: jest.fn(),


### PR DESCRIPTION
## Summary
- add test verifying add-button disposer uses same listener

## Testing
- `npm test` *(fails: SyntaxError: The requested module '../../src/browser/toys.js' does not provide an export named 'parseJSONResult')*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68455f25d7b0832e9de9f3b98e83dc9a