### PR TITLE
Add missing test for dropdown handler

### DIFF
--- a/test/browser/createAddDropdownListener.sameDom.test.js
+++ b/test/browser/createAddDropdownListener.sameDom.test.js
@@ -1,0 +1,24 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { createAddDropdownListener } from '../../src/browser/toys.js';
+
+describe('createAddDropdownListener using same dom', () => {
+  it('returns a new handler on each invocation', () => {
+    const dom = { addEventListener: jest.fn() };
+    const onChange = jest.fn();
+
+    const first = createAddDropdownListener(onChange, dom);
+    const second = createAddDropdownListener(onChange, dom);
+
+    expect(typeof first).toBe('function');
+    expect(typeof second).toBe('function');
+    expect(first).not.toBe(second);
+
+    const dropdown1 = {};
+    const dropdown2 = {};
+    first(dropdown1);
+    second(dropdown2);
+
+    expect(dom.addEventListener).toHaveBeenNthCalledWith(1, dropdown1, 'change', onChange);
+    expect(dom.addEventListener).toHaveBeenNthCalledWith(2, dropdown2, 'change', onChange);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure each call to `createAddDropdownListener` with the same DOM returns a unique handler

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846965a5100832ebb8460402a0ffef3