### PR TITLE
Add deepObject test for getDeepStateCopy

### DIFF
--- a/test/browser/getDeepStateCopy.deepObject.test.js
+++ b/test/browser/getDeepStateCopy.deepObject.test.js
@@ -1,0 +1,14 @@
+import { describe, it, expect } from '@jest/globals';
+import { getDeepStateCopy } from '../../src/browser/toys.js';
+
+describe('getDeepStateCopy deeply nested object', () => {
+  it('clones objects with multiple nested levels', () => {
+    const original = { a: { b: { c: { d: 1 } } } };
+    const copy = getDeepStateCopy(original);
+    expect(copy).toEqual(original);
+    expect(copy).not.toBe(original);
+    expect(copy.a.b.c).not.toBe(original.a.b.c);
+    copy.a.b.c.d = 2;
+    expect(original.a.b.c.d).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add a deep object test for `getDeepStateCopy` to improve coverage

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846c05cb5e4832e91375aace731722f