### PR TITLE
Add DOCTYPE runtime test

### DIFF
--- a/test/generator/html.doctype.runtime.test.js
+++ b/test/generator/html.doctype.runtime.test.js
@@ -1,0 +1,9 @@
+import { describe, test, expect } from '@jest/globals';
+import { wrapHtml } from '../../src/generator/html.js';
+
+describe('wrapHtml DOCTYPE runtime', () => {
+  test('prepends the standard DOCTYPE', () => {
+    const result = wrapHtml('content');
+    expect(result.startsWith('<!DOCTYPE html>')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure `wrapHtml` outputs the standard DOCTYPE

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6846adcf9d0c832e8502655f956a3f96