### PR TITLE
Add width preservation test

### DIFF
--- a/test/toys/2025-05-08/parseConfig.width.mutant.test.js
+++ b/test/toys/2025-05-08/parseConfig.width.mutant.test.js
@@ -1,0 +1,12 @@
+import { describe, test, expect } from '@jest/globals';
+import { generateFleet } from '../../../src/toys/2025-05-08/battleshipSolitaireFleet.js';
+
+const env = new Map([['getRandomNumber', () => 0]]);
+
+describe('parseConfig width mutant', () => {
+  test('preserves non-string width values', () => {
+    const cfg = { width: true, height: 2, ships: [1] };
+    const result = JSON.parse(generateFleet(JSON.stringify(cfg), env));
+    expect(result.width).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure generateFleet preserves non-string width values

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68457111be04832eaec0f8e94fda053c