### PR TITLE
Add dynamic media sections test

### DIFF
--- a/test/generator/mediaSections.dynamic.test.js
+++ b/test/generator/mediaSections.dynamic.test.js
@@ -1,0 +1,32 @@
+import { describe, test, expect } from '@jest/globals';
+
+// Dynamically import within test to ensure mutant coverage
+
+async function getGenerator() {
+  return await import('../../src/generator/generator.js');
+}
+
+describe('media sections dynamic import', () => {
+  test('blog with all media types renders each section', async () => {
+    const { generateBlogOuter } = await getGenerator();
+    const blog = {
+      posts: [
+        {
+          key: 'DYN1',
+          title: 'Dynamic Media',
+          publicationDate: '2024-01-01',
+          illustration: { fileType: 'png', altText: 'Alt' },
+          audio: { fileType: 'mp3' },
+          youtube: { id: 'abc', timestamp: 0, title: 'Video' },
+        },
+      ],
+    };
+    const html = generateBlogOuter(blog);
+    expect(html).toContain('<div class="key media">illus</div>');
+    expect(html).toContain('<div class="key media">audio</div>');
+    expect(html).toContain('<div class="key media">video</div>');
+    expect(html).toContain('<img');
+    expect(html).toContain('<audio');
+    expect(html).toContain('<iframe');
+  });
+});


### PR DESCRIPTION
## Summary
- add a dynamic import test for media sections

## Testing
- `npm test --silent`
- `npm run lint --silent`

------
https://chatgpt.com/codex/tasks/task_e_6846780bc154832e80b89104788cf16c