### PR TITLE
Add mutant-killing test for article title class

### DIFF
--- a/test/generator/articleTitleClass.mutantKill.test.js
+++ b/test/generator/articleTitleClass.mutantKill.test.js
@@ -1,0 +1,19 @@
+import { describe, it, expect } from '@jest/globals';
+import { generateBlogOuter } from '../../src/generator/generator.js';
+
+describe('article title class mutant killer', () => {
+  it('renders the key div with the article-title class', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'A1',
+          title: 'Hello',
+          publicationDate: '2024-01-01',
+          content: []
+        }
+      ]
+    };
+    const html = generateBlogOuter(blog);
+    expect(html).toMatch(/<div class="key article-title">A1<\/div>/);
+  });
+});


### PR DESCRIPTION
## Summary
- add test to ensure article titles use the `article-title` class

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846a610da98832eb0349e6d4ef47260