### PR TITLE
Add wrapHtml empty content test

### DIFF
--- a/test/generator/wrapHtml.empty.test.js
+++ b/test/generator/wrapHtml.empty.test.js
@@ -1,0 +1,8 @@
+import { describe, test, expect } from '@jest/globals';
+import { wrapHtml } from '../../src/generator/html.js';
+
+describe('wrapHtml empty content', () => {
+  test('includes doctype and html wrapper even when content is empty', () => {
+    expect(wrapHtml('')).toBe('<!DOCTYPE html><html lang="en"></html>');
+  });
+});


### PR DESCRIPTION
## Summary
- test wrapHtml on an empty string to ensure the doctype is always added

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846a60c3e6c832e8f633bd391c73d31