### PR TITLE
Add test for createUpdateTextInputValue

### DIFF
--- a/test/browser/createUpdateTextInputValue.additional.test.js
+++ b/test/browser/createUpdateTextInputValue.additional.test.js
@@ -1,0 +1,20 @@
+import { test, expect, jest } from '@jest/globals';
+import { createUpdateTextInputValue } from '../../src/browser/toys.js';
+
+test('createUpdateTextInputValue returns handler that forwards value', () => {
+  const textInput = {};
+  const dom = {
+    getTargetValue: jest.fn(() => 'added'),
+    setValue: jest.fn(),
+  };
+
+  const handler = createUpdateTextInputValue(textInput, dom);
+  expect(typeof handler).toBe('function');
+  expect(handler.length).toBe(1);
+
+  const ev = {};
+  handler(ev);
+
+  expect(dom.getTargetValue).toHaveBeenCalledWith(ev);
+  expect(dom.setValue).toHaveBeenCalledWith(textInput, 'added');
+});


### PR DESCRIPTION
## Summary
- add a new unit test covering `createUpdateTextInputValue`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846da5bd344832eb99f161017ff93ac