### PR TITLE
Add test for styles constant

### DIFF
--- a/test/generator/styles.constant.test.js
+++ b/test/generator/styles.constant.test.js
@@ -1,0 +1,9 @@
+import { describe, test, expect } from '@jest/globals';
+import { styles } from '../../src/generator/styles.js';
+
+describe('styles constant', () => {
+  test('includes body background color rule', () => {
+    expect(typeof styles).toBe('string');
+    expect(styles).toContain('background-color: #121212');
+  });
+});


### PR DESCRIPTION
## Summary
- add a unit test to verify the exported CSS `styles` constant

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68458e150d9c832e868844b6d7ee719d