### PR TITLE
Add test for remove button disposer

### DIFF
--- a/test/browser/createRemoveRemoveListener.mutantKill.test.js
+++ b/test/browser/createRemoveRemoveListener.mutantKill.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { setupRemoveButton } from '../../src/browser/toys.js';
+
+describe('createRemoveRemoveListener mutant killer', () => {
+  it('returns a disposer that removes the added listener', () => {
+    const dom = {
+      setTextContent: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    };
+    const button = {};
+    const rows = { k: 'v' };
+    const render = jest.fn();
+    const disposers = [];
+
+    setupRemoveButton(dom, button, rows, render, 'k', disposers);
+
+    expect(disposers).toHaveLength(1);
+    const dispose = disposers[0];
+    expect(typeof dispose).toBe('function');
+
+    const [, , addedHandler] = dom.addEventListener.mock.calls[0];
+    dispose();
+
+    expect(dom.removeEventListener).toHaveBeenCalledWith(button, 'click', addedHandler);
+  });
+});


### PR DESCRIPTION
## Summary
- add regression test for `setupRemoveButton` disposer to ensure the attached click handler is properly removed

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684591d565e8832e9aeec0cbc0c55d57