### PR TITLE
Add test for boolean content normalization

### DIFF
--- a/test/generator/normalizeContentItem.booleanContent.test.js
+++ b/test/generator/normalizeContentItem.booleanContent.test.js
@@ -1,0 +1,23 @@
+import { describe, test, expect } from '@jest/globals';
+import { generateBlog } from '../../src/generator/generator.js';
+
+const header = '<body>';
+const footer = '</body>';
+const wrapHtml = c => c;
+
+describe('normalizeContentItem boolean content', () => {
+  test('generateBlog handles boolean content items', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'B1',
+          title: 'Boolean Post',
+          publicationDate: '2024-01-01',
+          content: [true]
+        }
+      ]
+    };
+    const html = generateBlog({ blog, header, footer }, wrapHtml);
+    expect(html).toContain('<p class="value">true</p>');
+  });
+});


### PR DESCRIPTION
## Summary
- address surviving mutant around `normalizationRules` in `generator.js`
- add regression test ensuring `generateBlog` correctly handles boolean content

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6846c05ad168832e90f577a4989b7936