### PR TITLE
Add createKeyValueRow return handler test

### DIFF
--- a/test/browser/createKeyValueRow.return.test.js
+++ b/test/browser/createKeyValueRow.return.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect } from '@jest/globals';
+import { createKeyValueRow } from '../../src/browser/toys.js';
+
+describe('createKeyValueRow return value', () => {
+  it('returns a handler function accepting [key,value] and index', () => {
+    const dom = {};
+    const entries = [];
+    const textInput = {};
+    const rows = {};
+    const syncHiddenField = () => {};
+    const disposers = [];
+    const render = () => {};
+    const container = {};
+    const rowHandler = createKeyValueRow(
+      dom,
+      entries,
+      textInput,
+      rows,
+      syncHiddenField,
+      disposers,
+      render,
+      container
+    );
+    expect(typeof rowHandler).toBe('function');
+    expect(rowHandler.length).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test verifying `createKeyValueRow` returns a handler function

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684591da1f74832e84a9ea71cfcea721