### PR TITLE
Add HTML_ESCAPE_REPLACEMENTS usage test

### DIFF
--- a/test/generator/html.escapeReplacements.usage.test.js
+++ b/test/generator/html.escapeReplacements.usage.test.js
@@ -1,0 +1,15 @@
+import { describe, test, expect } from '@jest/globals';
+import { HTML_ESCAPE_REPLACEMENTS, escapeHtml } from '../../src/generator/html.js';
+
+describe('HTML_ESCAPE_REPLACEMENTS usage', () => {
+  test('escapeHtml replaces all characters using replacements', () => {
+    const input = '&<>"\'';
+    const expected = '&amp;&lt;&gt;&quot;&#039;';
+    expect(escapeHtml(input)).toBe(expected);
+  });
+
+  test('HTML_ESCAPE_REPLACEMENTS array has five entries', () => {
+    expect(Array.isArray(HTML_ESCAPE_REPLACEMENTS)).toBe(true);
+    expect(HTML_ESCAPE_REPLACEMENTS).toHaveLength(5);
+  });
+});


### PR DESCRIPTION
## Summary
- add regression tests for `HTML_ESCAPE_REPLACEMENTS`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846ec3763a0832ebb2a37b2124e762f