### PR TITLE
Add DOCTYPE check for blog generator

### DIFF
--- a/test/generator/generateBlogOuter.doctype.test.js
+++ b/test/generator/generateBlogOuter.doctype.test.js
@@ -1,0 +1,11 @@
+import { describe, test, expect } from '@jest/globals';
+import { generateBlogOuter } from '../../src/generator/generator.js';
+
+// Ensure generateBlogOuter includes the DOCTYPE declaration at the start
+
+describe('generateBlogOuter DOCTYPE', () => {
+  test('prepends DOCTYPE to generated HTML', () => {
+    const html = generateBlogOuter({ posts: [] });
+    expect(html.startsWith('<!DOCTYPE html>')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add a test confirming `generateBlogOuter` includes the HTML doctype

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846a60e5554832eb39baf9913169911