### PR TITLE
Add mutation survivor test

### DIFF
--- a/test/browser/createAddDropdownListener.survivor.test.js
+++ b/test/browser/createAddDropdownListener.survivor.test.js
@@ -1,0 +1,32 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { createAddDropdownListener } from '../../src/browser/toys.js';
+
+describe('createAddDropdownListener survivor check', () => {
+  it('returns a unary function that registers the handler and forwards events', () => {
+    const dropdown = {};
+    const onChange = jest.fn();
+    const dom = {
+      addEventListener: jest.fn((el, event, handler) => {
+        // Save handler to invoke later
+        dom._handler = handler;
+      }),
+    };
+
+    const addListener = createAddDropdownListener(onChange, dom);
+    expect(typeof addListener).toBe('function');
+    expect(addListener.length).toBe(1);
+
+    const result = addListener(dropdown);
+
+    expect(result).toBeUndefined();
+    expect(dom.addEventListener).toHaveBeenCalledWith(
+      dropdown,
+      'change',
+      onChange
+    );
+
+    // Simulate event firing
+    dom._handler('evt');
+    expect(onChange).toHaveBeenCalledWith('evt');
+  });
+});


### PR DESCRIPTION
## Summary
- add a survivor test for `createAddDropdownListener`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684591db002c832ea97a1b6ed62eb83a