### PR TITLE
Add missing test for update handler

### DIFF
--- a/test/browser/toys.createUpdateTextInputValue.test.js
+++ b/test/browser/toys.createUpdateTextInputValue.test.js
@@ -173,4 +173,12 @@ describe('createUpdateTextInputValue', () => {
     expect(mockDom.setValue).toHaveBeenNthCalledWith(1, textInput, 'first');
     expect(mockDom.setValue).toHaveBeenNthCalledWith(2, textInput, 'second');
   });
+
+  it('returned handler can be invoked without throwing', () => {
+    const handler = createUpdateTextInputValue(textInput, mockDom);
+    mockDom.getTargetValue.mockReturnValue('foo');
+
+    expect(() => handler(mockEvent)).not.toThrow();
+    expect(mockDom.setValue).toHaveBeenCalledWith(textInput, 'foo');
+  });
 });


### PR DESCRIPTION
## Summary
- add a test calling the handler returned by `createUpdateTextInputValue`

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6845a8be5f48832eab4edef6302fa3e0