### PR TITLE
Add test for createDispose with empty parameters

### DIFF
--- a/test/browser/toys.createDispose.empty.test.js
+++ b/test/browser/toys.createDispose.empty.test.js
@@ -1,0 +1,18 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { createDispose } from '../../src/browser/toys.js';
+
+describe('createDispose with empty arrays', () => {
+  it('returns a disposer function even with empty parameters', () => {
+    const disposers = [];
+    const dom = { removeAllChildren: jest.fn() };
+    const container = {};
+    const rows = [];
+
+    const dispose = createDispose(disposers, dom, container, rows);
+    expect(typeof dispose).toBe('function');
+    dispose();
+    expect(dom.removeAllChildren).toHaveBeenCalledWith(container);
+    expect(disposers).toHaveLength(0);
+    expect(rows).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add a unit test covering `createDispose` with empty arrays

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68457103aa84832e8efbe906268c65af