### PR TITLE
Add repeated invocation test for text input update

### DIFF
--- a/test/browser/toys.createUpdateTextInputValue.test.js
+++ b/test/browser/toys.createUpdateTextInputValue.test.js
@@ -154,4 +154,23 @@ describe('createUpdateTextInputValue', () => {
     expect(domA.setValue).toHaveBeenCalledWith(textInputA, 'a');
     expect(domB.setValue).toHaveBeenCalledWith(textInputB, 'b');
   });
+
+  it('calls dom utilities for each invocation', () => {
+    mockDom.getTargetValue
+      .mockReturnValueOnce('first')
+      .mockReturnValueOnce('second');
+
+    const firstEvent = {};
+    const secondEvent = {};
+
+    const handler = createUpdateTextInputValue(textInput, mockDom);
+
+    handler(firstEvent);
+    handler(secondEvent);
+
+    expect(mockDom.getTargetValue).toHaveBeenNthCalledWith(1, firstEvent);
+    expect(mockDom.getTargetValue).toHaveBeenNthCalledWith(2, secondEvent);
+    expect(mockDom.setValue).toHaveBeenNthCalledWith(1, textInput, 'first');
+    expect(mockDom.setValue).toHaveBeenNthCalledWith(2, textInput, 'second');
+  });
 });


### PR DESCRIPTION
## Summary
- extend `createUpdateTextInputValue` tests to verify DOM utilities are invoked on multiple calls

## Testing
- `npm test --silent`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68458e149050832e9fafe8426597caf5