### PR TITLE
Add test for footer warning message

### DIFF
--- a/test/generator/footerWarningMessage.exact.test.js
+++ b/test/generator/footerWarningMessage.exact.test.js
@@ -1,0 +1,12 @@
+import { describe, test, expect } from '@jest/globals';
+import { generateBlogOuter } from '../../src/generator/generator.js';
+
+describe('footer warning message exact text', () => {
+  test('generateBlogOuter includes the full warning message exactly once', () => {
+    const html = generateBlogOuter({ posts: [] });
+    const msg =
+      'All content is authored by Matt Heard and is <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">CC BY-NC-SA 4.0</a>, unless otherwise noted.';
+    const matches = html.match(new RegExp(msg, 'g')) || [];
+    expect(matches).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure the footer warning text appears exactly once

## Testing
- `npm test --silent`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68458e103974832ea2e206c6fe608d6f