### PR TITLE
Add test for remove listener disposer

### DIFF
--- a/test/browser/createRemoveRemoveListener.count.test.js
+++ b/test/browser/createRemoveRemoveListener.count.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { setupRemoveButton } from '../../src/browser/toys.js';
+
+describe('createRemoveRemoveListener call count', () => {
+  it('invokes removeEventListener on dispose', () => {
+    const dom = {
+      setTextContent: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    };
+    const button = {};
+    const rows = {};
+    const render = jest.fn();
+    const disposers = [];
+
+    setupRemoveButton(dom, button, rows, render, 'k', disposers);
+
+    expect(disposers).toHaveLength(1);
+    const dispose = disposers[0];
+    const handler = dom.addEventListener.mock.calls[0][2];
+
+    dispose();
+
+    expect(dom.removeEventListener).toHaveBeenCalledTimes(1);
+    expect(dom.removeEventListener).toHaveBeenCalledWith(button, 'click', handler);
+  });
+});


### PR DESCRIPTION
## Summary
- add test to ensure `createRemoveRemoveListener` disposes event listeners

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846c05e03d4832eb42d62c79beb9751