### PR TITLE
Add missing test for createHandleSubmit handler

### DIFF
--- a/test/browser/createHandleSubmit.string.test.js
+++ b/test/browser/createHandleSubmit.string.test.js
@@ -1,0 +1,32 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { createHandleSubmit } from '../../src/browser/toys.js';
+
+describe('createHandleSubmit string representation', () => {
+  it('includes stopDefault call in the returned handler', () => {
+    const dom = {
+      stopDefault: jest.fn(),
+      removeAllChildren: jest.fn(),
+      appendChild: jest.fn(),
+      createElement: jest.fn(() => ({})),
+      setTextContent: jest.fn(),
+      addWarning: jest.fn(),
+    };
+    const env = {
+      dom,
+      createEnv: jest.fn(() => new Map([['getData', jest.fn()], ['setData', jest.fn()]])),
+      errorFn: jest.fn(),
+      fetchFn: jest.fn(() => Promise.resolve({ text: jest.fn(() => Promise.resolve('') ) })),
+    };
+    const elements = {
+      inputElement: { value: '' },
+      outputParentElement: {},
+      outputSelect: { value: 'text' },
+      article: { id: 'a1' },
+    };
+
+    const handler = createHandleSubmit(elements, jest.fn(() => ''), env);
+    expect(typeof handler).toBe('function');
+    expect(handler.length).toBe(1);
+    expect(handler.toString()).toContain('stopDefault');
+  });
+});


### PR DESCRIPTION
## Summary
- ensure createHandleSubmit's returned handler contains the stopDefault call

## Testing
- `npm test --silent`
- `npm run lint --silent`

------
https://chatgpt.com/codex/tasks/task_e_6846da54ea2c832ebfe00ba14f1d30e7