### PR TITLE
Add test for alley stealth state

### DIFF
--- a/test/toys/2025-03-30/cyberpunkAdventure.test.js
+++ b/test/toys/2025-03-30/cyberpunkAdventure.test.js
@@ -153,6 +153,7 @@ describe('Cyberpunk Text Game', () => {
         /trip a wire|Sirens start up|sprint back to the Market/i
       );
     }
+    expect(tempData.state).toBe('hub');
   });
 
   test('trips wire in alley if stealth check is exactly 0.3', () => {
@@ -177,6 +178,7 @@ describe('Cyberpunk Text Game', () => {
     }
     expect(tempData.inventory).not.toContain('stimpack');
     expect(tempData.visited).not.toContain('alley');
+    expect(tempData.state).toBe('hub');
   });
 
   test('unknown input in hub', () => {


### PR DESCRIPTION
## Summary
- extend the cyberpunk adventure tests to verify state updates when sneaking in the alley

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846965b7548832e998ce2437818c67b