### PR TITLE
Add symbol test for text input updates

### DIFF
--- a/test/browser/toys.createUpdateTextInputValue.test.js
+++ b/test/browser/toys.createUpdateTextInputValue.test.js
@@ -173,4 +173,12 @@ describe('createUpdateTextInputValue', () => {
     expect(mockDom.setValue).toHaveBeenNthCalledWith(1, textInput, 'first');
     expect(mockDom.setValue).toHaveBeenNthCalledWith(2, textInput, 'second');
   });
+  it('handles symbol values without conversion', () => {
+    const symbolValue = Symbol('sym');
+    mockDom.getTargetValue.mockReturnValue(symbolValue);
+    const handler = createUpdateTextInputValue(textInput, mockDom);
+    handler(mockEvent);
+    expect(mockDom.setValue).toHaveBeenCalledWith(textInput, symbolValue);
+  });
+
 });


### PR DESCRIPTION
## Summary
- expand createUpdateTextInputValue tests with a Symbol case

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6845a8bf5d30832ea89ed649a76431a8