### PR TITLE
Add sequential dropdown handler test

### DIFF
--- a/test/browser/createInputDropdownHandler.sequenceAdditional.test.js
+++ b/test/browser/createInputDropdownHandler.sequenceAdditional.test.js
@@ -1,0 +1,45 @@
+import { describe, test, expect, jest } from '@jest/globals';
+import { createInputDropdownHandler } from '../../src/browser/toys.js';
+
+describe('createInputDropdownHandler sequential values', () => {
+  test('handles text then unknown then text again', () => {
+    const select = {};
+    const container = {};
+    const textInput = {};
+    const event = {};
+
+    const dom = {
+      getCurrentTarget: jest.fn(() => select),
+      getParentElement: jest.fn(() => container),
+      querySelector: jest.fn((_, selector) =>
+        selector === 'input[type="text"]' ? textInput : null
+      ),
+      getValue: jest
+        .fn()
+        .mockReturnValueOnce('text')
+        .mockReturnValueOnce('unknown')
+        .mockReturnValueOnce('text'),
+      reveal: jest.fn(),
+      enable: jest.fn(),
+      hide: jest.fn(),
+      disable: jest.fn(),
+    };
+
+    const handler = createInputDropdownHandler(dom);
+
+    expect(() => handler(event)).not.toThrow();
+    expect(dom.reveal).toHaveBeenCalledWith(textInput);
+    expect(dom.enable).toHaveBeenCalledWith(textInput);
+
+    dom.reveal.mockClear();
+    dom.enable.mockClear();
+
+    expect(() => handler(event)).not.toThrow();
+    expect(dom.hide).toHaveBeenCalledWith(textInput);
+    expect(dom.disable).toHaveBeenCalledWith(textInput);
+
+    expect(() => handler(event)).not.toThrow();
+    expect(dom.reveal).toHaveBeenCalledWith(textInput);
+    expect(dom.enable).toHaveBeenCalledWith(textInput);
+  });
+});


### PR DESCRIPTION
## Summary
- add test for sequential input dropdown values

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6846da5875f4832e9692af20fc700a44