### PR TITLE
Add regex test for fullWidthElement

### DIFF
--- a/test/generator/fullWidthElement.regex.test.js
+++ b/test/generator/fullWidthElement.regex.test.js
@@ -1,0 +1,11 @@
+import { describe, test, expect } from '@jest/globals';
+import { fullWidthElement } from '../../src/generator/full-width.js';
+
+// Ensure the exported constant includes the expected markup structure
+
+describe('fullWidthElement structure', () => {
+  test('contains full-width key and value divs', () => {
+    const regex = /<div class="key full-width">[^<]*<\/div><div class="value full-width">[^<]*<\/div>/;
+    expect(fullWidthElement).toMatch(regex);
+  });
+});


### PR DESCRIPTION
## Summary
- add new test verifying that the `fullWidthElement` constant contains the expected markup

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68458e143444832ea3c562876db29e2e