### PR TITLE
Add additional test for footer warning placement

### DIFF
--- a/test/generator/footerWarningMessage.position.test.js
+++ b/test/generator/footerWarningMessage.position.test.js
@@ -1,0 +1,12 @@
+import { describe, test, expect } from '@jest/globals';
+import { generateBlogOuter } from '../../src/generator/generator.js';
+
+describe('footer warning message position', () => {
+  test('warning message is inside footer value div', () => {
+    const html = generateBlogOuter({ posts: [] });
+    const expected =
+      '<div class="key"></div><div class="footer value warning">' +
+      'All content is authored by Matt Heard';
+    expect(html.includes(expected)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure the footer warning message appears inside the warning div

## Testing
- `npm test --silent`
- `npm run lint --silent`

------
https://chatgpt.com/codex/tasks/task_e_6845a8c17374832e80ca9bdd58a36aba