### PR TITLE
Add remove button cleanup test

### DIFF
--- a/test/browser/setupRemoveButton.handlerRemoval.test.js
+++ b/test/browser/setupRemoveButton.handlerRemoval.test.js
@@ -1,0 +1,35 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { setupRemoveButton } from '../../src/browser/toys.js';
+
+describe('setupRemoveButton removes specific listener', () => {
+  it('cleanup removes the same handler that was added', () => {
+    const dom = {
+      setTextContent: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    };
+    const button = {};
+    const rows = { a: 1 };
+    const render = jest.fn();
+    const disposers = [];
+
+    setupRemoveButton(dom, button, rows, render, 'a', disposers);
+
+    expect(dom.addEventListener).toHaveBeenCalledWith(
+      button,
+      'click',
+      expect.any(Function)
+    );
+    expect(disposers).toHaveLength(1);
+    const dispose = disposers[0];
+    const [, , handler] = dom.addEventListener.mock.calls[0];
+
+    dispose();
+
+    expect(dom.removeEventListener).toHaveBeenCalledWith(
+      button,
+      'click',
+      handler
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add test verifying setupRemoveButton cleanup removes the specific listener

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684591d103c4832e94d07be36d7d3fad