### PR TITLE
Add forward event test

### DIFF
--- a/test/browser/createAddDropdownListener.forward.test.js
+++ b/test/browser/createAddDropdownListener.forward.test.js
@@ -1,0 +1,17 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { createAddDropdownListener } from '../../src/browser/toys.js';
+
+describe('createAddDropdownListener forward event', () => {
+  it('registers change handler and forwards event object', () => {
+    const onChange = jest.fn();
+    const dom = {
+      addEventListener: jest.fn((el, evt, handler) => handler('evt')),
+    };
+    const dropdown = {};
+    const addListener = createAddDropdownListener(onChange, dom);
+    const result = addListener(dropdown);
+    expect(result).toBeUndefined();
+    expect(dom.addEventListener).toHaveBeenCalledWith(dropdown, 'change', onChange);
+    expect(onChange).toHaveBeenCalledWith('evt');
+  });
+});


### PR DESCRIPTION
## Summary
- add a test ensuring `createAddDropdownListener` forwards the event after registering the handler

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846a6087ea8832e9344aa797203003c