### PR TITLE
Add date format test

### DIFF
--- a/test/generator/dateFormat.test.js
+++ b/test/generator/dateFormat.test.js
@@ -1,0 +1,23 @@
+import { describe, test, expect } from '@jest/globals';
+import { generateBlog } from '../../src/generator/generator.js';
+
+const header = '<body>';
+const footer = '</body>';
+const wrapHtml = c => c;
+
+describe('date formatting', () => {
+  test('publication date is formatted using en-GB locale', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'DATE1',
+          title: 'Date Post',
+          publicationDate: '2024-05-04',
+          content: ['entry'],
+        },
+      ],
+    };
+    const html = generateBlog({ blog, header, footer }, wrapHtml);
+    expect(html).toContain('<p class="value metadata">4 May 2024</p>');
+  });
+});


### PR DESCRIPTION
## Summary
- add a unit test to verify blog post publication dates are formatted correctly

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68457101e704832eaa1c2202a422f60f