### PR TITLE
Add deep clone test for getDeepStateCopy

### DIFF
--- a/test/browser/getDeepStateCopy.survivor.test.js
+++ b/test/browser/getDeepStateCopy.survivor.test.js
@@ -1,0 +1,14 @@
+import { describe, it, expect } from '@jest/globals';
+import { getDeepStateCopy } from '../../src/browser/toys.js';
+
+describe('getDeepStateCopy survivor elimination', () => {
+  it('creates a deep copy that does not share references', () => {
+    const original = { a: { b: 1 } };
+    const copy = getDeepStateCopy(original);
+    expect(copy).toEqual(original);
+    expect(copy).not.toBe(original);
+    expect(copy.a).not.toBe(original.a);
+    copy.a.b = 2;
+    expect(original.a.b).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add regression test for `getDeepStateCopy` to ensure returned object is a deep clone

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846c05de908832eaca5d64bc7c09c1d