### PR TITLE
Add test covering empty parsed request

### DIFF
--- a/test/browser/toys.isValidParsedRequest.test.js
+++ b/test/browser/toys.isValidParsedRequest.test.js
@@ -15,6 +15,7 @@ describe('isValidParsedRequest', () => {
     expect(isValidParsedRequest(undefined)).toBe(false);
     expect(isValidParsedRequest(42)).toBe(false);
     expect(isValidParsedRequest('string')).toBe(false);
+    expect(isValidParsedRequest({})).toBe(false);
   });
 
   it('returns false for object without request field', () => {


### PR DESCRIPTION
## Summary
- add a missing case for `isValidParsedRequest` when given an empty object

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6845888578e0832e9f8e96189dab5304