### PR TITLE
Add battship clues null fleet test

### DIFF
--- a/test/toys/2025-05-11/battleshipSolitaireClues.test.js
+++ b/test/toys/2025-05-11/battleshipSolitaireClues.test.js
@@ -162,4 +162,9 @@ describe('generateClues', () => {
   it('does not throw when the fleet is null', () => {
     expect(() => generateClues('null')).not.toThrow();
   });
+
+  it('returns exact error string when fleet is null', () => {
+    const result = generateClues('null');
+    expect(result).toBe('{"error":"Invalid fleet structure"}');
+  });
 });


### PR DESCRIPTION
## Summary
- add unit test for `generateClues('null')` to verify returned error string

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68457114ff40832e9776ecd8d7867bfb