### PR TITLE
Add test to validate createHandleSubmit handler

### DIFF
--- a/test/browser/toys.createHandleSubmit.test.js
+++ b/test/browser/toys.createHandleSubmit.test.js
@@ -189,4 +189,38 @@ describe('createHandleSubmit', () => {
     expect(stopDefault).toHaveBeenCalled();
     expect(fetchFn).toHaveBeenCalledWith('https://example.com');
   });
+
+  it('returns undefined after handling submit', () => {
+    const stopDefault = jest.fn();
+    const dom = {
+      stopDefault,
+      removeAllChildren: jest.fn(),
+      appendChild: jest.fn(),
+      createElement: jest.fn(() => ({})),
+      setTextContent: jest.fn(),
+      addWarning: jest.fn(),
+    };
+    const env = {
+      dom,
+      createEnv: jest.fn(() => new Map()),
+      errorFn: jest.fn(),
+      fetchFn: jest.fn(() =>
+        Promise.resolve({ text: jest.fn(() => Promise.resolve('body')) })
+      ),
+    };
+    const elements = {
+      inputElement: { value: 'x' },
+      outputParentElement: {},
+      outputSelect: { value: 'text' },
+      article: { id: 'a1' },
+    };
+    const processingFunction = jest.fn(() => 'res');
+
+    const handler = createHandleSubmit(elements, processingFunction, env);
+    const result = handler({});
+
+    expect(result).toBeUndefined();
+    expect(stopDefault).toHaveBeenCalledWith({});
+    expect(processingFunction).toHaveBeenCalledWith('x', expect.any(Map));
+  });
 });


### PR DESCRIPTION
## Summary
- extend `createHandleSubmit` tests to verify that the handler returns `undefined` while processing an event

## Testing
- `npm test --silent`
- `npm run lint --silent`

------
https://chatgpt.com/codex/tasks/task_e_684591d025cc832e813734d8b191b516