### PR TITLE
Export helpers for direct testing

### DIFF
--- a/src/presenters/ticTacToeBoard.js
+++ b/src/presenters/ticTacToeBoard.js
@@ -90,3 +90,5 @@ function renderTicTacToeBoardFromData(data, dom) {
   dom.setTextContent(pre, content);
   return pre;
 }
+
+export { getPlayer, getPosition };

--- a/src/toys/2025-05-08/battleshipSolitaireFleet.js
+++ b/src/toys/2025-05-08/battleshipSolitaireFleet.js
@@ -358,4 +358,10 @@ function getFleetResultOrError(fleetResult) {
   return fleetRetryError();
 }
 
-export { generateFleet, placeAllShips };
+export {
+  generateFleet,
+  placeAllShips,
+  isCoordNonNegative,
+  isCoordWithinBoard,
+  neighbours
+};

--- a/test/presenters/ticTacToeBoard.getPlayer.test.js
+++ b/test/presenters/ticTacToeBoard.getPlayer.test.js
@@ -1,23 +1,8 @@
-import fs from 'fs';
-import path from 'path';
-import { pathToFileURL } from 'url';
-import { beforeAll, describe, test, expect } from '@jest/globals';
-
-let getPlayer;
-let getPosition;
-
-beforeAll(async () => {
-  const filePath = path.join(process.cwd(), 'src/presenters/ticTacToeBoard.js');
-  let src = fs.readFileSync(filePath, 'utf8');
-  src = src.replace(/from '((?:\.\.?\/).*?)'/g, (_, p) => {
-    const abs = pathToFileURL(path.join(path.dirname(filePath), p));
-    return `from '${abs.href}'`;
-  });
-  src += '\nexport { getPlayer, getPosition };';
-  ({ getPlayer, getPosition } = await import(
-    `data:text/javascript,${encodeURIComponent(src)}`
-  ));
-});
+import { describe, test, expect } from '@jest/globals';
+import {
+  getPlayer,
+  getPosition
+} from '../../src/presenters/ticTacToeBoard.js';
 
 describe('getPlayer and getPosition', () => {
   test('return undefined for null move', () => {

--- a/test/presenters/ticTacToeBoard.getters.covered.test.js
+++ b/test/presenters/ticTacToeBoard.getters.covered.test.js
@@ -1,23 +1,8 @@
-import fs from 'fs';
-import path from 'path';
-import { pathToFileURL } from 'url';
-import { beforeAll, describe, test, expect } from '@jest/globals';
-
-let getPlayer;
-let getPosition;
-
-beforeAll(async () => {
-  const filePath = path.join(process.cwd(), 'src/presenters/ticTacToeBoard.js');
-  let src = fs.readFileSync(filePath, 'utf8');
-  src = src.replace(/from '((?:\.\.?\/)[^']*)'/g, (_, p) => {
-    const abs = pathToFileURL(path.join(path.dirname(filePath), p));
-    return `from '${abs.href}'`;
-  });
-  src += `\nexport { getPlayer, getPosition };\n//# sourceURL=${pathToFileURL(filePath).href}`;
-  ({ getPlayer, getPosition } = await import(
-    `data:text/javascript,${encodeURIComponent(src)}`
-  ));
-});
+import { describe, test, expect } from '@jest/globals';
+import {
+  getPlayer,
+  getPosition
+} from '../../src/presenters/ticTacToeBoard.js';
 
 describe('ticTacToeBoard getters via import', () => {
   test('getPlayer returns undefined for undefined move', () => {

--- a/test/presenters/ticTacToeBoard.getters.test.js
+++ b/test/presenters/ticTacToeBoard.getters.test.js
@@ -1,26 +1,16 @@
-import fs from "fs";
-import path from "path";
 import { describe, it, expect } from "@jest/globals";
-
-function loadGetters() {
-  const filePath = path.join(process.cwd(), "src/presenters/ticTacToeBoard.js");
-  const code = fs.readFileSync(filePath, "utf8");
-  const playerMatch = code.match(/function getPlayer\(move\) {[^]*?\n}\n/);
-  const positionMatch = code.match(/function getPosition\(move\) {[^]*?\n}\n/);
-  const getPlayer = eval("(" + playerMatch[0] + ")");
-  const getPosition = eval("(" + positionMatch[0] + ")");
-  return { getPlayer, getPosition };
-}
+import {
+  getPlayer,
+  getPosition
+} from "../../src/presenters/ticTacToeBoard.js";
 
 describe("ticTacToeBoard getters", () => {
   it("getPlayer returns undefined for null or undefined", () => {
-    const { getPlayer } = loadGetters();
     expect(getPlayer(undefined)).toBeUndefined();
     expect(getPlayer(null)).toBeUndefined();
   });
 
   it("getPosition returns undefined for null or undefined", () => {
-    const { getPosition } = loadGetters();
     expect(getPosition(undefined)).toBeUndefined();
     expect(getPosition(null)).toBeUndefined();
   });

--- a/test/presenters/ticTacToeBoard.internal.test.js
+++ b/test/presenters/ticTacToeBoard.internal.test.js
@@ -1,23 +1,8 @@
-import fs from 'fs';
-import path from 'path';
-import { pathToFileURL } from 'url';
-import { beforeAll, describe, it, expect } from '@jest/globals';
-
-let getPlayer;
-let getPosition;
-
-beforeAll(async () => {
-  const srcPath = path.join(process.cwd(), 'src/presenters/ticTacToeBoard.js');
-  let src = fs.readFileSync(srcPath, 'utf8');
-  src = src.replace(/from '((?:\.\.?\/).*?)'/g, (_, p) => {
-    const abs = pathToFileURL(path.join(path.dirname(srcPath), p));
-    return `from '${abs.href}'`;
-  });
-  src += '\nexport { getPlayer, getPosition };';
-  ({ getPlayer, getPosition } = await import(
-    `data:text/javascript,${encodeURIComponent(src)}`
-  ));
-});
+import { describe, it, expect } from '@jest/globals';
+import {
+  getPlayer,
+  getPosition
+} from '../../src/presenters/ticTacToeBoard.js';
 
 describe('ticTacToeBoard internal functions', () => {
   it('getPlayer returns undefined for undefined move', () => {

--- a/test/toys/2025-05-08/battleshipSolitaireFleet.neighbours.mutant.test.js
+++ b/test/toys/2025-05-08/battleshipSolitaireFleet.neighbours.mutant.test.js
@@ -1,17 +1,8 @@
 import { describe, test, expect } from '@jest/globals';
-import fs from 'fs';
-import path from 'path';
-
-function loadNeighbours() {
-  const filePath = path.join(process.cwd(), 'src/toys/2025-05-08/battleshipSolitaireFleet.js');
-  const code = fs.readFileSync(filePath, 'utf8');
-  const match = code.match(/function isOrigin[^]*?function neighbours\([^]*?\n\}/);
-  return eval(`(() => {${match[0]}; return neighbours;})()`);
-}
+import { neighbours } from '../../../src/toys/2025-05-08/battleshipSolitaireFleet.js';
 
 describe('neighbours mutants', () => {
   test('does not include origin coordinate', () => {
-    const neighbours = loadNeighbours();
     const result = neighbours({ x: 1, y: 2 });
     const hasOrigin = result.some(c => c.x === 1 && c.y === 2);
     expect(hasOrigin).toBe(false);

--- a/test/toys/2025-05-08/isCoordNonNegative.mutant.test.js
+++ b/test/toys/2025-05-08/isCoordNonNegative.mutant.test.js
@@ -1,27 +1,16 @@
 import { describe, test, expect } from '@jest/globals';
-import fs from 'fs';
-import path from 'path';
-
-function loadIsCoordNonNegative() {
-  const filePath = path.join(
-    process.cwd(),
-    'src/toys/2025-05-08/battleshipSolitaireFleet.js'
-  );
-  const code = fs.readFileSync(filePath, 'utf8');
-  const match = code.match(/function isCoordNonNegative[^]*?\{[^]*?\}/);
-  return eval(`(${match[0]})`);
-}
+import {
+  isCoordNonNegative
+} from '../../../src/toys/2025-05-08/battleshipSolitaireFleet.js';
 
 describe('isCoordNonNegative mutant', () => {
   test('returns false when either coordinate is negative', () => {
-    const fn = loadIsCoordNonNegative();
-    expect(fn({ x: -1, y: 0 })).toBe(false);
-    expect(fn({ x: 0, y: -1 })).toBe(false);
+    expect(isCoordNonNegative({ x: -1, y: 0 })).toBe(false);
+    expect(isCoordNonNegative({ x: 0, y: -1 })).toBe(false);
   });
 
   test('returns true when both coordinates are non-negative', () => {
-    const fn = loadIsCoordNonNegative();
-    expect(fn({ x: 0, y: 0 })).toBe(true);
-    expect(fn({ x: 2, y: 3 })).toBe(true);
+    expect(isCoordNonNegative({ x: 0, y: 0 })).toBe(true);
+    expect(isCoordNonNegative({ x: 2, y: 3 })).toBe(true);
   });
 });

--- a/test/toys/2025-05-08/isCoordWithinBoard.mutant.test.js
+++ b/test/toys/2025-05-08/isCoordWithinBoard.mutant.test.js
@@ -1,29 +1,18 @@
 import { describe, test, expect } from '@jest/globals';
-import fs from 'fs';
-import path from 'path';
-
-function loadIsCoordWithinBoard() {
-  const filePath = path.join(
-    process.cwd(),
-    'src/toys/2025-05-08/battleshipSolitaireFleet.js'
-  );
-  const code = fs.readFileSync(filePath, 'utf8');
-  const match = code.match(/function isCoordWithinBoard[^]*?\{[^]*?\}/);
-  return eval(`(${match[0]})`);
-}
+import {
+  isCoordWithinBoard
+} from '../../../src/toys/2025-05-08/battleshipSolitaireFleet.js';
 
 describe('isCoordWithinBoard mutant', () => {
   test('returns false when coordinate equals board width or height', () => {
-    const fn = loadIsCoordWithinBoard();
     const cfg = { width: 3, height: 2 };
-    expect(fn({ x: 3, y: 0 }, cfg)).toBe(false);
-    expect(fn({ x: 0, y: 2 }, cfg)).toBe(false);
+    expect(isCoordWithinBoard({ x: 3, y: 0 }, cfg)).toBe(false);
+    expect(isCoordWithinBoard({ x: 0, y: 2 }, cfg)).toBe(false);
   });
 
   test('returns true for coordinates strictly within bounds', () => {
-    const fn = loadIsCoordWithinBoard();
     const cfg = { width: 3, height: 2 };
-    expect(fn({ x: 0, y: 0 }, cfg)).toBe(true);
-    expect(fn({ x: 2, y: 1 }, cfg)).toBe(true);
+    expect(isCoordWithinBoard({ x: 0, y: 0 }, cfg)).toBe(true);
+    expect(isCoordWithinBoard({ x: 2, y: 1 }, cfg)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- export helper functions from Battleship Solitaire fleet generator and Tic-Tac-Toe board presenter
- use those exports in mutant tests instead of reading the source
- update Tic-Tac-Toe internal tests to import helpers

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6845fce549bc832eaf7cb3b60ba376d3