### PR TITLE
Add test for blank blog status

### DIFF
--- a/test/browser/data.test.js
+++ b/test/browser/data.test.js
@@ -267,6 +267,14 @@ describe('getData, setData, and getDeepStateCopy', () => {
     expect(result).toBe(state);
   });
 
+  it('getData does nothing when status is blank', () => {
+    state.blogStatus = '';
+    const loggers = { logInfo: logFn, logError: errorFn, logWarning: warnFn };
+    getData(state, fetchFn, loggers);
+    expect(fetchFn).not.toHaveBeenCalled();
+    expect(warnFn).not.toHaveBeenCalled();
+  });
+
   it('getData sets status to loading then loaded when fetch completes', async () => {
     const blogData = { title: 'blog' };
     fetchFn = jest.fn(() =>


### PR DESCRIPTION
## Summary
- extend `data.test.js` with a case verifying `getData` ignores a blank status

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6846780be348832e99234973c17d04f3