### PR TITLE
Add runtime dropdown listener test

### DIFF
--- a/test/browser/createAddDropdownListener.runtime.test.js
+++ b/test/browser/createAddDropdownListener.runtime.test.js
@@ -1,0 +1,19 @@
+import { test, expect, jest } from '@jest/globals';
+
+// Dynamically import to ensure the mutated version is loaded during tests
+let createAddDropdownListener;
+
+test('createAddDropdownListener imported at runtime registers change handler', async () => {
+  ({ createAddDropdownListener } = await import('../../src/browser/toys.js'));
+  const onChange = jest.fn();
+  const dom = { addEventListener: jest.fn() };
+  const dropdown = {};
+
+  const listener = createAddDropdownListener(onChange, dom);
+  expect(typeof listener).toBe('function');
+
+  const result = listener(dropdown);
+
+  expect(result).toBeUndefined();
+  expect(dom.addEventListener).toHaveBeenCalledWith(dropdown, 'change', onChange);
+});


### PR DESCRIPTION
## Summary
- add a runtime import test for `createAddDropdownListener` to improve mutation coverage

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846965c4fa8832e8651f291aebfd030