### PR TITLE
Add dropdown handler dependency test

### DIFF
--- a/test/browser/createOutputDropdownHandler.multiple.test.js
+++ b/test/browser/createOutputDropdownHandler.multiple.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { createOutputDropdownHandler } from '../../src/browser/toys.js';
+
+describe('createOutputDropdownHandler multiple instances', () => {
+  it('binds dependencies for each returned handler', () => {
+    const handleDropdownChangeA = jest.fn().mockReturnValue('A');
+    const handleDropdownChangeB = jest.fn().mockReturnValue('B');
+    const getDataA = jest.fn();
+    const getDataB = jest.fn();
+    const dom = {};
+
+    const handlerA = createOutputDropdownHandler(handleDropdownChangeA, getDataA, dom);
+    const handlerB = createOutputDropdownHandler(handleDropdownChangeB, getDataB, dom);
+
+    const eventA = { currentTarget: { id: 'a' } };
+    const eventB = { currentTarget: { id: 'b' } };
+
+    const resultA = handlerA(eventA);
+    const resultB = handlerB(eventB);
+
+    expect(resultA).toBe('A');
+    expect(resultB).toBe('B');
+
+    expect(handleDropdownChangeA).toHaveBeenCalledWith(eventA.currentTarget, getDataA, dom);
+    expect(handleDropdownChangeB).toHaveBeenCalledWith(eventB.currentTarget, getDataB, dom);
+  });
+});


### PR DESCRIPTION
## Summary
- add a new test verifying `createOutputDropdownHandler` binds its dependencies correctly

## Testing
- `npm install`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846add1a96c832eb2ebbe1992e61279