### PR TITLE
Add test for multiple blockquote corners

### DIFF
--- a/test/generator/blockquoteCorners.multiple.test.js
+++ b/test/generator/blockquoteCorners.multiple.test.js
@@ -1,0 +1,31 @@
+import { describe, test, expect } from '@jest/globals';
+import { generateBlog } from '../../src/generator/generator.js';
+
+const header = '<body>';
+const footer = '</body>';
+const wrapHtml = c => ['<html>', c, '</html>'].join('');
+
+describe('BLOCKQUOTE_CORNERS multiple posts', () => {
+  test('blockquote corners appear for each quoted post', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'BQ1',
+          title: 'Quote1',
+          publicationDate: '2024-06-03',
+          content: [{ type: 'quote', content: 'Hi' }],
+        },
+        {
+          key: 'BQ2',
+          title: 'Quote2',
+          publicationDate: '2024-06-04',
+          content: [{ type: 'quote', content: 'Bye' }],
+        },
+      ],
+    };
+
+    const html = generateBlog({ blog, header, footer }, wrapHtml);
+    const matches = html.match(/corner-/g) || [];
+    expect(matches).toHaveLength(8);
+  });
+});


### PR DESCRIPTION
## Summary
- add blockquote corners test for multiple quoted posts

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6845a8c07d50832ea6c898baf4454719