### PR TITLE
Add extra null input test for generateClues

### DIFF
--- a/test/toys/2025-05-11/battleshipSolitaireClues.nullInput.functionality.test.js
+++ b/test/toys/2025-05-11/battleshipSolitaireClues.nullInput.functionality.test.js
@@ -1,0 +1,10 @@
+import { describe, it, expect } from '@jest/globals';
+import { generateClues } from '../../../src/toys/2025-05-11/battleshipSolitaireClues.js';
+
+describe('generateClues null input functionality', () => {
+  it('produces the expected error object without throwing', () => {
+    const call = () => generateClues('null');
+    expect(call).not.toThrow();
+    expect(call()).toBe('{"error":"Invalid fleet structure"}');
+  });
+});


### PR DESCRIPTION
## Summary
- add a new test covering `generateClues('null')` to guard against optional chaining mutations

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846d6647c34832eae9b3546a214ac63