### PR TITLE
Add event forwarding test for createAddDropdownListener

### DIFF
--- a/test/browser/createAddDropdownListener.kill3.test.js
+++ b/test/browser/createAddDropdownListener.kill3.test.js
@@ -1,0 +1,17 @@
+import { test, expect, jest } from '@jest/globals';
+import { createAddDropdownListener } from '../../src/browser/toys.js';
+
+test('createAddDropdownListener registers handler and forwards events', () => {
+  const onChange = jest.fn();
+  const dom = { addEventListener: jest.fn() };
+  const dropdown = {};
+
+  const add = createAddDropdownListener(onChange, dom);
+  add(dropdown);
+
+  expect(dom.addEventListener).toHaveBeenCalledWith(dropdown, 'change', onChange);
+
+  const [, , handler] = dom.addEventListener.mock.calls[0];
+  handler({ currentTarget: dropdown });
+  expect(onChange).toHaveBeenCalledWith({ currentTarget: dropdown });
+});


### PR DESCRIPTION
## Summary
- add a regression test for `createAddDropdownListener` ensuring registered handlers receive events

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846a610e4cc832eb1b5a550924c5f0f