### PR TITLE
Add mutant-killing tic-tac-toe test

### DIFF
--- a/test/presenters/ticTacToeBoard.test.js
+++ b/test/presenters/ticTacToeBoard.test.js
@@ -308,4 +308,18 @@ describe('createTicTacToeBoardElement', () => {
       '   |   |   '
     );
   });
+
+  it('renders an empty board when the only move has an invalid player', () => {
+    const input = JSON.stringify({
+      moves: [{ player: 'Q', position: { row: 0, column: 0 } }]
+    });
+    const el = createTicTacToeBoardElement(input, mockDom());
+    expect(el.textContent).toBe(
+      '   |   |   \n' +
+      '---+---+---\n' +
+      '   |   |   \n' +
+      '---+---+---\n' +
+      '   |   |   '
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- extend tic tac toe board tests with scenario where the only move has an invalid player

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846780b5ff4832ebbe6cd0e623d6555