### PR TITLE
Add repeat listener test

### DIFF
--- a/test/browser/createAddDropdownListener.repeat.test.js
+++ b/test/browser/createAddDropdownListener.repeat.test.js
@@ -1,0 +1,19 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { createAddDropdownListener } from '../../src/browser/toys.js';
+
+describe('createAddDropdownListener repeated calls', () => {
+  it('registers the handler each time it is invoked', () => {
+    const onChange = jest.fn();
+    const dom = { addEventListener: jest.fn() };
+    const dropdown = {};
+
+    const addListener = createAddDropdownListener(onChange, dom);
+
+    addListener(dropdown);
+    addListener(dropdown);
+
+    expect(dom.addEventListener).toHaveBeenCalledTimes(2);
+    expect(dom.addEventListener).toHaveBeenNthCalledWith(1, dropdown, 'change', onChange);
+    expect(dom.addEventListener).toHaveBeenNthCalledWith(2, dropdown, 'change', onChange);
+  });
+});


### PR DESCRIPTION
## Summary
- add a regression test for `createAddDropdownListener`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684588837a58832e9eab4d3557cde1d4