### PR TITLE
Add test for article tag

### DIFF
--- a/test/generator/articleTagUsage.test.js
+++ b/test/generator/articleTagUsage.test.js
@@ -1,0 +1,24 @@
+import { describe, test, expect } from '@jest/globals';
+import { generateBlog } from '../../src/generator/generator.js';
+
+const header = '<body>';
+const footer = '</body>';
+const wrapHtml = html => `<html>${html}</html>`;
+
+describe('ARTICLE_TAG_NAME usage', () => {
+  test('generateBlog uses article tag for posts', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'A1',
+          title: 'Post',
+          publicationDate: '2024-01-01',
+          content: ['text'],
+        },
+      ],
+    };
+    const html = generateBlog({ blog, header, footer }, wrapHtml);
+    expect(html).toContain('<article class="entry" id="A1">');
+    expect(html).toContain('</article>');
+  });
+});


### PR DESCRIPTION
## Summary
- cover article tag name usage in generator

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68467807cda8832e924ed3b2e234a79b