### PR TITLE
Add generator class constants test

### DIFF
--- a/test/generator/classConstants.additional.test.js
+++ b/test/generator/classConstants.additional.test.js
@@ -1,0 +1,16 @@
+import { describe, it, expect } from '@jest/globals';
+import { generateBlogOuter } from '../../src/generator/generator.js';
+
+describe('generator CLASS constants additional', () => {
+  it('uses expected CSS classes in generated blog output', () => {
+    const blog = {
+      posts: [
+        { key: 'A1', title: 'Title', publicationDate: '2024-01-01', content: [] }
+      ]
+    };
+    const html = generateBlogOuter(blog);
+    expect(html).toContain('class="entry"');
+    expect(html).toContain('class="key article-title"');
+    expect(html).toContain('class="footer value warning"');
+  });
+});


### PR DESCRIPTION
## Summary
- add a unit test ensuring CSS class constants appear in generated HTML

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68469659adc8832eb0bb7d39da51e840