### PR TITLE
Add test for inputHandlers constant

### DIFF
--- a/test/browser/toys.inputHandlersSource.test.js
+++ b/test/browser/toys.inputHandlersSource.test.js
@@ -1,0 +1,13 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, test, expect } from '@jest/globals';
+
+const sourcePath = path.join(process.cwd(), 'src/browser/toys.js');
+
+describe('inputHandlers constant source', () => {
+  test('definition includes text and default handlers', () => {
+    const src = fs.readFileSync(sourcePath, 'utf8');
+    const regex = /const inputHandlers = \{\s*text: \(dom, container, textInput\) => \{[\s\S]*?\},\s*default: \(dom, _container, textInput\) => \{[\s\S]*?\}\s*\};/s;
+    expect(src).toMatch(regex);
+  });
+});


### PR DESCRIPTION
## Summary
- add a new unit test ensuring `inputHandlers` constant is intact

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6845711144d8832e9a90b8c2a044ed1b