### PR TITLE
Add test for wrapHtml with empty content

### DIFF
--- a/test/generator/wrapHtml.empty.test.js
+++ b/test/generator/wrapHtml.empty.test.js
@@ -1,0 +1,7 @@
+import { test, expect } from '@jest/globals';
+import { wrapHtml } from '../../src/generator/html.js';
+
+test('wrapHtml handles empty content', () => {
+  const result = wrapHtml('');
+  expect(result).toBe('<!DOCTYPE html><html lang="en"></html>');
+});


### PR DESCRIPTION
## Summary
- ensure `wrapHtml('')` handles empty input correctly

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846a60ec6c4832ebb7f4dcbef345a8c