### PR TITLE
Add createKeyValueRow factory tests

### DIFF
--- a/test/browser/createKeyValueRow.return.test.js
+++ b/test/browser/createKeyValueRow.return.test.js
@@ -24,4 +24,45 @@ describe('createKeyValueRow return value', () => {
     expect(typeof rowHandler).toBe('function');
     expect(rowHandler.length).toBe(2);
   });
+
+  it('has an arity of 8 and each call returns a new unary function', () => {
+    const dom = {};
+    const entries = [];
+    const textInput = {};
+    const rows = {};
+    const syncHiddenField = () => {};
+    const disposers = [];
+    const render = () => {};
+    const container = {};
+
+    expect(createKeyValueRow.length).toBe(8);
+
+    const first = createKeyValueRow(
+      dom,
+      entries,
+      textInput,
+      rows,
+      syncHiddenField,
+      disposers,
+      render,
+      container
+    );
+
+    const second = createKeyValueRow(
+      dom,
+      entries,
+      textInput,
+      rows,
+      syncHiddenField,
+      disposers,
+      render,
+      container
+    );
+
+    expect(typeof first).toBe('function');
+    expect(typeof second).toBe('function');
+    expect(first).not.toBe(second);
+    expect(first.length).toBe(2);
+    expect(second.length).toBe(2);
+  });
 });


### PR DESCRIPTION
## Summary
- extend `createKeyValueRow.return.test.js` with additional checks

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6845a8bef184832e954311ce53de7646