### PR TITLE
Add runtime test for article-title class

### DIFF
--- a/test/generator/articleTitleClass.runtimeKill.test.js
+++ b/test/generator/articleTitleClass.runtimeKill.test.js
@@ -1,0 +1,19 @@
+import { test, expect } from '@jest/globals';
+
+// Dynamically import within the test so Stryker associates coverage
+
+test('generateBlogOuter uses article-title class when module loaded at runtime', async () => {
+  const { generateBlogOuter } = await import('../../src/generator/generator.js');
+  const blog = {
+    posts: [
+      {
+        key: 'A1',
+        title: 'Hello',
+        publicationDate: '2024-01-01',
+        content: []
+      }
+    ]
+  };
+  const html = generateBlogOuter(blog);
+  expect(html).toMatch(/<div class="key article-title">A1<\/div>/);
+});


### PR DESCRIPTION
## Summary
- add runtime test using dynamic import to cover ARTICLE_TITLE constant

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846add1ce44832ea15bad523c58b205