### PR TITLE
Add test for media class

### DIFF
--- a/test/generator/mediaDisplayRules.test.js
+++ b/test/generator/mediaDisplayRules.test.js
@@ -31,5 +31,7 @@ describe('MEDIA_DISPLAY_RULES integration', () => {
     expect(html).toContain('<img');
     expect(html).toContain('<audio');
     expect(html).toContain('<iframe');
+    // Ensure media sections include the correct key class
+    expect(html).toContain('class="key media"');
   });
 });


### PR DESCRIPTION
## Summary
- extend media display rules test to check for the `key media` class

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68458e15bd44832ea4722f9647a6b720