### PR TITLE
Add dynamic blog status test

### DIFF
--- a/test/browser/blogStatus.dynamicValue.test.js
+++ b/test/browser/blogStatus.dynamicValue.test.js
@@ -1,0 +1,8 @@
+import { describe, it, expect } from '@jest/globals';
+import { shouldCopyStateForFetch } from '../../src/browser/data.js';
+
+describe('BLOG_STATUS dynamic value check', () => {
+  it('shouldCopyStateForFetch returns true for idle status', () => {
+    expect(shouldCopyStateForFetch('idle')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add a new test to exercise `shouldCopyStateForFetch` while importing the data module

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846780ece10832ea10e7c62d60dae8e