### PR TITLE
Add extra mutation test

### DIFF
--- a/test/browser/createAddDropdownListener.mutationExtra.test.js
+++ b/test/browser/createAddDropdownListener.mutationExtra.test.js
@@ -1,0 +1,25 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { createAddDropdownListener } from '../../src/browser/toys.js';
+
+describe('createAddDropdownListener mutation extra', () => {
+  it('returns a unary listener that registers change handler once when invoked', () => {
+    const onChange = jest.fn();
+    const dom = { addEventListener: jest.fn() };
+    const dropdown = {};
+
+    expect(createAddDropdownListener.length).toBe(2);
+    const addListener = createAddDropdownListener(onChange, dom);
+    expect(typeof addListener).toBe('function');
+    expect(addListener.length).toBe(1);
+
+    expect(dom.addEventListener).not.toHaveBeenCalled();
+    const result = addListener(dropdown);
+    expect(result).toBeUndefined();
+    expect(dom.addEventListener).toHaveBeenCalledTimes(1);
+    expect(dom.addEventListener).toHaveBeenCalledWith(
+      dropdown,
+      'change',
+      onChange
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add additional test for `createAddDropdownListener` to ensure the returned listener registers the change handler

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6845a8bb004c832ea617060ec82ad31f