### PR TITLE
Add HTML escape coverage test

### DIFF
--- a/test/generator/html.constants.test.js
+++ b/test/generator/html.constants.test.js
@@ -5,6 +5,7 @@ import {
   HTML_TAG_NAME,
   ATTR_NAME,
   HTML_ESCAPE_REPLACEMENTS,
+  escapeHtml,
 } from '../../src/generator/html.js';
 
 describe('html constants', () => {
@@ -34,5 +35,11 @@ describe('html constants', () => {
       { from: /'/g, to: '&#039;' },
     ];
     expect(HTML_ESCAPE_REPLACEMENTS).toEqual(expected);
+  });
+
+  test('escapeHtml applies all replacements', () => {
+    const input = '&<>"\'';
+    const expected = '&amp;&lt;&gt;&quot;&#039;';
+    expect(escapeHtml(input)).toBe(expected);
   });
 });


### PR DESCRIPTION
## Summary
- strengthen HTML escape tests to ensure all escape characters are handled

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684591d004d8832e8d2afc8922ddbf11