### PR TITLE
Add kv handler test

### DIFF
--- a/test/browser/createInputDropdownHandler.kv.test.js
+++ b/test/browser/createInputDropdownHandler.kv.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import * as toys from '../../src/browser/toys.js';
+
+describe('createInputDropdownHandler kv type', () => {
+  it('removes number input and ensures kv container', () => {
+    const select = {};
+    const container = { insertBefore: jest.fn() };
+    const textInput = {};
+    const numberInput = { _dispose: jest.fn() };
+    const event = {};
+
+    const dom = {
+      getCurrentTarget: jest.fn(() => select),
+      getParentElement: jest.fn(() => container),
+      querySelector: jest.fn((el, selector) => {
+        if (selector === 'input[type="text"]') {return textInput;}
+        if (selector === 'input[type="number"]') {return numberInput;}
+        return null;
+      }),
+      createElement: jest.fn(() => ({})),
+      setClassName: jest.fn(),
+      getNextSibling: jest.fn(() => null),
+      insertBefore: jest.fn(),
+      removeChild: jest.fn(),
+      removeAllChildren: jest.fn(),
+      setType: jest.fn(),
+      setPlaceholder: jest.fn(),
+      setValue: jest.fn(),
+      setDataAttribute: jest.fn(),
+      addEventListener: jest.fn(),
+      setTextContent: jest.fn(),
+      appendChild: jest.fn(),
+      getValue: jest.fn(() => 'kv'),
+      reveal: jest.fn(),
+      enable: jest.fn(),
+      hide: jest.fn(),
+      disable: jest.fn(),
+      querySelectorAll: jest.fn(),
+      createTextNode: jest.fn(),
+    };
+
+    const handler = toys.createInputDropdownHandler(dom);
+
+    expect(() => handler(event)).not.toThrow();
+    expect(dom.hide).toHaveBeenCalledWith(textInput);
+    expect(dom.disable).toHaveBeenCalledWith(textInput);
+    expect(dom.removeChild).toHaveBeenCalledWith(container, numberInput);
+    expect(dom.insertBefore).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add missing test for createInputDropdownHandler when the `kv` option is selected

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846d6639c60832e8ce5bd5b99e4bd7e