### PR TITLE
Add missing null input test

### DIFF
--- a/test/toys/2025-05-11/battleshipSolitaireClues.nullInput.direct.test.js
+++ b/test/toys/2025-05-11/battleshipSolitaireClues.nullInput.direct.test.js
@@ -1,0 +1,10 @@
+import { describe, it, expect } from '@jest/globals';
+import { generateClues } from '../../../src/toys/2025-05-11/battleshipSolitaireClues.js';
+
+describe('generateClues null input direct call', () => {
+  it('returns invalid fleet structure and does not throw', () => {
+    const call = () => generateClues('null');
+    expect(call).not.toThrow();
+    expect(call()).toBe('{"error":"Invalid fleet structure"}');
+  });
+});


### PR DESCRIPTION
## Summary
- add direct test for `generateClues('null')` to ensure graceful error handling

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6846da5a44f8832ead9091bcdaaf9993