### PR TITLE
Add unit test for output dropdown handler

### DIFF
--- a/test/browser/createOutputDropdownHandler.arrow.test.js
+++ b/test/browser/createOutputDropdownHandler.arrow.test.js
@@ -1,0 +1,28 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { createOutputDropdownHandler } from '../../src/browser/toys.js';
+
+describe('createOutputDropdownHandler arrow behaviour', () => {
+  it('forwards the event target using provided dependencies', () => {
+    const handleDropdownChange = jest.fn().mockReturnValue('ok');
+    const getData = jest.fn();
+    const dom = {};
+
+    const handler = createOutputDropdownHandler(
+      handleDropdownChange,
+      getData,
+      dom
+    );
+    expect(typeof handler).toBe('function');
+    expect(handler.length).toBe(1);
+
+    const event = { currentTarget: { value: 'x' } };
+    const result = handler(event);
+
+    expect(result).toBe('ok');
+    expect(handleDropdownChange).toHaveBeenCalledWith(
+      event.currentTarget,
+      getData,
+      dom
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add a new test covering createOutputDropdownHandler to ensure events are forwarded

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846a6100ae8832ea3247d874aa47a7a