### PR TITLE
Add missing prefixIfPresent test

### DIFF
--- a/test/generator/prefixIfPresent.test.js
+++ b/test/generator/prefixIfPresent.test.js
@@ -27,5 +27,6 @@ describe('prefixIfPresent', () => {
     expect(prefixIfPresent(' by ', '')).toBe('');
     expect(prefixIfPresent(' by ', null)).toBe('');
     expect(prefixIfPresent(' by ', undefined)).toBe('');
+    expect(prefixIfPresent(' by ', 0)).toBe('');
   });
 });


### PR DESCRIPTION
## Summary
- extend prefixIfPresent test to cover numeric 0 case

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6846ec3253f8832eb6baba2c0383fe09