### PR TITLE
Add test for createAddDropdownListener

### DIFF
--- a/test/browser/createAddDropdownListener.new.test.js
+++ b/test/browser/createAddDropdownListener.new.test.js
@@ -1,0 +1,18 @@
+import { test, expect, jest } from '@jest/globals';
+import { createAddDropdownListener } from '../../src/browser/toys.js';
+
+test('createAddDropdownListener attaches change listeners on multiple calls', () => {
+  const dom = { addEventListener: jest.fn() };
+  const onChange = jest.fn();
+  const dropdownA = {};
+  const dropdownB = {};
+
+  const addListener = createAddDropdownListener(onChange, dom);
+  expect(typeof addListener).toBe('function');
+
+  addListener(dropdownA);
+  addListener(dropdownB);
+
+  expect(dom.addEventListener).toHaveBeenNthCalledWith(1, dropdownA, 'change', onChange);
+  expect(dom.addEventListener).toHaveBeenNthCalledWith(2, dropdownB, 'change', onChange);
+});


### PR DESCRIPTION
## Summary
- extend coverage for `createAddDropdownListener` by calling the returned listener multiple times

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846a60f4910832ebe409bb44bacd320