### PR TITLE
Add BLOG_STATUS static test

### DIFF
--- a/test/browser/blogStatus.constants.static.test.js
+++ b/test/browser/blogStatus.constants.static.test.js
@@ -1,0 +1,19 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { fetchAndCacheBlogData } from '../../src/browser/data.js';
+
+describe('BLOG_STATUS constants static import', () => {
+  it('transitions status from idle to loaded', async () => {
+    const state = {
+      blog: null,
+      blogStatus: 'idle',
+      blogError: null,
+      blogFetchPromise: null,
+    };
+    const fetchFn = jest.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }));
+    const loggers = { logInfo: jest.fn(), logError: jest.fn() };
+    const promise = fetchAndCacheBlogData(state, fetchFn, loggers);
+    expect(state.blogStatus).toBe('loading');
+    await promise;
+    expect(state.blogStatus).toBe('loaded');
+  });
+});


### PR DESCRIPTION
## Summary
- add a static import test for `fetchAndCacheBlogData` to verify BLOG_STATUS transitions

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684591d18e60832e97fce818684dba78