### PR TITLE
Add mutant-killing test for createOutputDropdownHandler

### DIFF
--- a/test/browser/createOutputDropdownHandler.mutantKill.test.js
+++ b/test/browser/createOutputDropdownHandler.mutantKill.test.js
@@ -1,0 +1,23 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { createOutputDropdownHandler } from '../../src/browser/toys.js';
+
+describe('createOutputDropdownHandler mutant killer', () => {
+  it('delegates to handleDropdownChange and returns its result', () => {
+    const expected = 'ok';
+    const handleDropdownChange = jest.fn().mockReturnValue(expected);
+    const getData = jest.fn();
+    const dom = {};
+
+    const handler = createOutputDropdownHandler(handleDropdownChange, getData, dom);
+
+    expect(createOutputDropdownHandler.length).toBe(3);
+    expect(typeof handler).toBe('function');
+    expect(handler.length).toBe(1);
+
+    const event = { currentTarget: { val: 42 } };
+    const result = handler(event);
+
+    expect(result).toBe(expected);
+    expect(handleDropdownChange).toHaveBeenCalledWith(event.currentTarget, getData, dom);
+  });
+});


### PR DESCRIPTION
## Summary
- target surviving mutant in `createOutputDropdownHandler`
- add a regression test covering delegate behavior and return value

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846780e8180832eb4fe491e6114d7d9