### PR TITLE
Add parseJSONResult tests

### DIFF
--- a/test/browser/parseJSONResult.unit.test.js
+++ b/test/browser/parseJSONResult.unit.test.js
@@ -1,0 +1,13 @@
+import { describe, it, expect } from '@jest/globals';
+import { parseJSONResult } from '../../src/browser/toys.js';
+
+describe('parseJSONResult', () => {
+  it('returns parsed object for valid JSON', () => {
+    const obj = { a: 1 };
+    expect(parseJSONResult(JSON.stringify(obj))).toEqual(obj);
+  });
+
+  it('returns null for invalid JSON', () => {
+    expect(parseJSONResult('invalid')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for `parseJSONResult`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6845710b3928832e89e30afaa9b02587