### PR TITLE
Add extra date formatting test

### DIFF
--- a/test/generator/dateFormat.additional.test.js
+++ b/test/generator/dateFormat.additional.test.js
@@ -1,0 +1,21 @@
+import { test, expect } from '@jest/globals';
+import { generateBlog } from '../../src/generator/generator.js';
+
+const header = '<body>';
+const footer = '</body>';
+const wrapHtml = html => html;
+
+test('generateBlog formats another publication date with short month', () => {
+  const blog = {
+    posts: [
+      {
+        key: 'DATE2',
+        title: 'Another Date',
+        publicationDate: '2025-12-31',
+        content: ['entry'],
+      },
+    ],
+  };
+  const html = generateBlog({ blog, header, footer }, wrapHtml);
+  expect(html).toContain('31 Dec 2025');
+});


### PR DESCRIPTION
## Summary
- add a test checking that a different publication date formats with the expected short month name

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846da517ee4832e81826655d1c3c19b