### PR TITLE
Add test for getDeepStateCopy

### DIFF
--- a/test/browser/getDeepStateCopy.mutationKill.test.js
+++ b/test/browser/getDeepStateCopy.mutationKill.test.js
@@ -1,0 +1,14 @@
+import { describe, it, expect } from '@jest/globals';
+import { getDeepStateCopy } from '../../src/browser/toys.js';
+
+describe('getDeepStateCopy mutant killer', () => {
+  it('creates a deep clone without mutating the original', () => {
+    const original = { a: { b: 1 } };
+    const copy = getDeepStateCopy(original);
+    expect(copy).toEqual(original);
+    expect(copy).not.toBe(original);
+    expect(copy.a).not.toBe(original.a);
+    copy.a.b = 2;
+    expect(original.a.b).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- extend unit tests to cover getDeepStateCopy

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684591d48f20832ea708f45df968d278