### PR TITLE
Add test covering full HTML escaping

### DIFF
--- a/test/generator/html.test.js
+++ b/test/generator/html.test.js
@@ -38,6 +38,10 @@ describe('html utilities', () => {
     expect(escapeHtml("O'Reilly")).toBe('O&#039;Reilly');
   });
 
+  test('escapeHtml escapes all special characters together', () => {
+    expect(escapeHtml('&<>"\'')).toBe('&amp;&lt;&gt;&quot;&#039;');
+  });
+
   test('createHtmlTag wraps content with html lang attribute', () => {
     expect(createHtmlTag('hi')).toBe('<html lang="en">hi</html>');
   });


### PR DESCRIPTION
## Summary
- extend `escapeHtml` tests with case including all HTML characters

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68458e129550832eb82b3e9e09cc1952