### PR TITLE
Add runtime test for HTML_TAG_NAME

### DIFF
--- a/test/generator/html.constant.runtime.test.js
+++ b/test/generator/html.constant.runtime.test.js
@@ -1,0 +1,11 @@
+import { describe, test, expect } from '@jest/globals';
+
+// Dynamically import within the test to ensure coverage of constant initialization
+
+describe('HTML_TAG_NAME runtime constant', () => {
+  test('HTML_TAG_NAME is html and used by createHtmlTag', async () => {
+    const { HTML_TAG_NAME, createHtmlTag } = await import('../../src/generator/html.js');
+    expect(HTML_TAG_NAME).toBe('html');
+    expect(createHtmlTag('hi')).toBe('<html lang="en">hi</html>');
+  });
+});


### PR DESCRIPTION
## Summary
- add runtime test to ensure HTML_TAG_NAME constant is evaluated during tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6845888c3e3c832e9f34285f11d678c1