### PR TITLE
Add test to kill createHandleSubmit mutant

### DIFF
--- a/test/browser/createHandleSubmit.mutant.test.js
+++ b/test/browser/createHandleSubmit.mutant.test.js
@@ -1,0 +1,40 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { createHandleSubmit } from '../../src/browser/toys.js';
+
+describe('createHandleSubmit mutant killer', () => {
+  it('returns a handler that stops default and processes input', () => {
+    const dom = {
+      stopDefault: jest.fn(),
+      removeAllChildren: jest.fn(),
+      appendChild: jest.fn(),
+      createElement: jest.fn(() => ({})),
+      setTextContent: jest.fn(),
+      addWarning: jest.fn(),
+    };
+    const env = {
+      dom,
+      createEnv: jest.fn(() => new Map()),
+      errorFn: jest.fn(),
+      fetchFn: jest.fn(() =>
+        Promise.resolve({ text: jest.fn(() => Promise.resolve('body')) })
+      ),
+    };
+    const elements = {
+      inputElement: { value: 'v' },
+      outputParentElement: {},
+      outputSelect: { value: 'text' },
+      article: { id: 'a1' },
+    };
+    const processingFunction = jest.fn(() => 'result');
+
+    const handler = createHandleSubmit(elements, processingFunction, env);
+    expect(typeof handler).toBe('function');
+
+    const evt = {};
+    const result = handler(evt);
+
+    expect(result).toBeUndefined();
+    expect(dom.stopDefault).toHaveBeenCalledWith(evt);
+    expect(processingFunction).toHaveBeenCalledWith('v', expect.any(Map));
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test to ensure `createHandleSubmit` returns a function that invokes `stopDefault` and the processing function

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684591d70938832ead0968a5979c61b3