### PR TITLE
Add test for repeated dropdown delegation

### DIFF
--- a/test/browser/toys.createOutputDropdownHandler.test.js
+++ b/test/browser/toys.createOutputDropdownHandler.test.js
@@ -165,4 +165,22 @@ describe('createOutputDropdownHandler', () => {
     expect(handle1).toHaveBeenCalledTimes(1);
     expect(handle2).toHaveBeenCalledTimes(1);
   });
+
+  test('returned handler delegates for multiple events', () => {
+    const handle = jest.fn();
+    const getData = jest.fn();
+    const dom = {};
+
+    const handler = createOutputDropdownHandler(handle, getData, dom);
+
+    const firstEvent = { currentTarget: { value: 'first' } };
+    const secondEvent = { currentTarget: { value: 'second' } };
+
+    handler(firstEvent);
+    handler(secondEvent);
+
+    expect(handle).toHaveBeenNthCalledWith(1, firstEvent.currentTarget, getData, dom);
+    expect(handle).toHaveBeenNthCalledWith(2, secondEvent.currentTarget, getData, dom);
+    expect(handle).toHaveBeenCalledTimes(2);
+  });
 });


### PR DESCRIPTION
## Summary
- extend output dropdown handler tests

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6845888b78a0832ea8d985e5beecc2bf