### PR TITLE
Add missing expectation for createHandleSubmit

### DIFF
--- a/test/browser/toys.createHandleSubmit.test.js
+++ b/test/browser/toys.createHandleSubmit.test.js
@@ -8,9 +8,12 @@ describe('createHandleSubmit', () => {
   });
   it('should handle being called without arguments', () => {
     // This test verifies that the function can be called without throwing
+    // and that it returns a handler function
+    let handler;
     expect(() => {
-      createHandleSubmit();
+      handler = createHandleSubmit();
     }).not.toThrow();
+    expect(typeof handler).toBe('function');
   });
 
   it('handles errors from the processing function', () => {


### PR DESCRIPTION
## Summary
- strengthen createHandleSubmit no-args test to ensure a handler is returned

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684588864d5c832e8fdde94c2cb228d8