### PR TITLE
Add test to cover generator section class

### DIFF
--- a/test/generator/entryClass.test.js
+++ b/test/generator/entryClass.test.js
@@ -1,0 +1,8 @@
+import { test, expect } from '@jest/globals';
+import { generateBlogOuter } from '../../src/generator/generator.js';
+
+test('generateBlogOuter includes entry class in article and sections', () => {
+  const blog = { posts: [{ key: 'a1', content: ['hello'] }] };
+  const html = generateBlogOuter(blog);
+  expect(html).toContain('class="entry"');
+});


### PR DESCRIPTION
## Summary
- add unit test ensuring `generateBlogOuter` output includes `class="entry"`

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6845a8bf4554832ea726501331baa5ce