### PR TITLE
Add missing test for generateClues null input

### DIFF
--- a/test/toys/2025-05-11/generateClues.nullInput.test.js
+++ b/test/toys/2025-05-11/generateClues.nullInput.test.js
@@ -1,0 +1,8 @@
+import { test, expect } from '@jest/globals';
+import { generateClues } from '../../../src/toys/2025-05-11/battleshipSolitaireClues.js';
+
+test('generateClues gracefully handles "null" input', () => {
+  const call = () => generateClues('null');
+  expect(call).not.toThrow();
+  expect(call()).toBe('{"error":"Invalid fleet structure"}');
+});


### PR DESCRIPTION
## Summary
- add a regression test for handling `"null"` input in `generateClues`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846ec36c69c832eb89dcfd9f537e7d2