### PR TITLE
Add mutant-killing tic-tac-toe test

### DIFF
--- a/test/presenters/ticTacToeBoard.test.js
+++ b/test/presenters/ticTacToeBoard.test.js
@@ -322,4 +322,21 @@ describe('createTicTacToeBoardElement', () => {
       '   |   |   '
     );
   });
+
+  it('ignores multiple moves with invalid players', () => {
+    const input = JSON.stringify({
+      moves: [
+        { player: 'Q', position: { row: 0, column: 0 } },
+        { player: 'P', position: { row: 2, column: 2 } }
+      ]
+    });
+    const el = createTicTacToeBoardElement(input, mockDom());
+    expect(el.textContent).toBe(
+      '   |   |   \n' +
+      '---+---+---\n' +
+      '   |   |   \n' +
+      '---+---+---\n' +
+      '   |   |   '
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- add test ensuring multiple invalid moves are ignored in ticTacToe presenter

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846a611cdf8832eabdc29d104b663fb