### PR TITLE
Add HTML replacements length test

### DIFF
--- a/test/generator/html.escapeReplacements.length.test.js
+++ b/test/generator/html.escapeReplacements.length.test.js
@@ -1,0 +1,11 @@
+import { describe, test, expect } from '@jest/globals';
+import { HTML_ESCAPE_REPLACEMENTS } from '../../src/generator/html.js';
+
+describe('HTML_ESCAPE_REPLACEMENTS length', () => {
+  test('contains five standard replacements', () => {
+    expect(Array.isArray(HTML_ESCAPE_REPLACEMENTS)).toBe(true);
+    expect(HTML_ESCAPE_REPLACEMENTS).toHaveLength(5);
+    const keys = HTML_ESCAPE_REPLACEMENTS.map(r => Object.keys(r).sort());
+    keys.forEach(k => expect(k).toEqual(['from', 'to']));
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test verifying the standard HTML escape replacements array

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846965aedc4832e99c296b052a19bb4