### PR TITLE
Add dynamic BLOG_STATUS test

### DIFF
--- a/test/browser/data.blogStatus.constants.dynamic.test.js
+++ b/test/browser/data.blogStatus.constants.dynamic.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect, jest } from '@jest/globals';
+
+/**
+ * Dynamically import data module to ensure BLOG_STATUS initialization
+ * is attributed to this test for mutation coverage.
+ */
+
+describe('BLOG_STATUS dynamic import', () => {
+  it('fetchAndCacheBlogData uses BLOG_STATUS values', async () => {
+    const { fetchAndCacheBlogData } = await import('../../src/browser/data.js');
+    const state = {
+      blog: null,
+      blogStatus: 'idle',
+      blogError: null,
+      blogFetchPromise: null,
+    };
+    const fetchFn = jest.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    );
+    const loggers = { logInfo: jest.fn(), logError: jest.fn() };
+
+    const promise = fetchAndCacheBlogData(state, fetchFn, loggers);
+    expect(state.blogStatus).toBe('loading');
+    await promise;
+    expect(state.blogStatus).toBe('loaded');
+  });
+});


### PR DESCRIPTION
## Summary
- add a runtime test to verify BLOG_STATUS values

## Testing
- `npm test --silent`
- `npm run lint --silent`

------
https://chatgpt.com/codex/tasks/task_e_68458e11028c832eab5b9e0dc7b347f7