### PR TITLE
Add test for toy output dropdown

### DIFF
--- a/test/generator/toyOutputDropdown.string.test.js
+++ b/test/generator/toyOutputDropdown.string.test.js
@@ -1,0 +1,28 @@
+import { describe, test, expect } from '@jest/globals';
+import { generateBlog } from '../../src/generator/generator.js';
+
+const header = '<body>';
+const footer = '</body>';
+const wrapHtml = content => `<html>${content}</html>`;
+
+// Additional test to ensure dropdown contains all options in correct order
+
+describe('toy output dropdown exact match', () => {
+  test('generateBlog renders dropdown with expected options', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'TOYO2',
+          title: 'Toy Post',
+          publicationDate: '2024-01-01',
+          toy: { modulePath: './toys/2024-01-01/example.js', functionName: 'example' }
+        }
+      ]
+    };
+
+    const html = generateBlog({ blog, header, footer }, wrapHtml);
+    const expected =
+      '<select class="output"><option value="text">text</option><option value="pre">pre</option><option value="tic-tac-toe">tic-tac-toe</option><option value="battleship-solitaire-fleet">battleship-solitaire-fleet</option><option value="battleship-solitaire-clues-presenter">battleship-solitaire-clues-presenter</option></select>';
+    expect(html).toContain(expected);
+  });
+});


### PR DESCRIPTION
## Summary
- add test verifying toy output dropdown options string

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684588893d2c832ebf0c6eeb96b2e968