### PR TITLE
Add parseJSONResult tests

### DIFF
--- a/test/browser/parseJSONResult.unit.test.js
+++ b/test/browser/parseJSONResult.unit.test.js
@@ -1,0 +1,19 @@
+import { describe, test, expect } from '@jest/globals';
+import { parseJSONResult } from '../../src/browser/toys.js';
+
+describe('parseJSONResult', () => {
+  test('returns null for invalid JSON', () => {
+    expect(parseJSONResult('not-json')).toBeNull();
+  });
+
+  test('returns parsed object for valid JSON', () => {
+    const obj = { a: 1 };
+    expect(parseJSONResult(JSON.stringify(obj))).toEqual(obj);
+  });
+
+  test('ignores leading and trailing whitespace', () => {
+    const obj = { b: 2 };
+    const input = `\n  ${JSON.stringify(obj)}  \t`;
+    expect(parseJSONResult(input)).toEqual(obj);
+  });
+});


### PR DESCRIPTION
## Summary
- test `parseJSONResult` directly via new unit tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684571010ef8832ebc39cfe67f2dc436