### PR TITLE
Add test for related link attributes

### DIFF
--- a/test/generator/defaultRelatedLinkAttrs.multiple.test.js
+++ b/test/generator/defaultRelatedLinkAttrs.multiple.test.js
@@ -1,0 +1,38 @@
+import { describe, test, expect } from '@jest/globals';
+import { generateBlog } from '../../src/generator/generator.js';
+
+const header = '<body>';
+const footer = '</body>';
+const wrapHtml = c => c;
+
+describe('DEFAULT_RELATED_LINK_ATTRS multiple links', () => {
+  test('each related link includes target and rel attributes', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'P1',
+          title: 'Post1',
+          publicationDate: '2024-01-01',
+          content: ['A'],
+          relatedLinks: [
+            { url: 'https://a.com', type: 'article', title: 'A1' },
+            { url: 'https://b.com', type: 'article', title: 'A2' },
+          ],
+        },
+        {
+          key: 'P2',
+          title: 'Post2',
+          publicationDate: '2024-01-02',
+          content: ['B'],
+          relatedLinks: [
+            { url: 'https://c.com', type: 'article', title: 'C1' },
+          ],
+        },
+      ],
+    };
+
+    const html = generateBlog({ blog, header, footer }, wrapHtml);
+    const matches = html.match(/target="_blank" rel="noopener"/g) || [];
+    expect(matches).toHaveLength(3);
+  });
+});


### PR DESCRIPTION
## Summary
- add coverage for multiple related links

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684591d31fb4832e8f99b1eb1f5b900a