### PR TITLE
Add test to kill mutation for update handler

### DIFF
--- a/test/browser/createUpdateTextInputValue.survivor.test.js
+++ b/test/browser/createUpdateTextInputValue.survivor.test.js
@@ -1,0 +1,17 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { createUpdateTextInputValue } from '../../src/browser/toys.js';
+
+describe('createUpdateTextInputValue survivor killer', () => {
+  it('updates the text input using dom utilities', () => {
+    const textInput = {};
+    const dom = {
+      getTargetValue: jest.fn(() => 'survivor'),
+      setValue: jest.fn(),
+    };
+    const handler = createUpdateTextInputValue(textInput, dom);
+    expect(typeof handler).toBe('function');
+    handler({});
+    expect(dom.getTargetValue).toHaveBeenCalled();
+    expect(dom.setValue).toHaveBeenCalledWith(textInput, 'survivor');
+  });
+});


### PR DESCRIPTION
## Summary
- extend coverage for `createUpdateTextInputValue`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846add1b8c0832eaacdf3fd40d24487