### PR TITLE
Add test for formatBaseLink default attributes

### DIFF
--- a/test/generator/formatBaseLink.targetRel.test.js
+++ b/test/generator/formatBaseLink.targetRel.test.js
@@ -1,0 +1,27 @@
+import fs from 'fs';
+import path from 'path';
+import { pathToFileURL } from 'url';
+import { beforeAll, describe, test, expect } from '@jest/globals';
+
+let formatBaseLink;
+
+beforeAll(async () => {
+  const generatorPath = path.join(process.cwd(), 'src/generator/generator.js');
+  let src = fs.readFileSync(generatorPath, 'utf8');
+  src = src.replace(/from '\.\/(.*?)'/g, (_, p) => {
+    const absolute = pathToFileURL(path.join(path.dirname(generatorPath), p));
+    return `from '${absolute.href}'`;
+  });
+  src += '\nexport { formatBaseLink };';
+  src += `\n//# sourceURL=${generatorPath}`;
+  ({ formatBaseLink } = await import(`data:text/javascript,${encodeURIComponent(src)}`));
+});
+
+describe('formatBaseLink default attributes', () => {
+  test('includes target and rel attributes', () => {
+    const result = formatBaseLink('article', 'https://example.com', 'Example');
+    expect(result).toBe(
+      '<a href="https://example.com" target="_blank" rel="noopener">"Example"</a>'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add test to ensure `formatBaseLink` inserts the default `target` and `rel` attributes

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846d6632038832e8ca066a1058b3565