### PR TITLE
Add test for blog date formatting

### DIFF
--- a/test/generator/generateBlogOuter.dateFormat.test.js
+++ b/test/generator/generateBlogOuter.dateFormat.test.js
@@ -1,0 +1,15 @@
+import { describe, it, expect } from '@jest/globals';
+import { generateBlogOuter } from '../../src/generator/generator.js';
+
+describe('generateBlogOuter date formatting', () => {
+  it('formats publication dates with short month names', () => {
+    const blog = {
+      posts: [
+        { key: 'DF1', title: 'Date Test', publicationDate: '2024-06-01', content: [] },
+      ],
+    };
+
+    const html = generateBlogOuter(blog);
+    expect(html).toContain('<p class="value metadata">1 Jun 2024</p>');
+  });
+});


### PR DESCRIPTION
## Summary
- add a unit test verifying `generateBlogOuter` formats publication dates with short month names

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846da536c38832eb7d9de86771fe6f7