### PR TITLE
Add test for repeated null input in generateClues

### DIFF
--- a/test/toys/2025-05-11/battleshipSolitaireClues.nullInput.repeat.test.js
+++ b/test/toys/2025-05-11/battleshipSolitaireClues.nullInput.repeat.test.js
@@ -1,0 +1,12 @@
+import { describe, it, expect } from '@jest/globals';
+import { generateClues } from '../../../src/toys/2025-05-11/battleshipSolitaireClues.js';
+
+describe('generateClues repeated null input', () => {
+  it('handles null input consistently without throwing', () => {
+    const call = () => generateClues('null');
+    for (let i = 0; i < 3; i++) {
+      expect(call).not.toThrow();
+      expect(call()).toBe('{"error":"Invalid fleet structure"}');
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add regression test that repeatedly calls `generateClues('null')`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846add0da0c832e9532111958adf46a