### PR TITLE
Add sequential dropdown handler test

### DIFF
--- a/test/browser/createInputDropdownHandler.sequentialValues.test.js
+++ b/test/browser/createInputDropdownHandler.sequentialValues.test.js
@@ -1,0 +1,47 @@
+import { test, expect, jest } from '@jest/globals';
+import { createInputDropdownHandler } from '../../src/browser/toys.js';
+
+test('createInputDropdownHandler handles text, unknown, then text', () => {
+  const event = {};
+  const select = {};
+  const container = {};
+  const textInput = {};
+
+  const dom = {
+    getCurrentTarget: jest.fn(() => select),
+    getParentElement: jest.fn(() => container),
+    querySelector: jest.fn((_, selector) => (selector === 'input[type="text"]' ? textInput : null)),
+    getValue: jest
+      .fn()
+      .mockReturnValueOnce('text')
+      .mockReturnValueOnce('unknown')
+      .mockReturnValueOnce('text'),
+    reveal: jest.fn(),
+    enable: jest.fn(),
+    hide: jest.fn(),
+    disable: jest.fn(),
+  };
+
+  const handler = createInputDropdownHandler(dom);
+
+  // text value
+  expect(() => handler(event)).not.toThrow();
+  expect(dom.reveal).toHaveBeenCalledWith(textInput);
+  expect(dom.enable).toHaveBeenCalledWith(textInput);
+
+  dom.reveal.mockClear();
+  dom.enable.mockClear();
+
+  // unknown value
+  expect(() => handler(event)).not.toThrow();
+  expect(dom.hide).toHaveBeenCalledWith(textInput);
+  expect(dom.disable).toHaveBeenCalledWith(textInput);
+
+  dom.hide.mockClear();
+  dom.disable.mockClear();
+
+  // text value again
+  expect(() => handler(event)).not.toThrow();
+  expect(dom.reveal).toHaveBeenCalledWith(textInput);
+  expect(dom.enable).toHaveBeenCalledWith(textInput);
+});


### PR DESCRIPTION
## Summary
- extend `createInputDropdownHandler` tests with sequential value scenario

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846da59f5b8832eb66d5e9ec2f42cb6