### PR TITLE
Fix revealBetaArticles

### DIFF
--- a/public/browser/beta.js
+++ b/public/browser/beta.js
@@ -2,6 +2,7 @@ export function revealBetaArticles(dom) {
   if (dom.hasBetaParam()) {
     const articles = dom.querySelectorAll('article.release-beta');
     Array.from(articles).forEach(article => {
+      dom.removeClass(article, 'release-beta');
       dom.reveal(article);
     });
   }

--- a/public/browser/document.js
+++ b/public/browser/document.js
@@ -10,6 +10,10 @@ export const querySelectorAll = selector => document.querySelectorAll(selector);
 export const addClass = (element, className) =>
   element.classList.add(className);
 
+export const removeClass = (element, className) => {
+  element.classList.remove(className);
+};
+
 export const setClassName = (element, className) => {
   element.className = className;
 };
@@ -250,6 +254,7 @@ export const dom = {
   setDataAttribute,
   getDataAttribute,
   addClass,
+  removeClass,
   removeEventListener,
   appendChild,
   createTextNode,

--- a/src/browser/beta.js
+++ b/src/browser/beta.js
@@ -2,6 +2,7 @@ export function revealBetaArticles(dom) {
   if (dom.hasBetaParam()) {
     const articles = dom.querySelectorAll('article.release-beta');
     Array.from(articles).forEach(article => {
+      dom.removeClass(article, 'release-beta');
       dom.reveal(article);
     });
   }

--- a/src/browser/document.js
+++ b/src/browser/document.js
@@ -10,6 +10,10 @@ export const querySelectorAll = selector => document.querySelectorAll(selector);
 export const addClass = (element, className) =>
   element.classList.add(className);
 
+export const removeClass = (element, className) => {
+  element.classList.remove(className);
+};
+
 export const setClassName = (element, className) => {
   element.className = className;
 };
@@ -250,6 +254,7 @@ export const dom = {
   setDataAttribute,
   getDataAttribute,
   addClass,
+  removeClass,
   removeEventListener,
   appendChild,
   createTextNode,

--- a/test/browser/revealBetaArticles.test.js
+++ b/test/browser/revealBetaArticles.test.js
@@ -6,11 +6,15 @@ describe('revealBetaArticles', () => {
     const articles = [{}, {}];
     const dom = {
       querySelectorAll: jest.fn(() => articles),
+      removeClass: jest.fn(),
       reveal: jest.fn(),
       hasBetaParam: () => true,
     };
     revealBetaArticles(dom);
     expect(dom.querySelectorAll).toHaveBeenCalledWith('article.release-beta');
+    expect(dom.removeClass).toHaveBeenCalledTimes(2);
+    expect(dom.removeClass).toHaveBeenCalledWith(articles[0], 'release-beta');
+    expect(dom.removeClass).toHaveBeenCalledWith(articles[1], 'release-beta');
     expect(dom.reveal).toHaveBeenCalledTimes(2);
     expect(dom.reveal).toHaveBeenCalledWith(articles[0]);
     expect(dom.reveal).toHaveBeenCalledWith(articles[1]);
@@ -19,11 +23,13 @@ describe('revealBetaArticles', () => {
   test('does nothing when query parameter is absent', () => {
     const dom = {
       querySelectorAll: jest.fn(),
+      removeClass: jest.fn(),
       reveal: jest.fn(),
       hasBetaParam: () => false,
     };
     revealBetaArticles(dom);
     expect(dom.querySelectorAll).not.toHaveBeenCalled();
+    expect(dom.removeClass).not.toHaveBeenCalled();
     expect(dom.reveal).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- update revealBetaArticles to remove `release-beta` class when ?beta is in the URL
- add `removeClass` DOM helper and expose via `dom`
- update public assets and tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846d08bfb14832ea52c90bb279bb47b