### PR TITLE
Add regression test for generator CLASS constants

### DIFF
--- a/test/generator/classConstants.mutantKill.test.js
+++ b/test/generator/classConstants.mutantKill.test.js
@@ -1,0 +1,14 @@
+import { test, expect } from '@jest/globals';
+import { generateBlogOuter } from '../../src/generator/generator.js';
+
+test('generateBlogOuter uses entry and footer classes', () => {
+  const blog = {
+    posts: [
+      { key: 'A1', title: 'Title', publicationDate: '2024-01-01', content: [] }
+    ]
+  };
+  const html = generateBlogOuter(blog);
+  expect(html).toContain('<div class="entry">');
+  expect(html).toContain('<article class="entry"');
+  expect(html).toContain('class="footer value warning"');
+});


### PR DESCRIPTION
## Summary
- add missing test ensuring `generateBlogOuter` applies the `entry` and footer CSS classes

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6846ec33b608832ea619afebc851d634