### PR TITLE
Add mutant-killing deep copy test

### DIFF
--- a/test/browser/getDeepStateCopy.mutantKill.test.js
+++ b/test/browser/getDeepStateCopy.mutantKill.test.js
@@ -1,0 +1,20 @@
+import { describe, it, expect } from '@jest/globals';
+import { getDeepStateCopy } from '../../src/browser/toys.js';
+
+describe('getDeepStateCopy mutant killer', () => {
+  it('creates independent deep copies on each call', () => {
+    const original = { nested: { arr: [1, 2] } };
+    const copyA = getDeepStateCopy(original);
+    const copyB = getDeepStateCopy(original);
+
+    expect(copyA).toEqual(original);
+    expect(copyB).toEqual(original);
+    expect(copyA).not.toBe(copyB);
+    expect(copyA.nested).not.toBe(original.nested);
+    expect(copyB.nested).not.toBe(original.nested);
+
+    copyA.nested.arr.push(3);
+    expect(copyB.nested.arr).toEqual([1, 2]);
+    expect(original.nested.arr).toEqual([1, 2]);
+  });
+});


### PR DESCRIPTION
## Summary
- add an additional test for `getDeepStateCopy` to verify each call returns an independent deep clone

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684591d6363c832eab04a349f8f11db7