### PR TITLE
Improve string content normalization test

### DIFF
--- a/test/generator/normalizeContentItem.stringContent.test.js
+++ b/test/generator/normalizeContentItem.stringContent.test.js
@@ -1,23 +1,24 @@
-import { describe, test, expect } from "@jest/globals";
-import { generateBlog } from "../../src/generator/generator.js";
+import { describe, test, expect } from '@jest/globals';
+import { generateBlog } from '../../src/generator/generator.js';
 
-const header = "<body>";
-const footer = "</body>";
-const wrapHtml = (c) => c;
+const header = '<body>';
+const footer = '</body>';
+const wrapHtml = c => c;
 
-describe("normalizeContentItem integration", () => {
-  test("generateBlog renders string content as paragraphs", () => {
+describe('normalizeContentItem integration', () => {
+  test('generateBlog renders string content as paragraphs', () => {
     const blog = {
       posts: [
         {
-          key: "S1",
-          title: "String Post",
-          publicationDate: "2024-01-01",
-          content: ["Hello world"],
+          key: 'S1',
+          title: 'String Post',
+          publicationDate: '2024-01-01',
+          content: ['Hello world'],
         },
       ],
     };
     const html = generateBlog({ blog, header, footer }, wrapHtml);
+    expect(html).toContain('<div class="key">text</div>');
     expect(html).toContain('<p class="value">Hello world</p>');
   });
 });


### PR DESCRIPTION
## Summary
- ensure generateBlog output includes the `text` key when normalizing string content

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846d664d984832eb0d92304ffcf9212