### PR TITLE
Add test for invalid URL case

### DIFF
--- a/test/browser/toys.handleParsedResult.test.js
+++ b/test/browser/toys.handleParsedResult.test.js
@@ -57,4 +57,15 @@ describe('handleParsedResult', () => {
     expect(env.fetchFn).not.toHaveBeenCalled();
     expect(result).toBe(false);
   });
+
+  it('returns false when request.url is not a string', () => {
+    parsed = {
+      request: { url: 123 }
+    };
+
+    const result = handleParsedResult(parsed, env, options);
+
+    expect(env.fetchFn).not.toHaveBeenCalled();
+    expect(result).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- cover the case where `handleParsedResult` receives a request with a non-string `url`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68457100bf64832e8567c9ff3cb8c7c4