### PR TITLE
Add coverage test for updateTextInputValue

### DIFF
--- a/test/browser/000.createUpdateTextInputValue.first.test.js
+++ b/test/browser/000.createUpdateTextInputValue.first.test.js
@@ -1,0 +1,15 @@
+import { test, expect, jest } from '@jest/globals';
+import { createUpdateTextInputValue } from '../../src/browser/toys.js';
+
+test('createUpdateTextInputValue returns a handler that updates text input', () => {
+  const textInput = {};
+  const dom = {
+    getTargetValue: jest.fn(() => 'value'),
+    setValue: jest.fn()
+  };
+  const handler = createUpdateTextInputValue(textInput, dom);
+  expect(typeof handler).toBe('function');
+  handler({});
+  expect(dom.getTargetValue).toHaveBeenCalled();
+  expect(dom.setValue).toHaveBeenCalledWith(textInput, 'value');
+});


### PR DESCRIPTION
## Summary
- add early test for `createUpdateTextInputValue` to ensure mutation coverage

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846ec3158d4832e9ebe8428d2b822e8