### PR TITLE
Add test to kill getDeepStateCopy mutant

### DIFF
--- a/test/browser/getDeepStateCopy.importCache.test.js
+++ b/test/browser/getDeepStateCopy.importCache.test.js
@@ -1,0 +1,17 @@
+import { test, expect } from '@jest/globals';
+
+// Dynamically import with cache-busting query to avoid module caching
+async function loadModule() {
+  const suffix = `?cacheBust=${Date.now()}`;
+  const module = await import(`../../src/browser/toys.js${suffix}`);
+  return module.getDeepStateCopy;
+}
+
+test('getDeepStateCopy dynamically imported with cache busting returns deep copy', async () => {
+  const getDeepStateCopy = await loadModule();
+  const original = { level1: { value: 'x' } };
+  const copy = getDeepStateCopy(original);
+  expect(copy).toEqual(original);
+  expect(copy).not.toBe(original);
+  expect(copy.level1).not.toBe(original.level1);
+});


### PR DESCRIPTION
## Summary
- add cache-busting runtime import test for `getDeepStateCopy`

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6846c05d0c24832e99b499aed7af4d08