### PR TITLE
Add test for remove button disposer behavior

### DIFF
--- a/test/browser/createRemoveRemoveListener.unique.test.js
+++ b/test/browser/createRemoveRemoveListener.unique.test.js
@@ -1,0 +1,52 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { setupRemoveButton } from '../../src/browser/toys.js';
+
+// Additional test ensuring each call to setupRemoveButton returns a unique
+// disposer that removes the specific handler that was added.
+
+describe('setupRemoveButton multiple disposers', () => {
+  it('returns distinct disposers for separate buttons', () => {
+    const dom = {
+      setTextContent: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    };
+    const buttonA = {};
+    const buttonB = {};
+    const rows = {};
+    const render = jest.fn();
+    const disposers = [];
+
+    // First setup
+    setupRemoveButton(dom, buttonA, rows, render, 'a', disposers);
+    const disposerA = disposers.pop();
+
+    // Second setup
+    setupRemoveButton(dom, buttonB, rows, render, 'b', disposers);
+    const disposerB = disposers.pop();
+
+    expect(typeof disposerA).toBe('function');
+    expect(typeof disposerB).toBe('function');
+    expect(disposerA).not.toBe(disposerB);
+
+    // Capture handlers used during setup
+    const handlerA = dom.addEventListener.mock.calls[0][2];
+    const handlerB = dom.addEventListener.mock.calls[1][2];
+
+    disposerA();
+    disposerB();
+
+    expect(dom.removeEventListener).toHaveBeenNthCalledWith(
+      1,
+      buttonA,
+      'click',
+      handlerA
+    );
+    expect(dom.removeEventListener).toHaveBeenNthCalledWith(
+      2,
+      buttonB,
+      'click',
+      handlerB
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add a unit test for `setupRemoveButton` to ensure each call returns a unique disposer that removes the correct listener

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6845a8c116d8832ea4a99966d8d36a64