### PR TITLE
Add test for single blockquote corners

### DIFF
--- a/test/generator/blockquoteCorners.single.test.js
+++ b/test/generator/blockquoteCorners.single.test.js
@@ -1,0 +1,25 @@
+import { describe, test, expect } from '@jest/globals';
+import { generateBlog } from '../../src/generator/generator.js';
+
+const header = '<body>';
+const footer = '</body>';
+const wrapHtml = c => ['<html>', c, '</html>'].join('');
+
+describe('BLOCKQUOTE_CORNERS single post', () => {
+  test('blockquote corners appear for a quoted post', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'BQ1',
+          title: 'Quote1',
+          publicationDate: '2024-06-03',
+          content: [{ type: 'quote', content: 'Hi' }],
+        },
+      ],
+    };
+
+    const html = generateBlog({ blog, header, footer }, wrapHtml);
+    const matches = html.match(/corner-/g) || [];
+    expect(matches).toHaveLength(4);
+  });
+});


### PR DESCRIPTION
## Summary
- add coverage for BLOCKQUOTE_CORNERS constant when only one quote post is present

## Testing
- `npm test --silent`
- `npm run lint --silent`

------
https://chatgpt.com/codex/tasks/task_e_6846a60d6f2c832ea0018a4ea5e2e4c5