### PR TITLE
Add coverage for pre presenter

### DIFF
--- a/test/browser/toys.setTextContent.test.js
+++ b/test/browser/toys.setTextContent.test.js
@@ -23,4 +23,30 @@ describe('setTextContent via handleDropdownChange', () => {
     expect(dom.createElement).toHaveBeenCalledWith('p');
     expect(dom.appendChild).toHaveBeenCalledWith(created, { tagName: 'P' });
   });
+
+  it('uses the pre presenter for "pre" output', () => {
+    const created = {};
+    const dom = {
+      querySelector: jest.fn(() => created),
+      removeAllChildren: jest.fn(),
+      appendChild: jest.fn(),
+      createElement: jest.fn(() => ({ tagName: 'PRE' })),
+      setTextContent: jest.fn(),
+    };
+    const dropdown = {
+      value: 'pre',
+      closest: jest.fn(() => ({ id: 'post-id' })),
+      parentNode: { querySelector: () => created },
+    };
+    const getData = jest.fn(() => ({ output: { 'post-id': 'hello' } }));
+
+    handleDropdownChange(dropdown, getData, dom);
+
+    expect(dom.createElement).toHaveBeenCalledWith('pre');
+    expect(dom.setTextContent).toHaveBeenCalledWith(
+      { tagName: 'PRE' },
+      'hello'
+    );
+    expect(dom.appendChild).toHaveBeenCalledWith(created, { tagName: 'PRE' });
+  });
 });


### PR DESCRIPTION
## Summary
- extend `toys.setTextContent.test.js` to verify the `pre` presenter path

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684582b71dc4832e9c06e63ad663b71f