### PR TITLE
Add disposer uniqueness test

### DIFF
--- a/test/browser/toys.setupAddButton.test.js
+++ b/test/browser/toys.setupAddButton.test.js
@@ -138,4 +138,19 @@ describe('setupAddButton', () => {
       addedHandler
     );
   });
+
+  it('returns a unique disposer for each setup call', () => {
+    setupAddButton(mockDom, button, rows, render, disposers);
+    const firstCleanup = disposers[0];
+
+    setupAddButton(mockDom, {}, rows, render, disposers);
+    const secondCleanup = disposers[1];
+
+    expect(firstCleanup).not.toBe(secondCleanup);
+
+    firstCleanup();
+    secondCleanup();
+
+    expect(mockDom.removeEventListener).toHaveBeenCalledTimes(2);
+  });
 });


### PR DESCRIPTION
## Summary
- extend `setupAddButton` tests with new check for unique disposer instances

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68458884cd00832e9b7cb6aaed2cef7f