### PR TITLE
Add title assertion for headElement

### DIFF
--- a/test/generator/headElement.test.js
+++ b/test/generator/headElement.test.js
@@ -17,4 +17,9 @@ describe('headElement', () => {
     expect(headElement).toContain('window.addComponent');
     expect(headElement.trim().endsWith('</head>')).toBe(true);
   });
+
+  test('contains page title', () => {
+    expect(headElement).toContain('<title>Matt Heard</title>');
+    expect(headElement.length).toBeGreaterThan(0);
+  });
 });


### PR DESCRIPTION
## Summary
- extend `headElement` tests to check that the blog header includes the page title

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6845a8c15370832e9a9dc73d2a62835e