### PR TITLE
Add test for unknown content type

### DIFF
--- a/test/generator/normalizeContentItem.unknownType.test.js
+++ b/test/generator/normalizeContentItem.unknownType.test.js
@@ -1,0 +1,23 @@
+import { describe, test, expect } from '@jest/globals';
+import { generateBlog } from '../../src/generator/generator.js';
+
+const header = '<body>';
+const footer = '</body>';
+const wrapHtml = c => c;
+
+describe('normalizeContentItem unknown type', () => {
+  test('generateBlog throws on unrecognized content type', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'UNK1',
+          title: 'Unknown Content',
+          publicationDate: '2025-01-01',
+          content: [{ type: 'unknown', content: 'oops' }],
+        },
+      ],
+    };
+    const call = () => generateBlog({ blog, header, footer }, wrapHtml);
+    expect(call).toThrow('renderer is not a function');
+  });
+});


### PR DESCRIPTION
## Summary
- add test for generating blog posts with unrecognized content type

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846d1803f54832ea10f4f31c23c70af