### PR TITLE
Add test for createAddDropdownListener registration

### DIFF
--- a/test/browser/createAddDropdownListener.ensureListenerReturn.test.js
+++ b/test/browser/createAddDropdownListener.ensureListenerReturn.test.js
@@ -1,0 +1,25 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { createAddDropdownListener } from '../../src/browser/toys.js';
+
+describe('createAddDropdownListener ensures listener registration', () => {
+  it('returns a unary function that attaches a change handler', () => {
+    const onChange = jest.fn();
+    const dom = { addEventListener: jest.fn() };
+    const dropdown = {};
+
+    const listener = createAddDropdownListener(onChange, dom);
+
+    expect(typeof listener).toBe('function');
+    expect(listener.length).toBe(1);
+
+    const result = listener(dropdown);
+
+    expect(result).toBeUndefined();
+    expect(dom.addEventListener).toHaveBeenCalledTimes(1);
+    expect(dom.addEventListener).toHaveBeenCalledWith(
+      dropdown,
+      'change',
+      onChange
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add `createAddDropdownListener.ensureListenerReturn.test.js` to verify the returned listener registers the change handler

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846a60cc588832ebf2252a30f519c4e