### PR TITLE
Add test to cover normalization rules

### DIFF
--- a/test/generator/normalizationRules.source.test.js
+++ b/test/generator/normalizationRules.source.test.js
@@ -1,0 +1,13 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, test, expect } from '@jest/globals';
+
+const sourcePath = path.join(process.cwd(), 'src/generator/generator.js');
+
+describe('normalizationRules constant source', () => {
+  test('definition includes default text and identity rules', () => {
+    const src = fs.readFileSync(sourcePath, 'utf8');
+    const regex = /const normalizationRules = \[\s*\[\s*c => typeof c !== 'object' \|\| c === null,\s*c => \({ type: 'text', content: c }\),\s*\],\s*\[\(\) => true, c => c\],\s*\];/s;
+    expect(src).toMatch(regex);
+  });
+});


### PR DESCRIPTION
## Summary
- add a test verifying the `normalizationRules` constant definition in `generator.js`

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6845888a6cfc832e8e56544446f578cd