### PR TITLE
Add date formatting survivor test

### DIFF
--- a/test/generator/dateFormat.survivorKill.test.js
+++ b/test/generator/dateFormat.survivorKill.test.js
@@ -1,0 +1,21 @@
+import { test, expect } from '@jest/globals';
+import { generateBlog } from '../../src/generator/generator.js';
+
+const header = '<body>';
+const footer = '</body>';
+const wrapHtml = html => html;
+
+test('generateBlog formats publication date with short month name', () => {
+  const blog = {
+    posts: [
+      {
+        key: 'DATE-SK',
+        title: 'Date Survivor',
+        publicationDate: '2024-05-04',
+        content: ['entry'],
+      },
+    ],
+  };
+  const html = generateBlog({ blog, header, footer }, wrapHtml);
+  expect(html).toContain('4 May 2024');
+});


### PR DESCRIPTION
## Summary
- add a regression test ensuring formatted dates include a short month name

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846d6613830832eaf674eaea13b4c72