### PR TITLE
Add test for remove listener disposer

### DIFF
--- a/test/browser/createRemoveRemoveListener.doubleRemoval.test.js
+++ b/test/browser/createRemoveRemoveListener.doubleRemoval.test.js
@@ -1,0 +1,30 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { setupRemoveButton } from '../../src/browser/toys.js';
+
+describe('createRemoveRemoveListener multiple disposals', () => {
+  it('removes the listener each time the disposer is called', () => {
+    const dom = {
+      setTextContent: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    };
+    const button = {};
+    const rows = {};
+    const render = jest.fn();
+    const disposers = [];
+
+    setupRemoveButton(dom, button, rows, render, 'k', disposers);
+
+    expect(disposers).toHaveLength(1);
+    const dispose = disposers[0];
+    expect(typeof dispose).toBe('function');
+
+    const handler = dom.addEventListener.mock.calls[0][2];
+
+    dispose();
+    dispose();
+
+    expect(dom.removeEventListener).toHaveBeenNthCalledWith(1, button, 'click', handler);
+    expect(dom.removeEventListener).toHaveBeenNthCalledWith(2, button, 'click', handler);
+  });
+});


### PR DESCRIPTION
## Summary
- add coverage for repeated dispose calls on remove listener cleanup

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846da5adc08832eae52f62931e0f7ea