### PR TITLE
Add test for createInputDropdownHandler order

### DIFF
--- a/test/browser/createInputDropdownHandler.order.test.js
+++ b/test/browser/createInputDropdownHandler.order.test.js
@@ -1,0 +1,35 @@
+import { test, expect, jest } from '@jest/globals';
+import { createInputDropdownHandler } from '../../src/browser/toys.js';
+
+test('createInputDropdownHandler calls reveal before enable', () => {
+  const select = {};
+  const container = {};
+  const textInput = {};
+  const event = {};
+
+  const reveal = jest.fn();
+  const enable = jest.fn();
+
+  const querySelector = jest.fn((_, selector) =>
+    selector === 'input[type="text"]' ? textInput : null
+  );
+  const dom = {
+    getCurrentTarget: jest.fn(() => select),
+    getParentElement: jest.fn(() => container),
+    querySelector,
+    getValue: jest.fn(() => 'text'),
+    reveal,
+    enable,
+    hide: jest.fn(),
+    disable: jest.fn(),
+  };
+
+  const handler = createInputDropdownHandler(dom);
+  handler(event);
+
+  expect(reveal).toHaveBeenCalled();
+  expect(enable).toHaveBeenCalled();
+  expect(reveal.mock.invocationCallOrder[0]).toBeLessThan(enable.mock.invocationCallOrder[0]);
+  expect(dom.hide).not.toHaveBeenCalled();
+  expect(dom.disable).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- add a new unit test ensuring `createInputDropdownHandler` reveals before enabling the text input

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846c05befb0832ea1003d05ea84b716