### PR TITLE
Add dynamic test for shouldCopyStateForFetch

### DIFF
--- a/test/browser/shouldCopyStateForFetch.dynamic.test.js
+++ b/test/browser/shouldCopyStateForFetch.dynamic.test.js
@@ -1,0 +1,11 @@
+import { describe, it, expect } from '@jest/globals';
+
+describe('shouldCopyStateForFetch dynamic import', () => {
+  it('returns true for idle and error statuses', async () => {
+    const { shouldCopyStateForFetch } = await import(
+      '../../src/browser/data.js'
+    );
+    expect(shouldCopyStateForFetch('idle')).toBe(true);
+    expect(shouldCopyStateForFetch('error')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add a dynamic import test verifying `shouldCopyStateForFetch` values

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6845a8ba8a34832ea4fb8cb2727dfbc5