### PR TITLE
Add test for number input cleanup

### DIFF
--- a/test/browser/createNumberInput.dispose.test.js
+++ b/test/browser/createNumberInput.dispose.test.js
@@ -1,0 +1,30 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { createNumberInput } from '../../src/browser/toys.js';
+
+describe('createNumberInput disposer', () => {
+  it('removes the input event listener when _dispose is called', () => {
+    const mockInput = {};
+    const onChange = jest.fn();
+    let handler;
+    const dom = {
+      createElement: jest.fn(() => mockInput),
+      setType: jest.fn(),
+      setValue: jest.fn(),
+      addEventListener: jest.fn((el, event, h) => {
+        if (event === 'input') {handler = h;}
+      }),
+      removeEventListener: jest.fn(),
+    };
+
+    const input = createNumberInput('1', onChange, dom);
+
+    expect(typeof input._dispose).toBe('function');
+    dom.removeEventListener.mockClear();
+    input._dispose();
+    expect(dom.removeEventListener).toHaveBeenCalledWith(
+      mockInput,
+      'input',
+      handler
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add createNumberInput disposer test to strengthen event cleanup behavior

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684571005950832e845c931f34d9290a