### PR TITLE
Add deferred registration test

### DIFF
--- a/test/browser/createAddDropdownListener.defer.test.js
+++ b/test/browser/createAddDropdownListener.defer.test.js
@@ -1,0 +1,19 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { createAddDropdownListener } from '../../src/browser/toys.js';
+
+describe('createAddDropdownListener deferred registration', () => {
+  it('does not register until the returned listener is invoked', () => {
+    const onChange = jest.fn();
+    const dom = { addEventListener: jest.fn() };
+    const dropdown = {};
+
+    const addListener = createAddDropdownListener(onChange, dom);
+    // Should not register the listener yet
+    expect(dom.addEventListener).not.toHaveBeenCalled();
+
+    addListener(dropdown);
+
+    expect(dom.addEventListener).toHaveBeenCalledTimes(1);
+    expect(dom.addEventListener).toHaveBeenCalledWith(dropdown, 'change', onChange);
+  });
+});


### PR DESCRIPTION
## Summary
- add a new unit test ensuring `createAddDropdownListener` only registers its handler when invoked

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684591d442fc832e8fa08a0fed107362