### PR TITLE
Add dynamic test for isValidParsedRequest

### DIFF
--- a/test/browser/toys.isValidParsedRequest.dynamic.test.js
+++ b/test/browser/toys.isValidParsedRequest.dynamic.test.js
@@ -1,0 +1,12 @@
+import { describe, it, expect } from '@jest/globals';
+
+describe('isValidParsedRequest dynamic import', () => {
+  it('validates parsed requests using predicates', async () => {
+    const { isValidParsedRequest } = await import('../../src/browser/toys.js');
+    const valid = { request: { url: 'https://example.com' } };
+    const invalid = { request: { url: 123 } };
+
+    expect(isValidParsedRequest(valid)).toBe(true);
+    expect(isValidParsedRequest(invalid)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure `isValidParsedRequest` initialization is attributed to a test
- add a dynamic-import test covering invalid requests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6845a8bbb530832eb161735468cbb765