### PR TITLE
Improve objectUtils.mapValues test

### DIFF
--- a/test/utils/objectUtils.test.js
+++ b/test/utils/objectUtils.test.js
@@ -55,4 +55,12 @@ describe('mapValues', () => {
   test('handles empty objects', () => {
     expect(mapValues({}, v => v)).toEqual({});
   });
+
+  test('does not mutate the source object', () => {
+    const obj = { a: 1, b: 2 };
+    const copy = { ...obj };
+    const result = mapValues(obj, v => v + 1);
+    expect(obj).toEqual(copy);
+    expect(result).toEqual({ a: 2, b: 3 });
+  });
 });


### PR DESCRIPTION
## Summary
- add test confirming mapValues does not mutate its input

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684582ba2578832e81675e1549dc0289