### PR TITLE
Add test for html tag wrapping

### DIFF
--- a/test/generator/html.tagName.runtime.test.js
+++ b/test/generator/html.tagName.runtime.test.js
@@ -1,0 +1,9 @@
+import { describe, test, expect } from '@jest/globals';
+import { wrapHtml } from '../../src/generator/html.js';
+
+describe('HTML_TAG_NAME usage', () => {
+  test('wrapHtml wraps content in html tag', () => {
+    const result = wrapHtml('body');
+    expect(result).toContain('<html lang="en">body</html>');
+  });
+});


### PR DESCRIPTION
## Summary
- add regression test ensuring `wrapHtml` uses the correct html tag

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6846da568184832ead224896cb3bd42c