### PR TITLE
Improve coverage for convertArrayToKeyValueObject

### DIFF
--- a/test/browser/toys.convertArrayToKeyValueObject.test.js
+++ b/test/browser/toys.convertArrayToKeyValueObject.test.js
@@ -83,4 +83,18 @@ describe('convertArrayToKeyValueObject', () => {
     expect(convertArrayToKeyValueObject(123)).toEqual({});
     expect(convertArrayToKeyValueObject({})).toEqual({});
   });
+
+  it('should preserve falsy but defined values', () => {
+    const input = [
+      { key: 'count', value: 0 },
+      { key: 'active', value: false },
+      { key: 'empty', value: '' },
+    ];
+    const expected = {
+      count: 0,
+      active: false,
+      empty: '',
+    };
+    expect(convertArrayToKeyValueObject(input)).toEqual(expected);
+  });
 });


### PR DESCRIPTION
## Summary
- extend `convertArrayToKeyValueObject` tests to cover falsy values

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684576a3e1c0832ea0d952fd741b7723