### PR TITLE
Add test for HTML escape replacements

### DIFF
--- a/test/generator/html.replacements.integrity.test.js
+++ b/test/generator/html.replacements.integrity.test.js
@@ -1,0 +1,25 @@
+import { describe, test, expect } from '@jest/globals';
+import { HTML_ESCAPE_REPLACEMENTS } from '../../src/generator/html.js';
+
+function escapeWithReplacements(text, replacements) {
+  return replacements.reduce((acc, { from, to }) => acc.replace(from, to), text);
+}
+
+describe('HTML_ESCAPE_REPLACEMENTS integrity', () => {
+  test('contains all standard replacements', () => {
+    const expected = [
+      { from: /&/g, to: '&amp;' },
+      { from: /</g, to: '&lt;' },
+      { from: />/g, to: '&gt;' },
+      { from: /"/g, to: '&quot;' },
+      { from: /'/g, to: '&#039;' },
+    ];
+    expect(HTML_ESCAPE_REPLACEMENTS).toEqual(expected);
+  });
+
+  test('replacements escape all special characters', () => {
+    const input = '&<>"\'';
+    const escaped = escapeWithReplacements(input, HTML_ESCAPE_REPLACEMENTS);
+    expect(escaped).toBe('&amp;&lt;&gt;&quot;&#039;');
+  });
+});


### PR DESCRIPTION
## Summary
- add integrity tests for `HTML_ESCAPE_REPLACEMENTS`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6845a8c0c0ec832e97fae4a44c7b44a3