### PR TITLE
Add adjacency test

### DIFF
--- a/test/toys/2025-05-08/battleshipSolitaireFleet.horizontalAdjacency.test.js
+++ b/test/toys/2025-05-08/battleshipSolitaireFleet.horizontalAdjacency.test.js
@@ -1,0 +1,13 @@
+import { describe, test, expect } from '@jest/globals';
+import { generateFleet } from '../../../src/toys/2025-05-08/battleshipSolitaireFleet.js';
+
+describe('generateFleet noTouching horizontal adjacency', () => {
+  test('fails on single row board due to adjacency', () => {
+    const cfg = { width: 2, height: 1, ships: [1, 1], noTouching: true };
+    const env = new Map([['getRandomNumber', () => 0]]);
+    const result = generateFleet(JSON.stringify(cfg), env);
+    expect(JSON.parse(result)).toEqual({
+      error: 'Failed to generate fleet after max retries',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- test horizontal adjacency failure when generating fleets

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684591d7a838832e9389478cd5e65d38