### PR TITLE
Add nested array test for getDeepStateCopy

### DIFF
--- a/test/browser/getDeepStateCopy.nestedArray.test.js
+++ b/test/browser/getDeepStateCopy.nestedArray.test.js
@@ -1,0 +1,16 @@
+import { describe, it, expect } from '@jest/globals';
+import { getDeepStateCopy } from '../../src/browser/toys.js';
+
+describe('getDeepStateCopy nested arrays', () => {
+  it('deeply clones objects with multi-level arrays', () => {
+    const original = { items: [{ a: 1 }, { b: [2, { c: 3 }] }] };
+    const copy = getDeepStateCopy(original);
+    expect(copy).toEqual(original);
+    expect(copy).not.toBe(original);
+    expect(copy.items).not.toBe(original.items);
+    expect(copy.items[0]).not.toBe(original.items[0]);
+    expect(copy.items[1]).not.toBe(original.items[1]);
+    expect(copy.items[1].b).not.toBe(original.items[1].b);
+    expect(copy.items[1].b[1]).not.toBe(original.items[1].b[1]);
+  });
+});


### PR DESCRIPTION
## Summary
- add a new test verifying getDeepStateCopy deeply clones nested arrays

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846c059aba0832e894695695864c23d