### PR TITLE
Add test to dispose number input listener

### DIFF
--- a/test/browser/toys.createNumberInput.test.js
+++ b/test/browser/toys.createNumberInput.test.js
@@ -87,4 +87,19 @@ describe('createNumberInput', () => {
     // Assert
     expect(mockOnChange).toHaveBeenCalledWith(mockEvent);
   });
+
+  it('provides a disposer that removes the input listener', () => {
+    createNumberInput('1', mockOnChange, mockDom);
+
+    const [[inputEl, , handler]] = mockDom.addEventListener.mock.calls;
+    expect(typeof inputEl._dispose).toBe('function');
+
+    inputEl._dispose();
+
+    expect(mockDom.removeEventListener).toHaveBeenCalledWith(
+      inputEl,
+      'input',
+      handler
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- test that `createNumberInput` provides a disposer to remove the input listener

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68457109def8832e804f07b603f3a5d8