### PR TITLE
Add test guarding BLOG_STATUS idle value

### DIFF
--- a/test/browser/shouldCopyStateForFetch.mutantKill.test.js
+++ b/test/browser/shouldCopyStateForFetch.mutantKill.test.js
@@ -1,0 +1,23 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { shouldCopyStateForFetch, getData } from '../../src/browser/data.js';
+
+// Additional test to ensure BLOG_STATUS.IDLE mutations are caught
+
+describe('shouldCopyStateForFetch mutant kill', () => {
+  it('returns true for idle and getData triggers fetch', () => {
+    const state = {
+      blog: null,
+      blogStatus: 'idle',
+      blogError: null,
+      blogFetchPromise: null,
+    };
+    const fetchFn = jest.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    );
+    const loggers = { logInfo: jest.fn(), logError: jest.fn(), logWarning: jest.fn() };
+
+    expect(shouldCopyStateForFetch('idle')).toBe(true);
+    getData(state, fetchFn, loggers);
+    expect(fetchFn).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- cover `BLOG_STATUS.IDLE` via `shouldCopyStateForFetch`
- ensure `getData` triggers a fetch when state is idle

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846780ca710832ebfd1556cfe9baae9