### PR TITLE
Add coverage test for createAddDropdownListener

### DIFF
--- a/test/browser/createAddDropdownListener.coverage.test.js
+++ b/test/browser/createAddDropdownListener.coverage.test.js
@@ -1,0 +1,14 @@
+import { test, expect, jest } from '@jest/globals';
+import { createAddDropdownListener } from '../../src/browser/toys.js';
+
+test('createAddDropdownListener registers change handler when invoked', () => {
+  const onChange = jest.fn();
+  const dom = { addEventListener: jest.fn() };
+  const dropdown = {};
+
+  const addListener = createAddDropdownListener(onChange, dom);
+  const result = addListener(dropdown);
+
+  expect(result).toBeUndefined();
+  expect(dom.addEventListener).toHaveBeenCalledWith(dropdown, 'change', onChange);
+});


### PR DESCRIPTION
## Summary
- add a new unit test ensuring `createAddDropdownListener` registers the change listener

## Testing
- `npm test --silent`
- `npm run lint --silent`

------
https://chatgpt.com/codex/tasks/task_e_6846a60faf8c832eb1daa1ccd287da5f