### PR TITLE
Add test for BLOG_STATUS constants

### DIFF
--- a/test/browser/blogStatus.constant.values.test.js
+++ b/test/browser/blogStatus.constant.values.test.js
@@ -1,0 +1,32 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import {
+  fetchAndCacheBlogData,
+  shouldCopyStateForFetch,
+} from '../../src/browser/data.js';
+
+describe('BLOG_STATUS constant values', () => {
+  it('shouldCopyStateForFetch respects BLOG_STATUS values', () => {
+    expect(shouldCopyStateForFetch('idle')).toBe(true);
+    expect(shouldCopyStateForFetch('error')).toBe(true);
+    expect(shouldCopyStateForFetch('loaded')).toBe(false);
+    expect(shouldCopyStateForFetch('loading')).toBe(false);
+  });
+
+  it('fetchAndCacheBlogData transitions status using BLOG_STATUS', async () => {
+    const state = {
+      blog: null,
+      blogStatus: 'idle',
+      blogError: null,
+      blogFetchPromise: null,
+    };
+    const fetchFn = jest.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    );
+    const loggers = { logInfo: jest.fn(), logError: jest.fn() };
+
+    const promise = fetchAndCacheBlogData(state, fetchFn, loggers);
+    expect(state.blogStatus).toBe('loading');
+    await promise;
+    expect(state.blogStatus).toBe('loaded');
+  });
+});


### PR DESCRIPTION
## Summary
- add coverage for `BLOG_STATUS` constants via `shouldCopyStateForFetch` and `fetchAndCacheBlogData`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846780d981c832ebc4c22e9cf752bab