### PR TITLE
Add trimming test for cyberpunkAdventure

### DIFF
--- a/test/toys/2025-03-30/cyberpunkAdventure.trim.test.js
+++ b/test/toys/2025-03-30/cyberpunkAdventure.trim.test.js
@@ -1,0 +1,18 @@
+import { describe, test, expect } from '@jest/globals';
+import { cyberpunkAdventure } from '../../../src/toys/2025-03-30/cyberpunkAdventure.js';
+
+describe('cyberpunkAdventure input trimming', () => {
+  test('trims whitespace around commands', () => {
+    let tempData = {};
+    const env = new Map([
+      ['getRandomNumber', () => 0.5],
+      ['getCurrentTime', () => '00:00'],
+      ['getData', () => ({ temporary: { CYBE1: tempData } })],
+      ['setData', data => { tempData = { ...tempData, ...data.temporary?.CYBE1 }; }],
+    ]);
+
+    cyberpunkAdventure('Blaze', env);
+    const result = cyberpunkAdventure('   start  ', env);
+    expect(result).toMatch(/Neon Market/);
+  });
+});


### PR DESCRIPTION
## Summary
- add a unit test verifying cyberpunkAdventure handles whitespace around commands

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846c05a10a4832e9faf5a0ec3b36180