### PR TITLE
Add mutation killer test for createUpdateTextInputValue

### DIFF
--- a/test/browser/createUpdateTextInputValue.mutationKill.test.js
+++ b/test/browser/createUpdateTextInputValue.mutationKill.test.js
@@ -1,0 +1,22 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { createUpdateTextInputValue } from '../../src/browser/toys.js';
+
+describe('createUpdateTextInputValue mutant killer', () => {
+  it('delegates DOM helpers to update input value', () => {
+    const textInput = {};
+    const dom = {
+      getTargetValue: jest.fn(() => 'val'),
+      setValue: jest.fn(),
+    };
+    const event = {};
+
+    const updateHandler = createUpdateTextInputValue(textInput, dom);
+    expect(typeof updateHandler).toBe('function');
+
+    const result = updateHandler(event);
+
+    expect(result).toBeUndefined();
+    expect(dom.getTargetValue).toHaveBeenCalledWith(event);
+    expect(dom.setValue).toHaveBeenCalledWith(textInput, 'val');
+  });
+});


### PR DESCRIPTION
## Summary
- add a dedicated test that exercises `createUpdateTextInputValue`

## Testing
- `npm run lint`
- `npm test`
- `node --experimental-vm-modules ./node_modules/.bin/stryker run --mutate src/browser/toys.js --logLevel error` *(fails: Codex couldn't run certain commands due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_6845987d8424832ea4e6e5b44ae93a51