### PR TITLE
Add UUID toy with updated beta post

### DIFF
--- a/public/2025-06-09/uuid.js
+++ b/public/2025-06-09/uuid.js
@@ -1,0 +1,6 @@
+// Toy: UUID from environment
+// (input, env) -> string
+export function uuidToy(input, env) {
+  const getUuid = env.get("getUuid");
+  return getUuid();
+}

--- a/public/blog.json
+++ b/public/blog.json
@@ -1,11 +1,16 @@
 {
   "posts": [
     {
-      "key": "BETA1",
-      "title": "Beta Post",
-      "publicationDate": "2030-01-01",
+      "key": "UUID1",
+      "title": "UUID",
+      "publicationDate": "2025-06-09",
       "release": "beta",
-      "content": ["This is a beta post used for testing the beta feature flag."]
+      "content": ["Returns a random UUID."],
+      "toy": {
+        "modulePath": "/2025-06-09/uuid.js",
+        "functionName": "uuidToy"
+      },
+      "tags": ["toy", "uuid", "beta"]
     },
     {
       "key": "SELF1",

--- a/src/blog.json
+++ b/src/blog.json
@@ -1,11 +1,16 @@
 {
   "posts": [
     {
-      "key": "BETA1",
-      "title": "Beta Post",
-      "publicationDate": "2030-01-01",
+      "key": "UUID1",
+      "title": "UUID",
+      "publicationDate": "2025-06-09",
       "release": "beta",
-      "content": ["This is a beta post used for testing the beta feature flag."]
+      "content": ["Returns a random UUID."],
+      "toy": {
+        "modulePath": "/2025-06-09/uuid.js",
+        "functionName": "uuidToy"
+      },
+      "tags": ["toy", "uuid", "beta"]
     },
     {
       "key": "SELF1",

--- a/src/toys/2025-06-09/uuid.js
+++ b/src/toys/2025-06-09/uuid.js
@@ -1,0 +1,6 @@
+// Toy: UUID from environment
+// (input, env) -> string
+export function uuidToy(input, env) {
+  const getUuid = env.get("getUuid");
+  return getUuid();
+}

--- a/test/toys/2025-06-09/uuid.test.js
+++ b/test/toys/2025-06-09/uuid.test.js
@@ -1,0 +1,11 @@
+import { uuidToy } from '../../../src/toys/2025-06-09/uuid.js';
+import { jest } from '@jest/globals';
+
+describe('uuidToy', () => {
+  it('returns the uuid from the environment', () => {
+    const mockUuid = '84f8e1f2-3e9d-4fd1-b1a2-d9c2bd34fdba';
+    const getUuid = jest.fn(() => mockUuid);
+    const env = { get: key => (key === 'getUuid' ? getUuid : undefined) };
+    expect(uuidToy(undefined, env)).toBe(mockUuid);
+  });
+});


### PR DESCRIPTION
## Summary
- delete BETA1 placeholder blog post
- rename uuid toy directory to today's date
- adjust uuid toy to accept (input, env)
- post now titled "UUID" with updated date and tags
- refresh generated public files and tests

## Testing
- `npm run lint` (with warnings)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6846debc9c24832e90a7c20a2da42fd6