### PR TITLE
Add mutation-killing test

### DIFF
--- a/test/browser/createOutputDropdownHandler.additionalKill.test.js
+++ b/test/browser/createOutputDropdownHandler.additionalKill.test.js
@@ -1,0 +1,34 @@
+import { test, expect, jest } from '@jest/globals';
+import { createOutputDropdownHandler } from '../../src/browser/toys.js';
+
+test('createOutputDropdownHandler delegates using a fresh handler', () => {
+  const handleDropdownChange = jest.fn();
+  const getData = jest.fn();
+  const dom = {};
+
+  expect(createOutputDropdownHandler.length).toBe(3);
+
+  const handlerA = createOutputDropdownHandler(
+    handleDropdownChange,
+    getData,
+    dom
+  );
+  const handlerB = createOutputDropdownHandler(
+    handleDropdownChange,
+    getData,
+    dom
+  );
+
+  expect(typeof handlerA).toBe('function');
+  expect(typeof handlerB).toBe('function');
+  expect(handlerA).not.toBe(handlerB);
+  expect(handlerA.length).toBe(1);
+
+  const event = { currentTarget: { id: 'x' } };
+  handlerA(event);
+  expect(handleDropdownChange).toHaveBeenCalledWith(
+    event.currentTarget,
+    getData,
+    dom
+  );
+});


### PR DESCRIPTION
## Summary
- add additional unit test for `createOutputDropdownHandler`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846da54f77c832e9329a6d6996360b3