### PR TITLE
Add test for entry class constant

### DIFF
--- a/test/generator/headerAndFooterStart.test.js
+++ b/test/generator/headerAndFooterStart.test.js
@@ -1,0 +1,10 @@
+import { describe, test, expect } from '@jest/globals';
+import { getBlogGenerationArgs } from '../../src/generator/generator.js';
+
+describe('entry class usage', () => {
+  test('header and footer include entry class', () => {
+    const { header, footer } = getBlogGenerationArgs();
+    expect(header.includes('<div class="entry">')).toBe(true);
+    expect(footer.startsWith('<div class="entry">')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add new Jest test to check that both header and footer include `<div class="entry">`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846965de408832e9b61e3a94546fa96