### PR TITLE
Add branch tests for input dropdown handler

### DIFF
--- a/test/browser/createInputDropdownHandler.default.test.js
+++ b/test/browser/createInputDropdownHandler.default.test.js
@@ -42,4 +42,45 @@ describe('createInputDropdownHandler default branch', () => {
     expect(hide).toHaveBeenCalledWith(textInput);
     expect(disable).toHaveBeenCalledWith(textInput);
   });
+
+  it('reveals and enables text input when select value is text', () => {
+    const select = {};
+    const container = {};
+    const textInput = {};
+    const event = {};
+
+    const getCurrentTarget = jest.fn(() => select);
+    const getParentElement = jest.fn(() => container);
+    const querySelector = jest.fn((_, selector) =>
+      selector === 'input[type="text"]' ? textInput : null
+    );
+    const getValue = jest.fn(() => 'text');
+    const reveal = jest.fn();
+    const enable = jest.fn();
+    const hide = jest.fn();
+    const disable = jest.fn();
+    const removeChild = jest.fn();
+    const addEventListener = jest.fn();
+    const getNextSibling = jest.fn(() => null);
+
+    const dom = {
+      getCurrentTarget,
+      getParentElement,
+      querySelector,
+      getValue,
+      reveal,
+      enable,
+      hide,
+      disable,
+      removeChild,
+      addEventListener,
+      getNextSibling,
+    };
+
+    const handler = createInputDropdownHandler(dom);
+    handler(event);
+
+    expect(reveal).toHaveBeenCalledWith(textInput);
+    expect(enable).toHaveBeenCalledWith(textInput);
+  });
 });


### PR DESCRIPTION
## Summary
- add test coverage for text and default branches of `createInputDropdownHandler`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684577193420832e8d902a5f7accad20