### PR TITLE
Add createDispose empty disposers test

### DIFF
--- a/test/browser/toys.createDispose.test.js
+++ b/test/browser/toys.createDispose.test.js
@@ -83,4 +83,19 @@ describe('createDispose', () => {
     expect(typeof dispose).toBe('function');
     expect(dispose.length).toBe(0);
   });
+
+  it('handles empty disposers without errors', () => {
+    const disposers = [];
+    const dom = {
+      removeAllChildren: jest.fn(),
+    };
+    const container = {};
+    const rows = ['x'];
+
+    const dispose = createDispose(disposers, dom, container, rows);
+
+    expect(() => dispose()).not.toThrow();
+    expect(dom.removeAllChildren).toHaveBeenCalledWith(container);
+    expect(rows).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
## Summary
- extend `createDispose` tests for empty disposer list

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684571031154832e9d37f83393d2e96c