### PR TITLE
Add test for blockquote corners constant

### DIFF
--- a/test/generator/blockquoteCorners.start.test.js
+++ b/test/generator/blockquoteCorners.start.test.js
@@ -1,0 +1,23 @@
+import { describe, test, expect } from '@jest/globals';
+import { generateBlog } from '../../src/generator/generator.js';
+
+const header = '<body>';
+const footer = '</body>';
+const wrapHtml = c => ['<html>', c, '</html>'].join('');
+
+describe('BLOCKQUOTE_CORNERS placement', () => {
+  test('blockquote corners appear immediately after blockquote tag', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'BQSTART',
+          title: 'Quote Start',
+          publicationDate: '2024-06-05',
+          content: [{ type: 'quote', content: 'Hi there' }]
+        }
+      ]
+    };
+    const html = generateBlog({ blog, header, footer }, wrapHtml);
+    expect(html).toContain('<blockquote class="value"><div class="corner corner-tl"');
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test verifying blockquote corners appear immediately after the blockquote tag

## Testing
- `npm test --silent`
- `npm run lint --silent`

------
https://chatgpt.com/codex/tasks/task_e_6846c05a7294832ebf6b46a8eb0d6502