### PR TITLE
Add test for createAddDropdownListener

### DIFF
--- a/test/browser/createAddDropdownListener.mutationKill.test.js
+++ b/test/browser/createAddDropdownListener.mutationKill.test.js
@@ -1,0 +1,21 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { createAddDropdownListener } from '../../src/browser/toys.js';
+
+// Additional test targeting Stryker survivor around toys.js line 132
+// Ensures returned function registers the change handler
+
+describe('createAddDropdownListener mutant killer', () => {
+  it('registers change handler and returns undefined', () => {
+    const dom = { addEventListener: jest.fn() };
+    const onChange = jest.fn();
+    const dropdown = {};
+
+    const addListener = createAddDropdownListener(onChange, dom);
+    expect(typeof addListener).toBe('function');
+
+    const result = addListener(dropdown);
+
+    expect(result).toBeUndefined();
+    expect(dom.addEventListener).toHaveBeenCalledWith(dropdown, 'change', onChange);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure `createAddDropdownListener` registers a change handler and returns `undefined`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68457108b2f8832ea359bc72260e6293