### PR TITLE
Add missing remove button disposer test

### DIFF
--- a/test/browser/setupRemoveButton.specificListener.test.js
+++ b/test/browser/setupRemoveButton.specificListener.test.js
@@ -1,0 +1,28 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { setupRemoveButton } from '../../src/browser/toys.js';
+
+describe('setupRemoveButton disposers', () => {
+  it('removes the specific handler that was added', () => {
+    const dom = {
+      setTextContent: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    };
+    const button = {};
+    const rows = { k: 'v' };
+    const render = jest.fn();
+    const disposers = [];
+
+    setupRemoveButton(dom, button, rows, render, 'k', disposers);
+
+    const [, , onRemove] = dom.addEventListener.mock.calls[0];
+    const dispose = disposers[0];
+    dispose();
+
+    expect(dom.removeEventListener).toHaveBeenCalledWith(
+      button,
+      'click',
+      onRemove
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- ensure `setupRemoveButton` removes the same click handler it adds

## Testing
- `npm test --silent`
- `npm run lint --silent`

------
https://chatgpt.com/codex/tasks/task_e_684591d72274832e980c7d780e3bfb53