### PR TITLE
Add missing handler test

### DIFF
--- a/test/browser/createOutputDropdownHandler.undefined.test.js
+++ b/test/browser/createOutputDropdownHandler.undefined.test.js
@@ -1,0 +1,20 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { createOutputDropdownHandler } from '../../src/browser/toys.js';
+
+describe('createOutputDropdownHandler undefined target', () => {
+  it('handles events without currentTarget', () => {
+    const handleDropdownChange = jest.fn();
+    const getData = jest.fn();
+    const dom = {};
+
+    const handler = createOutputDropdownHandler(handleDropdownChange, getData, dom);
+
+    expect(typeof handler).toBe('function');
+    expect(handler.length).toBe(1);
+
+    const result = handler({});
+
+    expect(result).toBeUndefined();
+    expect(handleDropdownChange).toHaveBeenCalledWith(undefined, getData, dom);
+  });
+});


### PR DESCRIPTION
## Summary
- check that createOutputDropdownHandler forwards `undefined` when the event lacks `currentTarget`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846965d9644832eb66b6fcc783caa88