### PR TITLE
Add test to kill surviving mutant

### DIFF
--- a/test/browser/createUpdateTextInputValue.multipleCalls.test.js
+++ b/test/browser/createUpdateTextInputValue.multipleCalls.test.js
@@ -1,0 +1,23 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { createUpdateTextInputValue } from '../../src/browser/toys.js';
+
+describe('createUpdateTextInputValue multiple calls', () => {
+  it('updates the input using the latest value each time', () => {
+    const textInput = {};
+    const dom = {
+      getTargetValue: jest.fn()
+        .mockReturnValueOnce('first')
+        .mockReturnValueOnce('second'),
+      setValue: jest.fn(),
+    };
+    const handler = createUpdateTextInputValue(textInput, dom);
+    const evtA = {};
+    const evtB = {};
+    handler(evtA);
+    handler(evtB);
+    expect(dom.getTargetValue).toHaveBeenNthCalledWith(1, evtA);
+    expect(dom.getTargetValue).toHaveBeenNthCalledWith(2, evtB);
+    expect(dom.setValue).toHaveBeenNthCalledWith(1, textInput, 'first');
+    expect(dom.setValue).toHaveBeenNthCalledWith(2, textInput, 'second');
+  });
+});


### PR DESCRIPTION
## Summary
- add a unit test exercising repeated calls to `createUpdateTextInputValue`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846d17fafdc832e915ecb7a5119e9e5