### PR TITLE
Add headElement tests for meta viewport and title

### DIFF
--- a/test/generator/headElement.test.js
+++ b/test/generator/headElement.test.js
@@ -7,6 +7,9 @@ describe('headElement', () => {
     expect(headElement).toContain(
       '<link rel="manifest" href="/site.webmanifest">'
     );
+    expect(headElement).toContain(
+      '<meta name="viewport" content="width=device-width">'
+    );
   });
 
   test('includes style and script sections', () => {
@@ -16,5 +19,9 @@ describe('headElement', () => {
     expect(headElement).toContain('<script type="module">');
     expect(headElement).toContain('window.addComponent');
     expect(headElement.trim().endsWith('</head>')).toBe(true);
+  });
+
+  test('includes basic title tag', () => {
+    expect(headElement).toContain('<title>Matt Heard</title>');
   });
 });


### PR DESCRIPTION
## Summary
- expand headElement tests to check for viewport meta and title tags

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6845a8c053d4832ebe2680e07d2b304b