### PR TITLE
Add test for createAddDropdownListener error case

### DIFF
--- a/test/browser/createAddDropdownListener.noDom.test.js
+++ b/test/browser/createAddDropdownListener.noDom.test.js
@@ -1,0 +1,11 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { createAddDropdownListener } from '../../src/browser/toys.js';
+
+describe('createAddDropdownListener missing dom.addEventListener', () => {
+  it('throws a TypeError mentioning addEventListener when dom lacks it', () => {
+    const onChange = jest.fn();
+    const dom = {}; // no addEventListener
+    const listener = createAddDropdownListener(onChange, dom);
+    expect(() => listener({})).toThrow(/addEventListener/);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test for when `dom.addEventListener` is missing

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6845a8bb8b70832ea2a67df029e227f7