### PR TITLE
Improve dropdown handler test coverage

### DIFF
--- a/test/browser/createInputDropdownHandler.defaultHandler2.test.js
+++ b/test/browser/createInputDropdownHandler.defaultHandler2.test.js
@@ -1,0 +1,37 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { createInputDropdownHandler } from '../../src/browser/toys.js';
+
+describe('createInputDropdownHandler default fallback', () => {
+  it('uses default handler for unknown select values', () => {
+    const select = {};
+    const container = {};
+    const textInput = {};
+    const event = {};
+
+    const querySelector = jest.fn((parent, selector) => {
+      if (parent === container && selector === 'input[type="text"]') {
+        return textInput;
+      }
+      return null;
+    });
+
+    const dom = {
+      getCurrentTarget: jest.fn(() => select),
+      getParentElement: jest.fn(() => container),
+      querySelector,
+      getValue: jest.fn(() => 'unknown'),
+      reveal: jest.fn(),
+      enable: jest.fn(),
+      hide: jest.fn(),
+      disable: jest.fn(),
+      removeChild: jest.fn(),
+    };
+
+    const handler = createInputDropdownHandler(dom);
+    expect(() => handler(event)).not.toThrow();
+    expect(dom.hide).toHaveBeenCalledWith(textInput);
+    expect(dom.disable).toHaveBeenCalledWith(textInput);
+    expect(dom.reveal).not.toHaveBeenCalled();
+    expect(dom.enable).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add a test ensuring `createInputDropdownHandler` falls back to the default handler when the dropdown value is unknown

## Testing
- `npm test --silent`
- `npm run lint --silent`

------
https://chatgpt.com/codex/tasks/task_e_6846d17eeca8832e9933bfde14f745fd