### PR TITLE
Add missing getDeepStateCopy tests

### DIFF
--- a/test/browser/getDeepStateCopy.primitives.test.js
+++ b/test/browser/getDeepStateCopy.primitives.test.js
@@ -1,0 +1,8 @@
+import { describe, test, expect } from '@jest/globals';
+import { getDeepStateCopy } from '../../src/browser/toys.js';
+
+describe('getDeepStateCopy primitives', () => {
+  test.each([42, 'abc', true, null])('returns value unchanged for %p', value => {
+    expect(getDeepStateCopy(value)).toBe(value);
+  });
+});


### PR DESCRIPTION
## Summary
- add primitive handling tests for `getDeepStateCopy`

## Testing
- `npm test --silent`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6845a8bd647c832eb2cadefc12049b9d