### PR TITLE
Add test to ensure dropdown handler execution

### DIFF
--- a/test/browser/toys.createOutputDropdownHandler.test.js
+++ b/test/browser/toys.createOutputDropdownHandler.test.js
@@ -183,4 +183,15 @@ describe('createOutputDropdownHandler', () => {
     expect(handle).toHaveBeenNthCalledWith(2, secondEvent.currentTarget, getData, dom);
     expect(handle).toHaveBeenCalledTimes(2);
   });
+
+  test('returned handler can be invoked without throwing', () => {
+    const handle = jest.fn();
+    const getData = jest.fn();
+    const dom = {};
+    const handler = createOutputDropdownHandler(handle, getData, dom);
+    const event = { currentTarget: {} };
+
+    expect(() => handler(event)).not.toThrow();
+    expect(handle).toHaveBeenCalledWith(event.currentTarget, getData, dom);
+  });
 });


### PR DESCRIPTION
## Summary
- extend `createOutputDropdownHandler` tests to verify returned handler can be invoked without throwing

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68458e0d1320832e9f092c40ee897b7c