### PR TITLE
Add mutant-killing test for dropdown listener

### DIFF
--- a/test/browser/createAddDropdownListener.kill2.test.js
+++ b/test/browser/createAddDropdownListener.kill2.test.js
@@ -1,0 +1,18 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { createAddDropdownListener } from '../../src/browser/toys.js';
+
+describe('createAddDropdownListener mutation elimination', () => {
+  it('returns a unary function that registers on change and yields undefined', () => {
+    const onChange = jest.fn();
+    const dom = { addEventListener: jest.fn() };
+    const dropdown = {};
+    const addListener = createAddDropdownListener(onChange, dom);
+
+    expect(typeof addListener).toBe('function');
+    expect(addListener.length).toBe(1);
+
+    const result = addListener(dropdown);
+    expect(result).toBeUndefined();
+    expect(dom.addEventListener).toHaveBeenCalledWith(dropdown, 'change', onChange);
+  });
+});


### PR DESCRIPTION
## Summary
- add `createAddDropdownListener.kill2.test.js` to ensure `createAddDropdownListener` returns a unary listener

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846965d0d60832e9a83ae0719d4d3f7