### PR TITLE
Add failing mutant test

### DIFF
--- a/test/browser/createAddDropdownListener.mutant.test.js
+++ b/test/browser/createAddDropdownListener.mutant.test.js
@@ -1,0 +1,24 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { createAddDropdownListener } from '../../src/browser/toys.js';
+
+describe('createAddDropdownListener mutation check', () => {
+  it('returns a listener that registers and invokes onChange', () => {
+    const onChange = jest.fn();
+    const dropdown = {};
+    const dom = {
+      addEventListener: jest.fn((el, evt, handler) => {
+        handler();
+      }),
+    };
+
+    const addListener = createAddDropdownListener(onChange, dom);
+    expect(typeof addListener).toBe('function');
+    expect(addListener.length).toBe(1);
+
+    const result = addListener(dropdown);
+
+    expect(result).toBeUndefined();
+    expect(dom.addEventListener).toHaveBeenCalledWith(dropdown, 'change', onChange);
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add additional test to ensure `createAddDropdownListener` returns a listener that registers a change handler

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6845710c17a8832e9f64ad0c80baee3d