### PR TITLE
Add extra dropdown listener test

### DIFF
--- a/test/browser/createAddDropdownListener.eliminate.test.js
+++ b/test/browser/createAddDropdownListener.eliminate.test.js
@@ -1,0 +1,23 @@
+import { test, expect, jest } from '@jest/globals';
+import { createAddDropdownListener } from '../../src/browser/toys.js';
+
+test('createAddDropdownListener returns unary listener that registers change event', () => {
+  const onChange = jest.fn();
+  const dom = { addEventListener: jest.fn() };
+  const dropdown = {};
+
+  const listener = createAddDropdownListener(onChange, dom);
+
+  expect(typeof listener).toBe('function');
+  expect(createAddDropdownListener.length).toBe(2);
+  expect(listener.length).toBe(1);
+
+  const result = listener(dropdown);
+
+  expect(result).toBeUndefined();
+  expect(dom.addEventListener).toHaveBeenCalledWith(
+    dropdown,
+    'change',
+    onChange
+  );
+});


### PR DESCRIPTION
## Summary
- extend tests for `createAddDropdownListener` to verify return type and event registration

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68467805f314832eba225dcb28020533