### PR TITLE
Add test for createOutputDropdownHandler

### DIFF
--- a/test/browser/createOutputDropdownHandler.mutantElimination.test.js
+++ b/test/browser/createOutputDropdownHandler.mutantElimination.test.js
@@ -1,0 +1,21 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { createOutputDropdownHandler } from '../../src/browser/toys.js';
+
+describe('createOutputDropdownHandler mutation elimination', () => {
+  it('delegates to handleDropdownChange using event.currentTarget', () => {
+    const handleDropdownChange = jest.fn().mockReturnValue('xyz');
+    const getData = jest.fn();
+    const dom = {};
+
+    const handler = createOutputDropdownHandler(handleDropdownChange, getData, dom);
+
+    expect(handler.length).toBe(1);
+    expect(handler.toString()).toContain('currentTarget');
+
+    const evt = { currentTarget: { value: 42 } };
+    const result = handler(evt);
+
+    expect(result).toBe('xyz');
+    expect(handleDropdownChange).toHaveBeenCalledWith(evt.currentTarget, getData, dom);
+  });
+});


### PR DESCRIPTION
## Summary
- add a unit test that exercises `createOutputDropdownHandler`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846adccd7c4832ea1cbf2f717807eea