### PR TITLE
Add missing test for dropdown listener

### DIFF
--- a/test/browser/createAddDropdownListener.error.test.js
+++ b/test/browser/createAddDropdownListener.error.test.js
@@ -1,0 +1,16 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { createAddDropdownListener } from '../../src/browser/toys.js';
+
+describe('createAddDropdownListener error propagation', () => {
+  it('propagates errors from dom.addEventListener', () => {
+    const onChange = jest.fn();
+    const dropdown = {};
+    const dom = {
+      addEventListener: jest.fn(() => {
+        throw new Error('fail');
+      }),
+    };
+    const addListener = createAddDropdownListener(onChange, dom);
+    expect(() => addListener(dropdown)).toThrow('fail');
+  });
+});


### PR DESCRIPTION
## Summary
- ensure createAddDropdownListener propagates DOM errors

## Testing
- `npm test --silent`
- `npm run lint --silent`

------
https://chatgpt.com/codex/tasks/task_e_6845710d2520832eb7b96adff108528e