### PR TITLE
Add test to cover BLOG_STATUS constants

### DIFF
--- a/test/browser/data.blogStatus.constants.dynamic.test.js
+++ b/test/browser/data.blogStatus.constants.dynamic.test.js
@@ -24,4 +24,11 @@ describe('BLOG_STATUS dynamic import', () => {
     await promise;
     expect(state.blogStatus).toBe('loaded');
   });
+
+  it('shouldCopyStateForFetch relies on BLOG_STATUS constants', async () => {
+    const { shouldCopyStateForFetch } = await import('../../src/browser/data.js');
+    expect(shouldCopyStateForFetch('idle')).toBe(true);
+    expect(shouldCopyStateForFetch('error')).toBe(true);
+    expect(shouldCopyStateForFetch('loaded')).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- ensure BLOG_STATUS constants are exercised via dynamic import

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6845a8bcb36c832e98374667bb20ecad