### PR TITLE
Add test for audio controls

### DIFF
--- a/test/generator/mediaContentConfig.controlsFull.test.js
+++ b/test/generator/mediaContentConfig.controlsFull.test.js
@@ -1,0 +1,25 @@
+import { describe, test, expect } from '@jest/globals';
+import { generateBlog } from '../../src/generator/generator.js';
+
+const header = '<body>';
+const footer = '</body>';
+const wrapHtml = c => c;
+
+describe('MEDIA_CONTENT_CONFIG audio controls exact HTML', () => {
+  test('audio section includes controls attribute with source', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'AUDCTRL',
+          title: 'Audio Controls',
+          publicationDate: '2024-06-02',
+          audio: { fileType: 'mp3' },
+        },
+      ],
+    };
+    const html = generateBlog({ blog, header, footer }, wrapHtml);
+    expect(html).toContain(
+      '<audio class="value" controls><source src="2024-06-02.mp3"></audio>'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add a precise test for audio controls in generator output

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846ec3483a8832eb2736c3083786302