### PR TITLE
Add test for DOCTYPE constant

### DIFF
--- a/test/generator/html.doctype.constant.test.js
+++ b/test/generator/html.doctype.constant.test.js
@@ -1,0 +1,8 @@
+import { describe, test, expect } from '@jest/globals';
+import { DOCTYPE } from '../../src/generator/html.js';
+
+describe('DOCTYPE constant', () => {
+  test('is standard HTML doctype', () => {
+    expect(DOCTYPE).toBe('<!DOCTYPE html>');
+  });
+});


### PR DESCRIPTION
## Summary
- add a unit test for the `DOCTYPE` constant in `html.js`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846c05ecfd0832eb8df8f01766cc2f6