### PR TITLE
Add unit tests for html escape replacement helper

### DIFF
--- a/test/generator/applyHtmlEscapeReplacement.unit.test.js
+++ b/test/generator/applyHtmlEscapeReplacement.unit.test.js
@@ -1,0 +1,22 @@
+import { describe, test, expect } from '@jest/globals';
+import { applyHtmlEscapeReplacement } from '../../src/generator/html.js';
+
+describe('applyHtmlEscapeReplacement', () => {
+  test('replaces all occurrences of the pattern', () => {
+    const text = '5 > 3 && 2 < 4';
+    const replacement = { from: />/g, to: '&gt;' };
+    const result = applyHtmlEscapeReplacement(text, replacement);
+    expect(result).toBe('5 &gt; 3 && 2 < 4');
+  });
+
+  test('handles multiple characters using different replacements', () => {
+    const text = '"A" & <B>';
+    const reps = [
+      { from: /"/g, to: '&quot;' },
+      { from: /</g, to: '&lt;' },
+      { from: />/g, to: '&gt;' },
+    ];
+    const escaped = reps.reduce((acc, r) => applyHtmlEscapeReplacement(acc, r), text);
+    expect(escaped).toBe('&quot;A&quot; & &lt;B&gt;');
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for `applyHtmlEscapeReplacement` to verify escaping behavior

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846ec3177c4832e8a2844bda2d83af4