### PR TITLE
Add media labels test

### DIFF
--- a/test/generator/mediaSections.mutant.test.js
+++ b/test/generator/mediaSections.mutant.test.js
@@ -17,4 +17,26 @@ describe('media sections mutant', () => {
     expect(html.includes('undefined')).toBe(false);
     expect(html).toContain('<iframe');
   });
+
+  test('blog html includes labeled sections for all media types', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'ALLMEDIA',
+          title: 'All Media',
+          publicationDate: '2024-01-01',
+          illustration: { fileType: 'png', altText: 'Alt' },
+          audio: { fileType: 'mp3' },
+          youtube: { id: 'abc', timestamp: 0, title: 'Video' },
+        },
+      ],
+    };
+    const html = generateBlogOuter(blog);
+    expect(html).toContain('<div class="key media">illus</div>');
+    expect(html).toContain('<div class="key media">audio</div>');
+    expect(html).toContain('<div class="key media">video</div>');
+    expect(html).toContain('<img');
+    expect(html).toContain('<audio');
+    expect(html).toContain('<iframe');
+  });
 });


### PR DESCRIPTION
## Summary
- extend mediaSections.mutant tests to verify every media label and element

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6845711371b0832e85298358c1e01df7