### PR TITLE
Add mutant-killing check for fullWidthElement

### DIFF
--- a/test/generator/fullWidthElement.test.js
+++ b/test/generator/fullWidthElement.test.js
@@ -45,4 +45,8 @@ describe('fullWidthElement integration', () => {
     expect(fullWidthElement).toContain('class="key full-width"');
     expect(fullWidthElement).toContain('class="value full-width"');
   });
+
+  test('fullWidthElement has the correct length', () => {
+    expect(fullWidthElement).toHaveLength(206);
+  });
 });


### PR DESCRIPTION
## Summary
- extend `fullWidthElement` tests with precise length verification

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684588824620832e85543c9cc7a1af55