### PR TITLE
Add test to kill mutation in makeDisplayBody

### DIFF
--- a/test/browser/toys.makeDisplayBody.test.js
+++ b/test/browser/toys.makeDisplayBody.test.js
@@ -42,4 +42,22 @@ describe('makeDisplayBody', () => {
       expect.anything()
     );
   });
+  it('calls the correct presenter based on key', () => {
+    const mockDom = {
+      removeAllChildren: jest.fn(),
+      appendChild: jest.fn(),
+      createElement: jest.fn(tag => ({ tagName: tag.toUpperCase(), textContent: '' })),
+      setTextContent: (el, text) => {
+        el.textContent = text;
+      },
+    };
+    const parent = {};
+    const displayBody = makeDisplayBody(mockDom, parent, 'text');
+    displayBody('hello');
+    expect(mockDom.createElement).toHaveBeenCalledWith('p');
+    expect(mockDom.appendChild).toHaveBeenCalledWith(
+      parent,
+      expect.objectContaining({ tagName: 'P', textContent: 'hello' })
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- extend makeDisplayBody tests to verify the correct presenter element is chosen

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684582bb883c832e9ebdd4a9b471fcbb