### PR TITLE
Add missing test for createAddDropdownListener

### DIFF
--- a/test/browser/createAddDropdownListener.event.test.js
+++ b/test/browser/createAddDropdownListener.event.test.js
@@ -1,0 +1,20 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { createAddDropdownListener } from '../../src/browser/toys.js';
+
+describe('createAddDropdownListener direct usage', () => {
+  it('registers change handler on the provided element', () => {
+    const onChange = jest.fn();
+    const dom = { addEventListener: jest.fn() };
+    const dropdown = {};
+
+    const addListener = createAddDropdownListener(onChange, dom);
+    expect(typeof addListener).toBe('function');
+    expect(createAddDropdownListener.length).toBe(2);
+    expect(addListener.length).toBe(1);
+
+    const result = addListener(dropdown);
+    expect(result).toBeUndefined();
+    expect(dom.addEventListener).toHaveBeenCalledTimes(1);
+    expect(dom.addEventListener).toHaveBeenCalledWith(dropdown, 'change', onChange);
+  });
+});


### PR DESCRIPTION
## Summary
- add a direct test ensuring `createAddDropdownListener` registers a handler

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846a60a9cd0832e8b9882c787f20d5e