### PR TITLE
Add test for createRemoveRemoveListener disposer

### DIFF
--- a/test/browser/createRemoveRemoveListener.additionalInvocation.test.js
+++ b/test/browser/createRemoveRemoveListener.additionalInvocation.test.js
@@ -1,0 +1,32 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { setupRemoveButton } from '../../src/browser/toys.js';
+
+// Extra test exercising the disposer returned by createRemoveRemoveListener
+// directly to ensure the underlying mutation is detected.
+
+describe('createRemoveRemoveListener additional invocation', () => {
+  it('removes the click listener each time dispose is called', () => {
+    const dom = {
+      setTextContent: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    };
+    const button = {};
+    const rows = {};
+    const render = jest.fn();
+    const disposers = [];
+
+    setupRemoveButton(dom, button, rows, render, 'k', disposers);
+
+    expect(disposers).toHaveLength(1);
+    const dispose = disposers[0];
+    const [, , handler] = dom.addEventListener.mock.calls[0];
+
+    // Call dispose multiple times to ensure listener is always removed
+    dispose();
+    dispose();
+
+    expect(dom.removeEventListener).toHaveBeenNthCalledWith(1, button, 'click', handler);
+    expect(dom.removeEventListener).toHaveBeenNthCalledWith(2, button, 'click', handler);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure dispose function from `setupRemoveButton` removes its listener every time

## Testing
- `npm test --silent`
- `npm run lint --silent`

------
https://chatgpt.com/codex/tasks/task_e_6846ec3549b0832e9adb229d596c8a29