### PR TITLE
Add horizontal ship bounds test

### DIFF
--- a/test/toys/2025-05-08/battleshipSolitaireFleet.test.js
+++ b/test/toys/2025-05-08/battleshipSolitaireFleet.test.js
@@ -81,6 +81,18 @@ describe('generateFleet', () => {
         },
       ],
     });
+    const ship = fleet.ships[0];
+    const occupied = [];
+    for (let i = 0; i < ship.length; i++) {
+      const sx = ship.start.x + i;
+      const sy = ship.start.y;
+      occupied.push([sx, sy]);
+    }
+    expect(occupied).toEqual([
+      [0, 1],
+      [1, 1],
+      [2, 1],
+    ]);
   });
 
   test('generates a valid fleet for simple input', () => {


### PR DESCRIPTION
## Summary
- extend `battleshipSolitaireFleet.test.js` with assertions on occupied
  coordinates for horizontal ships

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68458e13b3d4832ebf98a6d761060920