### PR TITLE
Add audio-only media test

### DIFF
--- a/test/generator/mediaContentConfig.audioOnly.test.js
+++ b/test/generator/mediaContentConfig.audioOnly.test.js
@@ -1,0 +1,25 @@
+import { describe, test, expect } from '@jest/globals';
+import { generateBlog } from '../../src/generator/generator.js';
+
+const header = '<body>';
+const footer = '</body>';
+const wrapHtml = c => ['<html>', c, '</html>'].join('');
+
+describe('MEDIA_CONTENT_CONFIG single audio', () => {
+  test('generateBlog only outputs audio section when only audio present', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'AUDONLY',
+          title: 'Audio Only',
+          publicationDate: '2024-06-02',
+          audio: { fileType: 'mp3' },
+        },
+      ],
+    };
+    const html = generateBlog({ blog, header, footer }, wrapHtml);
+    expect(html).toContain('<audio');
+    expect(html).not.toContain('<img');
+    expect(html).not.toContain('<iframe');
+  });
+});


### PR DESCRIPTION
## Summary
- add regression test for MEDIA_CONTENT_CONFIG when only audio content is present

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6845a8b9af18832e854510cee1e4d574