### PR TITLE
Fix surviving mutant by verifying minimal fleet creation

### DIFF
--- a/test/toys/2025-05-08/battleshipSolitaireFleet.minimalBoard.test.js
+++ b/test/toys/2025-05-08/battleshipSolitaireFleet.minimalBoard.test.js
@@ -1,0 +1,24 @@
+import { describe, test, expect } from '@jest/globals';
+import { generateFleet } from '../../../src/toys/2025-05-08/battleshipSolitaireFleet.js';
+
+/**
+ * Ensure generateFleet can place a single ship on a small board.
+ * This covers the candidate accumulation logic in getValidCandidate.
+ */
+describe('generateFleet minimal board', () => {
+  test('places a single length-1 ship on a 2x2 board', () => {
+    const cfg = { width: 2, height: 2, ships: [1] };
+    const env = new Map([['getRandomNumber', () => 0]]);
+
+    const fleet = JSON.parse(generateFleet(JSON.stringify(cfg), env));
+
+    expect(fleet.width).toBe(2);
+    expect(fleet.height).toBe(2);
+    expect(Array.isArray(fleet.ships)).toBe(true);
+    expect(fleet.ships).toHaveLength(1);
+    const ship = fleet.ships[0];
+    expect(ship.length).toBe(1);
+    expect(ship.start).toEqual({ x: 1, y: 0 });
+    expect(['H', 'V']).toContain(ship.direction);
+  });
+});


### PR DESCRIPTION
## Summary
- add missing test case for battleshipSolitaireFleet to ensure a ship can be placed on a small board

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68458e127c38832eb2859d49c3c51bfa