### PR TITLE
Add missing createHandleSubmit test

### DIFF
--- a/test/browser/createHandleSubmit.handlerLength.test.js
+++ b/test/browser/createHandleSubmit.handlerLength.test.js
@@ -1,0 +1,38 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { createHandleSubmit } from '../../src/browser/toys.js';
+
+describe('createHandleSubmit handler length', () => {
+  it('returns a unary handler that stops default behaviour', () => {
+    const dom = {
+      stopDefault: jest.fn(),
+      removeAllChildren: jest.fn(),
+      appendChild: jest.fn(),
+      createElement: jest.fn(() => ({})),
+      setTextContent: jest.fn(),
+      addWarning: jest.fn(),
+    };
+    const env = {
+      dom,
+      createEnv: jest.fn(() => new Map()),
+      errorFn: jest.fn(),
+      fetchFn: jest.fn(() =>
+        Promise.resolve({ text: jest.fn(() => Promise.resolve('body')) })
+      ),
+    };
+    const elements = {
+      inputElement: { value: '' },
+      outputParentElement: {},
+      outputSelect: { value: 'text' },
+      article: { id: 'a1' },
+    };
+    const processingFunction = jest.fn(() => 'result');
+
+    const handler = createHandleSubmit(elements, processingFunction, env);
+    expect(typeof handler).toBe('function');
+    expect(handler.length).toBe(1);
+
+    handler({});
+    expect(dom.stopDefault).toHaveBeenCalled();
+    expect(processingFunction).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add test to ensure `createHandleSubmit` returns a unary handler

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846965cb40c832e86f4e41a27f98f20