### PR TITLE
Strengthen generator constants test

### DIFF
--- a/test/generator/generator.constants.test.js
+++ b/test/generator/generator.constants.test.js
@@ -1,10 +1,5 @@
-import { describe, test, expect, beforeAll } from '@jest/globals';
-
-let generateBlogOuter;
-
-beforeAll(async () => {
-  ({ generateBlogOuter } = await import('../../src/generator/generator.js'));
-});
+import { describe, test, expect } from '@jest/globals';
+import { generateBlogOuter } from '../../src/generator/generator.js';
 
 describe('generator constants usage', () => {
   test('blog output includes container id and footer classes', () => {
@@ -52,5 +47,13 @@ describe('generator constants usage', () => {
     expect(html).toContain(
       '</div><script type="module" src="browser/main.js" defer></script>'
     );
+  });
+
+  test('warning message appears exactly once', () => {
+    const html = generateBlogOuter({ posts: [] });
+    const msg =
+      'All content is authored by Matt Heard and is <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">CC BY-NC-SA 4.0</a>, unless otherwise noted.';
+    const matches = html.match(new RegExp(msg, 'g')) || [];
+    expect(matches.length).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- convert dynamic import to static import in generator.constants.test.js
- verify footer copyright message is present once

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68457107a8ac832ea08e24ad7803a878