### PR TITLE
Add test for blog error status

### DIFF
--- a/test/browser/blogStatus.errorState.additional.test.js
+++ b/test/browser/blogStatus.errorState.additional.test.js
@@ -1,0 +1,20 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { fetchAndCacheBlogData, shouldCopyStateForFetch } from '../../src/browser/data.js';
+
+describe('BLOG_STATUS error transition additional check', () => {
+  it('sets status to error on fetch failure and qualifies for state copy', async () => {
+    const state = {
+      blog: null,
+      blogStatus: 'idle',
+      blogError: null,
+      blogFetchPromise: null,
+    };
+    const fetchFn = jest.fn(() => Promise.reject(new Error('fail')));
+    const loggers = { logInfo: jest.fn(), logError: jest.fn() };
+
+    await fetchAndCacheBlogData(state, fetchFn, loggers);
+
+    expect(state.blogStatus).toBe('error');
+    expect(shouldCopyStateForFetch(state.blogStatus)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add test covering fetch failure state to ensure `BLOG_STATUS.ERROR` constant is used

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68467806aee8832eb4f25f2ae6838399