### PR TITLE
Add test for createOutputDropdownHandler

### DIFF
--- a/test/browser/createOutputDropdownHandler.mutant.test.js
+++ b/test/browser/createOutputDropdownHandler.mutant.test.js
@@ -1,0 +1,17 @@
+import { test, expect, jest } from '@jest/globals';
+import { createOutputDropdownHandler } from '../../src/browser/toys.js';
+
+test('createOutputDropdownHandler returns unary handler that delegates', () => {
+  const handleDropdownChange = jest.fn();
+  const getData = jest.fn();
+  const dom = {};
+
+  const handler = createOutputDropdownHandler(handleDropdownChange, getData, dom);
+  expect(typeof handler).toBe('function');
+  expect(handler.length).toBe(1);
+
+  const event = { currentTarget: {} };
+  handler(event);
+
+  expect(handleDropdownChange).toHaveBeenCalledWith(event.currentTarget, getData, dom);
+});


### PR DESCRIPTION
## Summary
- add a mutant-killing test for `createOutputDropdownHandler`

## Testing
- `npm test --silent`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6845710237a0832e9498bfa2ca0576de