### PR TITLE
Add test for YouTube wrapper

### DIFF
--- a/test/generator/mediaContentConfig.static.test.js
+++ b/test/generator/mediaContentConfig.static.test.js
@@ -49,4 +49,19 @@ describe('MEDIA_CONTENT_CONFIG via generateBlog', () => {
     const html = generateBlog({ blog, header, footer }, wrapHtml);
     expect(html).toContain('<audio class="value" controls>');
   });
+
+  test('youtube element wrapped in paragraph tag', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'YTP1',
+          title: 'Video',
+          publicationDate: '2024-06-01',
+          youtube: { id: 'abc', timestamp: 0, title: 'Example' },
+        },
+      ],
+    };
+    const html = generateBlog({ blog, header, footer }, wrapHtml);
+    expect(html).toContain('<p class="value"><iframe');
+  });
 });


### PR DESCRIPTION
## Summary
- extend mediaContentConfig tests to verify the YouTube wrapper element

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684591db6090832e809f1d3f1deecbbd