### PR TITLE
Add test for createHandleInputError

### DIFF
--- a/test/browser/createHandleInputError.test.js
+++ b/test/browser/createHandleInputError.test.js
@@ -1,0 +1,54 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { createHandleSubmit } from '../../src/browser/toys.js';
+
+describe('createHandleSubmit error handling via createHandleInputError', () => {
+  it('logs and warns when processing function throws', () => {
+    const addWarning = jest.fn();
+    const stopDefault = jest.fn();
+    const removeAllChildren = jest.fn();
+    const appendChild = jest.fn();
+    const createElement = jest.fn(() => ({}));
+    const setTextContent = jest.fn();
+
+    const dom = {
+      stopDefault,
+      addWarning,
+      removeAllChildren,
+      appendChild,
+      createElement,
+      setTextContent,
+    };
+
+    const env = {
+      errorFn: jest.fn(),
+      dom,
+      createEnv: jest.fn(() => ({})),
+      fetchFn: jest.fn(),
+    };
+
+    const elements = {
+      inputElement: { value: '' },
+      outputParentElement: {},
+      outputSelect: { value: 'text' },
+      article: { id: 'art' },
+    };
+
+    const processingFunction = jest.fn(() => {
+      throw new Error('boom');
+    });
+
+    const handler = createHandleSubmit(elements, processingFunction, env);
+
+    expect(() => handler({})).not.toThrow();
+
+    expect(env.errorFn).toHaveBeenCalledWith(
+      'Error processing input:',
+      expect.any(Error)
+    );
+    expect(addWarning).toHaveBeenCalledWith(elements.outputParentElement);
+    expect(removeAllChildren).toHaveBeenCalledWith(
+      elements.outputParentElement
+    );
+    expect(appendChild).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add a unit test to verify error handling uses dom.addWarning and cleans the output

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684582b8a4b8832ea1820239e344aeb0