### PR TITLE
Add test for deep state copy arrays

### DIFF
--- a/test/browser/getDeepStateCopy.iterable.test.js
+++ b/test/browser/getDeepStateCopy.iterable.test.js
@@ -1,0 +1,16 @@
+import { describe, it, expect } from '@jest/globals';
+import { getDeepStateCopy } from '../../src/browser/toys.js';
+
+describe('getDeepStateCopy arrays of objects', () => {
+  it('clones nested arrays without mutating the original', () => {
+    const original = { levels: [{ a: 1 }, { b: { c: 2 } }] };
+    const copy = getDeepStateCopy(original);
+    expect(copy).toEqual(original);
+    expect(copy).not.toBe(original);
+    expect(copy.levels).not.toBe(original.levels);
+    expect(copy.levels[0]).not.toBe(original.levels[0]);
+    expect(copy.levels[1].b).not.toBe(original.levels[1].b);
+    copy.levels[1].b.c = 3;
+    expect(original.levels[1].b.c).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add regression test for `getDeepStateCopy` with nested arrays

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846a60d7f08832eb19cacbda30332db