### PR TITLE
Add runtime test for footer warning

### DIFF
--- a/test/generator/footerWarningMessage.runtime.test.js
+++ b/test/generator/footerWarningMessage.runtime.test.js
@@ -1,0 +1,11 @@
+import { test, expect } from '@jest/globals';
+
+let generateBlogOuter;
+
+test('generateBlogOuter includes the warning message when imported at runtime', async () => {
+  ({ generateBlogOuter } = await import('../../src/generator/generator.js'));
+  const html = generateBlogOuter({ posts: [] });
+  const msg =
+    'All content is authored by Matt Heard and is <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">CC BY-NC-SA 4.0</a>, unless otherwise noted.';
+  expect(html).toContain(msg);
+});


### PR DESCRIPTION
## Summary
- add a dynamic import test to ensure the footer warning message is covered during runtime

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846780bd064832eb68cfea08539e8d7