### PR TITLE
Improve error handling in tests

### DIFF
--- a/test/browser/toys.handleRequestResponse.test.js
+++ b/test/browser/toys.handleRequestResponse.test.js
@@ -8,8 +8,19 @@ describe('handleRequestResponse', () => {
   let mockResponse;
   let mockParent;
   let url;
+  /**
+   * Captures unhandled promise rejections during tests so they surface as
+   * failures instead of crashing the process. This helps Stryker mark mutants
+   * as killed rather than timing out when the promise chain is broken.
+   */
+  let unhandled;
 
   beforeEach(() => {
+    unhandled = (err) => {
+      throw err;
+    };
+    process.on('unhandledRejection', unhandled);
+
     url = 'https://example.com';
     mockResponse = {
       text: jest.fn().mockResolvedValue('response text'),
@@ -48,6 +59,7 @@ describe('handleRequestResponse', () => {
   });
 
   afterEach(() => {
+    process.off('unhandledRejection', unhandled);
     jest.clearAllMocks();
   });
 


### PR DESCRIPTION
## Summary
- ensure unhandled promise rejections fail tests in `handleRequestResponse`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684582b82f5c832e99338eb1e8cfc495