### PR TITLE
Add runtime import test for getDeepStateCopy

### DIFF
--- a/test/browser/getDeepStateCopy.toys.runtimeImport.test.js
+++ b/test/browser/getDeepStateCopy.toys.runtimeImport.test.js
@@ -1,0 +1,14 @@
+import { test, expect } from '@jest/globals';
+
+// Dynamically import to ensure coverage at runtime
+let getDeepStateCopy;
+
+test('getDeepStateCopy dynamically imported from toys makes a deep clone', async () => {
+  ({ getDeepStateCopy } = await import('../../src/browser/toys.js'));
+  const original = { nested: { arr: [1, 2] } };
+  const copy = getDeepStateCopy(original);
+  expect(copy).toEqual(original);
+  expect(copy).not.toBe(original);
+  expect(copy.nested).not.toBe(original.nested);
+  expect(copy.nested.arr).not.toBe(original.nested.arr);
+});


### PR DESCRIPTION
## Summary
- add a dynamic import test for `getDeepStateCopy` from `toys.js`

## Testing
- `npm test --silent`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6846adcc77b0832e9ea88d72b54bc701