### PR TITLE
Add test for null dropdown listener

### DIFF
--- a/test/browser/createAddDropdownListener.null.test.js
+++ b/test/browser/createAddDropdownListener.null.test.js
@@ -1,0 +1,12 @@
+import { test, expect, jest } from '@jest/globals';
+import { createAddDropdownListener } from '../../src/browser/toys.js';
+
+test('createAddDropdownListener handles null dropdown', () => {
+  const onChange = jest.fn();
+  const dom = { addEventListener: jest.fn() };
+
+  const addListener = createAddDropdownListener(onChange, dom);
+  addListener(null);
+
+  expect(dom.addEventListener).toHaveBeenCalledWith(null, 'change', onChange);
+});


### PR DESCRIPTION
## Summary
- add a null dropdown case for `createAddDropdownListener` to strengthen mutation coverage

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846a60999dc832e837b231bae21cc5a