### PR TITLE
Improve input dropdown handler test coverage

### DIFF
--- a/test/browser/createInputDropdownHandler.default.test.js
+++ b/test/browser/createInputDropdownHandler.default.test.js
@@ -78,9 +78,11 @@ describe('createInputDropdownHandler default branch', () => {
     };
 
     const handler = createInputDropdownHandler(dom);
-    handler(event);
+    expect(() => handler(event)).not.toThrow();
 
     expect(reveal).toHaveBeenCalledWith(textInput);
     expect(enable).toHaveBeenCalledWith(textInput);
+    expect(hide).not.toHaveBeenCalled();
+    expect(disable).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- extend createInputDropdownHandler.text case to check for no-op conditions

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846add51fe0832ea0fa7b93fd08b955