### PR TITLE
Add order test for createInputDropdownHandler

### DIFF
--- a/test/browser/createInputDropdownHandler.order.test.js
+++ b/test/browser/createInputDropdownHandler.order.test.js
@@ -1,0 +1,34 @@
+import { test, expect, jest } from '@jest/globals';
+import { createInputDropdownHandler } from '../../src/browser/toys.js';
+
+test('createInputDropdownHandler reveals before enabling text input', () => {
+  const select = {};
+  const container = {};
+  const textInput = {};
+  const event = {};
+
+  const dom = {
+    getCurrentTarget: jest.fn(() => select),
+    getParentElement: jest.fn(() => container),
+    querySelector: jest.fn((_, selector) =>
+      selector === 'input[type="text"]' ? textInput : null
+    ),
+    getValue: jest.fn(() => 'text'),
+    reveal: jest.fn(),
+    enable: jest.fn(),
+    hide: jest.fn(),
+    disable: jest.fn(),
+    removeChild: jest.fn(),
+    addEventListener: jest.fn(),
+    getNextSibling: jest.fn(() => null),
+  };
+
+  const handler = createInputDropdownHandler(dom);
+  handler(event);
+
+  expect(dom.reveal).toHaveBeenCalledWith(textInput);
+  expect(dom.enable).toHaveBeenCalledWith(textInput);
+  const revealOrder = dom.reveal.mock.invocationCallOrder[0];
+  const enableOrder = dom.enable.mock.invocationCallOrder[0];
+  expect(revealOrder).toBeLessThan(enableOrder);
+});


### PR DESCRIPTION
## Summary
- add a test that checks reveal happens before enable in `createInputDropdownHandler`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846c05ed4e0832e9e1535eb2652b4d7