### PR TITLE
Add date formatting runtime test

### DIFF
--- a/test/generator/dateFormatOptions.runtime.test.js
+++ b/test/generator/dateFormatOptions.runtime.test.js
@@ -1,0 +1,24 @@
+import { describe, test, expect, jest } from '@jest/globals';
+import { generateBlog } from '../../src/generator/generator.js';
+
+const header = '<body>';
+const footer = '</body>';
+const wrapHtml = html => html;
+
+describe('DATE_FORMAT_OPTIONS runtime', () => {
+  test('generateBlog uses short month formatting', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'DATE_OPT',
+          title: 'Post',
+          publicationDate: '2024-05-04',
+          content: ['Example'],
+        },
+      ],
+    };
+
+    const html = generateBlog({ blog, header, footer }, wrapHtml);
+    expect(html).toContain('<p class="value metadata">4 May 2024</p>');
+  });
+});


### PR DESCRIPTION
## Summary
- add test covering DATE_FORMAT_OPTIONS at runtime

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846da557204832e874a89a9d5b93d5e