### PR TITLE
Add tic-tac-toe presenter test

### DIFF
--- a/test/browser/toys.setTextContent.ticTacToe.test.js
+++ b/test/browser/toys.setTextContent.ticTacToe.test.js
@@ -1,0 +1,26 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { handleDropdownChange } from '../../src/browser/toys.js';
+
+describe('setTextContent via handleDropdownChange tic-tac-toe', () => {
+  it('uses the tic-tac-toe presenter for "tic-tac-toe" output', () => {
+    const created = {};
+    const dom = {
+      querySelector: jest.fn(() => created),
+      removeAllChildren: jest.fn(),
+      appendChild: jest.fn(),
+      createElement: jest.fn(tag => ({ tagName: tag.toUpperCase() })),
+      setTextContent: jest.fn(),
+    };
+    const dropdown = {
+      value: 'tic-tac-toe',
+      closest: jest.fn(() => ({ id: 'post-ttt' })),
+      parentNode: { querySelector: () => created },
+    };
+    const getData = jest.fn(() => ({ output: { 'post-ttt': '{}' } }));
+
+    handleDropdownChange(dropdown, getData, dom);
+
+    expect(dom.createElement).toHaveBeenCalledWith('pre');
+    expect(dom.appendChild).toHaveBeenCalledWith(created, { tagName: 'PRE' });
+  });
+});


### PR DESCRIPTION
## Summary
- add a test ensuring the tic-tac-toe presenter is used by `handleDropdownChange`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684582b7c390832e8eed21c635ec3cf0