### PR TITLE
Add unit test for createInputDropdownHandler

### DIFF
--- a/test/browser/createInputDropdownHandler.mutant.test.js
+++ b/test/browser/createInputDropdownHandler.mutant.test.js
@@ -1,0 +1,30 @@
+import { test, expect, jest } from '@jest/globals';
+import { createInputDropdownHandler } from '../../src/browser/toys.js';
+
+test('createInputDropdownHandler invokes visibility handlers', () => {
+  const select = {};
+  const container = {};
+  const textInput = {};
+  const event = {};
+
+  const dom = {
+    getCurrentTarget: jest.fn(() => select),
+    getParentElement: jest.fn(() => container),
+    querySelector: jest.fn((_, selector) =>
+      selector === 'input[type="text"]' ? textInput : null
+    ),
+    getValue: jest.fn(() => 'text'),
+    reveal: jest.fn(),
+    enable: jest.fn(),
+    hide: jest.fn(),
+    disable: jest.fn(),
+  };
+
+  const handler = createInputDropdownHandler(dom);
+  expect(typeof handler).toBe('function');
+  expect(handler.length).toBe(1);
+
+  expect(() => handler(event)).not.toThrow();
+  expect(dom.reveal).toHaveBeenCalledWith(textInput);
+  expect(dom.enable).toHaveBeenCalledWith(textInput);
+});


### PR DESCRIPTION
## Summary
- cover `inputHandlers` in `createInputDropdownHandler`

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6846780f032c832eb49b3a7948ec7392