### PR TITLE
Add test for illustration wrapper

### DIFF
--- a/test/generator/mediaContentConfig.static.test.js
+++ b/test/generator/mediaContentConfig.static.test.js
@@ -64,4 +64,19 @@ describe('MEDIA_CONTENT_CONFIG via generateBlog', () => {
     const html = generateBlog({ blog, header, footer }, wrapHtml);
     expect(html).toContain('<p class="value"><iframe');
   });
+
+  test('illustration element wrapped in div tag', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'ILLU1',
+          title: 'Has Image',
+          publicationDate: '2024-07-01',
+          illustration: { fileType: 'jpg', altText: 'art' },
+        },
+      ],
+    };
+    const html = generateBlog({ blog, header, footer }, wrapHtml);
+    expect(html).toContain('<div class="value"><img');
+  });
 });


### PR DESCRIPTION
## Summary
- ensure MEDIA_CONTENT_CONFIG wraps illustrations in a div

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846a609f994832e9902033d17a77bb5