### PR TITLE
Add coverage for DATE_FORMAT_OPTIONS constant

### DIFF
--- a/test/generator/dateFormatOptions.constant.test.js
+++ b/test/generator/dateFormatOptions.constant.test.js
@@ -1,0 +1,13 @@
+import { describe, test, expect } from '@jest/globals';
+import fs from 'fs';
+import path from 'path';
+
+const generatorPath = path.join(process.cwd(), 'src/generator/generator.js');
+
+describe('DATE_FORMAT_OPTIONS constant', () => {
+  test('is defined with numeric day, short month, and numeric year', () => {
+    const source = fs.readFileSync(generatorPath, 'utf8');
+    const regex = /const DATE_FORMAT_OPTIONS = \{\s*day: 'numeric',\s*month: 'short',\s*year: 'numeric',?\s*\}/;
+    expect(source).toMatch(regex);
+  });
+});


### PR DESCRIPTION
## Summary
- test generator constant `DATE_FORMAT_OPTIONS` by inspecting `generator.js`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846d662e238832ea2a232ea5e50c8c1