### PR TITLE
Add DOCTYPE constant usage test

### DIFF
--- a/test/generator/html.doctype.constantUsage.test.js
+++ b/test/generator/html.doctype.constantUsage.test.js
@@ -1,0 +1,9 @@
+import { describe, test, expect } from '@jest/globals';
+import { wrapHtml, DOCTYPE } from '../../src/generator/html.js';
+
+describe('wrapHtml DOCTYPE usage', () => {
+  test('uses the exported DOCTYPE constant', () => {
+    const html = wrapHtml('hi');
+    expect(html.startsWith(DOCTYPE)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure `wrapHtml` starts with the exported `DOCTYPE` constant

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846ec361eac832e97c6d1c328d11a7a