### PR TITLE
Add null-input test for generateClues

### DIFF
--- a/test/toys/2025-05-11/battleshipSolitaireClues.null.mutant.test.js
+++ b/test/toys/2025-05-11/battleshipSolitaireClues.null.mutant.test.js
@@ -1,0 +1,10 @@
+import { describe, it, expect } from '@jest/globals';
+import { generateClues } from '../../../src/toys/2025-05-11/battleshipSolitaireClues.js';
+
+describe('generateClues null input handling', () => {
+  it('returns invalid fleet structure and does not throw', () => {
+    expect(() => generateClues('null')).not.toThrow();
+    const output = JSON.parse(generateClues('null'));
+    expect(output).toEqual({ error: 'Invalid fleet structure' });
+  });
+});


### PR DESCRIPTION
## Summary
- add a dedicated test verifying `generateClues` handles `null` input without throwing

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6845710ababc832e871ef5b08a4e3743