### PR TITLE
Add test for null input to kill mutant

### DIFF
--- a/test/toys/2025-05-11/battleshipSolitaireClues.nullInput.integration.test.js
+++ b/test/toys/2025-05-11/battleshipSolitaireClues.nullInput.integration.test.js
@@ -1,0 +1,10 @@
+import { describe, it, expect } from '@jest/globals';
+import { generateClues } from '../../../src/toys/2025-05-11/battleshipSolitaireClues.js';
+
+describe('generateClues null input integration', () => {
+  it('handles null JSON without throwing and returns error string', () => {
+    const call = () => generateClues('null');
+    expect(call).not.toThrow();
+    expect(call()).toBe('{"error":"Invalid fleet structure"}');
+  });
+});


### PR DESCRIPTION
## Summary
- add integration test for `generateClues` when passed `'null'`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684588887480832ea5343056f77fa728