### PR TITLE
Add blockquote corner count test

### DIFF
--- a/test/generator/createBlockquote.integration.test.js
+++ b/test/generator/createBlockquote.integration.test.js
@@ -23,4 +23,19 @@ describe('createBlockquote integration', () => {
     expect(html).toContain('corner corner-bl');
     expect(html).toContain('corner corner-br');
   });
+  test('blockquote corners appear exactly four times', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'BQ02',
+          title: 'Quote Count',
+          publicationDate: '2024-06-02',
+          content: [{ type: 'quote', content: 'Hello again' }],
+        },
+      ],
+    };
+    const html = generateBlog({ blog, header, footer }, wrapHtml);
+    const matches = html.match(/corner-/g) || [];
+    expect(matches.length).toBe(4);
+  });
 });


### PR DESCRIPTION
## Summary
- add additional expectation in `createBlockquote.integration.test.js` to verify blockquote corner count

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68458883f208832e842104388dae27f5