### PR TITLE
Add repeated disposal test

### DIFF
--- a/test/browser/createNumberInput.dispose.test.js
+++ b/test/browser/createNumberInput.dispose.test.js
@@ -27,4 +27,37 @@ describe('createNumberInput disposer', () => {
       handler
     );
   });
+
+  it('allows _dispose to be called multiple times', () => {
+    const mockInput = {};
+    const onChange = jest.fn();
+    const dom = {
+      createElement: jest.fn(() => mockInput),
+      setType: jest.fn(),
+      setValue: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    };
+
+    const input = createNumberInput('1', onChange, dom);
+    dom.removeEventListener.mockClear();
+
+    input._dispose();
+    input._dispose();
+
+    const [[el, event, handler]] = dom.addEventListener.mock.calls;
+    expect(dom.removeEventListener).toHaveBeenCalledTimes(2);
+    expect(dom.removeEventListener).toHaveBeenNthCalledWith(
+      1,
+      el,
+      'input',
+      handler
+    );
+    expect(dom.removeEventListener).toHaveBeenNthCalledWith(
+      2,
+      el,
+      'input',
+      handler
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- extend number input disposer tests to cover multiple calls

## Testing
- `npm test --silent`
- `npm run lint --silent`

------
https://chatgpt.com/codex/tasks/task_e_6845a8bc60dc832e99de00f0cb257faf