### PR TITLE
Improve createAddDropdownListener tests

### DIFF
--- a/test/browser/createAddDropdownListener.defer.test.js
+++ b/test/browser/createAddDropdownListener.defer.test.js
@@ -1,0 +1,18 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { createAddDropdownListener } from '../../src/browser/toys.js';
+
+describe('createAddDropdownListener deferred registration', () => {
+  it('defers calling addEventListener until the returned function is invoked', () => {
+    const dom = { addEventListener: jest.fn() };
+    const handler = jest.fn();
+
+    const addListener = createAddDropdownListener(handler, dom);
+    // Should not register listener yet
+    expect(dom.addEventListener).not.toHaveBeenCalled();
+
+    addListener('dropdown');
+
+    expect(dom.addEventListener).toHaveBeenCalledTimes(1);
+    expect(dom.addEventListener).toHaveBeenCalledWith('dropdown', 'change', handler);
+  });
+});


### PR DESCRIPTION
## Summary
- add test covering deferred event listener registration for `createAddDropdownListener`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684591d3c528832e8f5a83936eb09ddd