### PR TITLE
Add test for mixed content normalization

### DIFF
--- a/test/generator/normalizeContentItem.mixed.test.js
+++ b/test/generator/normalizeContentItem.mixed.test.js
@@ -1,0 +1,25 @@
+import { describe, test, expect } from '@jest/globals';
+import { generateBlog } from '../../src/generator/generator.js';
+
+const header = '<body>';
+const footer = '</body>';
+const wrapHtml = c => c;
+
+describe('normalizeContentItem mixed content', () => {
+  test('generateBlog handles string, number, and null content', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'MIX',
+          title: 'Mixed Post',
+          publicationDate: '2024-06-01',
+          content: ['hello', 42, null],
+        },
+      ],
+    };
+    const html = generateBlog({ blog, header, footer }, wrapHtml);
+    expect(html).toContain('<p class="value">hello</p>');
+    expect(html).toContain('<p class="value">42</p>');
+    expect(html).toContain('<p class="value">null</p>');
+  });
+});


### PR DESCRIPTION
## Summary
- add mixed content test covering strings, numbers, and null values

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846adce63a0832ebdd8488b9a09253c