### PR TITLE
Add test for blog fetch status transitions

### DIFF
--- a/test/browser/data.fetchStatus.integration.test.js
+++ b/test/browser/data.fetchStatus.integration.test.js
@@ -1,0 +1,23 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { fetchAndCacheBlogData } from '../../src/browser/data.js';
+
+describe('fetchAndCacheBlogData status integration', () => {
+  it('transitions from loading to loaded on success', async () => {
+    const state = {
+      blog: null,
+      blogStatus: 'idle',
+      blogError: null,
+      blogFetchPromise: null,
+    };
+    const fetchFn = jest.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    );
+    const loggers = { logInfo: jest.fn(), logError: jest.fn() };
+
+    const promise = fetchAndCacheBlogData(state, fetchFn, loggers);
+    expect(state.blogStatus).toBe('loading');
+
+    await promise;
+    expect(state.blogStatus).toBe('loaded');
+  });
+});


### PR DESCRIPTION
## Summary
- add integration test verifying fetchAndCacheBlogData transitions status from loading to loaded

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684588864c0c832ebd50ba48faf61227