### PR TITLE
Extend isValidParsedRequest tests

### DIFF
--- a/test/browser/toys.isValidParsedRequest.test.js
+++ b/test/browser/toys.isValidParsedRequest.test.js
@@ -44,4 +44,10 @@ describe('isValidParsedRequest', () => {
     };
     expect(isValidParsedRequest(invalidRequest)).toBe(false);
   });
+
+  it('returns false for arrays and boolean values', () => {
+    expect(isValidParsedRequest([])).toBe(false);
+    expect(isValidParsedRequest(true)).toBe(false);
+    expect(isValidParsedRequest(false)).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- add new coverage for `isValidParsedRequest` to check arrays and booleans

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684591db25a8832e905ad3b896a73fc2