### PR TITLE
Convert constants to functions

### DIFF
--- a/src/constants/markdown.js
+++ b/src/constants/markdown.js
@@ -1,81 +1,89 @@
 /**
  * Markdown formatting markers
  */
-export const MARKDOWN_MARKERS = Object.freeze({
-  ASTERISK: '*',
-  UNDERSCORE: '_',
-  BACKTICK: '`',
-  TILDE: '~',
-  DASH: '-',
-  EQUAL: '=',
-  HASH: '#',
-  GREATER_THAN: '>',
-  PIPE: '|',
-  BACKSLASH: '\\',
-  SLASH: '/',
-  EXCLAMATION: '!',
-  BRACKET_OPEN: '[',
-  BRACKET_CLOSE: ']',
-  PAREN_OPEN: '(',
-  PAREN_CLOSE: ')'
-});
+export function markdownMarkers() {
+  return Object.freeze({
+    ASTERISK: '*',
+    UNDERSCORE: '_',
+    BACKTICK: '`',
+    TILDE: '~',
+    DASH: '-',
+    EQUAL: '=',
+    HASH: '#',
+    GREATER_THAN: '>',
+    PIPE: '|',
+    BACKSLASH: '\\',
+    SLASH: '/',
+    EXCLAMATION: '!',
+    BRACKET_OPEN: '[',
+    BRACKET_CLOSE: ']',
+    PAREN_OPEN: '(',
+    PAREN_CLOSE: ')',
+  });
+}
 
 /**
  * HTML tags for markdown elements
  */
-export const HTML_TAGS = Object.freeze({
-  EMPHASIS: 'em',
-  STRONG: 'strong',
-  CODE: 'code',
-  PARAGRAPH: 'p',
-  BLOCKQUOTE: 'blockquote',
-  LIST: 'ul',
-  LIST_ITEM: 'li',
-  ORDERED_LIST: 'ol',
-  HORIZONTAL_RULE: 'hr',
-  LINE_BREAK: 'br',
-  LINK: 'a',
-  IMAGE: 'img',
-  DIV: 'div',
-  SPAN: 'span',
-  PRE: 'pre'
-});
+export function htmlTags() {
+  return Object.freeze({
+    EMPHASIS: 'em',
+    STRONG: 'strong',
+    CODE: 'code',
+    PARAGRAPH: 'p',
+    BLOCKQUOTE: 'blockquote',
+    LIST: 'ul',
+    LIST_ITEM: 'li',
+    ORDERED_LIST: 'ol',
+    HORIZONTAL_RULE: 'hr',
+    LINE_BREAK: 'br',
+    LINK: 'a',
+    IMAGE: 'img',
+    DIV: 'div',
+    SPAN: 'span',
+    PRE: 'pre',
+  });
+}
 
 /**
  * Common CSS class names
  */
-export const CSS_CLASSES = Object.freeze({
-  CONTAINER: 'markdown-container',
-  HEADING: 'markdown-heading',
-  PARAGRAPH: 'markdown-paragraph',
-  LIST: 'markdown-list',
-  LIST_ITEM: 'markdown-list-item',
-  BLOCKQUOTE: 'markdown-blockquote',
-  CODE: 'markdown-code',
-  INLINE_CODE: 'markdown-inline-code',
-  LINK: 'markdown-link',
-  IMAGE: 'markdown-image',
-  HORIZONTAL_RULE: 'markdown-hr'
-});
+export function cssClasses() {
+  return Object.freeze({
+    CONTAINER: 'markdown-container',
+    HEADING: 'markdown-heading',
+    PARAGRAPH: 'markdown-paragraph',
+    LIST: 'markdown-list',
+    LIST_ITEM: 'markdown-list-item',
+    BLOCKQUOTE: 'markdown-blockquote',
+    CODE: 'markdown-code',
+    INLINE_CODE: 'markdown-inline-code',
+    LINK: 'markdown-link',
+    IMAGE: 'markdown-image',
+    HORIZONTAL_RULE: 'markdown-hr',
+  });
+}
 
 /**
  * Default options for markdown parsing
  */
-export const DEFAULT_OPTIONS = Object.freeze({
-  gfm: true,
-  tables: true,
-  breaks: false,
-  pedantic: false,
-  sanitize: false,
-  smartLists: true,
-  smartypants: false,
-  xhtml: false,
-  highlight: null,
-  langPrefix: 'language-',
-  headerIds: true,
-  headerPrefix: '',
-  mangle: true,
-  baseUrl: null,
-  linkTarget: null,
-  renderer: null
-});
+export function defaultOptions() {
+  return Object.freeze({
+    gfm: true,
+    tables: true,
+    breaks: false,
+    pedantic: false,
+    sanitize: false,
+    smartLists: true,
+    smartypants: false,
+    xhtml: false,
+    highlight: null,
+    langPrefix: 'language-',
+    headerIds: true,
+    headerPrefix: '',
+    mangle: true,
+    baseUrl: null,
+    linkTarget: null,
+    renderer: null,
+  });
+}

--- a/src/generator/full-width.js
+++ b/src/generator/full-width.js
@@ -1,1 +1,3 @@
-export const fullWidthElement = `<div class="key full-width">▄▄▄▄▄▄▄▄▄▄</div><div class="value full-width">▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄</div>`;
+export function fullWidthElement() {
+  return `<div class="key full-width">▄▄▄▄▄▄▄▄▄▄</div><div class="value full-width">▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄</div>`;
+}

--- a/src/generator/generator.js
+++ b/src/generator/generator.js
@@ -1,6 +1,6 @@
 import { headElement } from './head.js';
 import { fullWidthElement } from './full-width.js';
-import { HEADER_BANNER } from './title.js';
+import { headerBanner } from './title.js';
 import {
   createTag,
   createAttrPair,
@@ -185,7 +185,7 @@ const METADATA_TEXT = `Software developer and philosopher in Berlin`;
  */
 function createHeaderContent() {
   const valueDivs = [
-    createValueDiv(HEADER_BANNER),
+    createValueDiv(headerBanner()),
     createValueDiv(METADATA_TEXT, [CLASS.METADATA]),
   ];
   const parts = valueDivs.map(valueDiv =>
@@ -258,7 +258,7 @@ function createContainerDivOpen() {
  */
 function createHeaderContentArray(headerElement) {
   return [
-    headElement,
+    headElement(),
     '<body>',
     createContainerDivOpen(),
     '<!-- Header -->',
@@ -373,7 +373,7 @@ function createArticleAttributes(post) {
  * Format article content with full width element
  */
 function formatArticleContent(content) {
-  return `${fullWidthElement}${content}`;
+  return `${fullWidthElement()}${content}`;
 }
 
 /**

--- a/src/generator/head.js
+++ b/src/generator/head.js
@@ -1,6 +1,7 @@
 import { styles } from './styles.js';
 
-export const headElement = `<head>
+export function headElement() {
+  return `<head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width">
   <title>Matt Heard</title>
@@ -22,7 +23,7 @@ export const headElement = `<head>
   <!-- Web App Manifest (optional but recommended for PWA or better platform integration) -->
   <link rel="manifest" href="/site.webmanifest">
   <style>
-    ${styles}
+    ${styles()}
   </style>
   
   <!-- Define the component management system in the head -->
@@ -61,3 +62,4 @@ export const headElement = `<head>
     window.addComponent = createComponentAdder();
   </script>
 </head>`;
+}

--- a/src/generator/html.js
+++ b/src/generator/html.js
@@ -1,31 +1,41 @@
 // html.js - Core HTML utilities layer
 
 // Constants for HTML structure
-export const DOCTYPE = '<!DOCTYPE html>';
+export function doctype() {
+  return '<!DOCTYPE html>';
+}
 
 // Language settings
-export const LANGUAGE = {
-  EN: 'en',
-};
+export function language() {
+  return {
+    EN: 'en',
+  };
+}
 
 // HTML tag names
-export const HTML_TAG_NAME = 'html';
+export function htmlTagName() {
+  return 'html';
+}
 
 // HTML attribute names
-export const ATTR_NAME = {
-  LANG: 'lang',
-  CLASS: 'class',
-  ID: 'id',
-};
+export function attrName() {
+  return {
+    LANG: 'lang',
+    CLASS: 'class',
+    ID: 'id',
+  };
+}
 
 // HTML escape replacements
-export const HTML_ESCAPE_REPLACEMENTS = [
-  { from: /&/g, to: '&amp;' },
-  { from: /</g, to: '&lt;' },
-  { from: />/g, to: '&gt;' },
-  { from: /"/g, to: '&quot;' },
-  { from: /'/g, to: '&#039;' },
-];
+export function htmlEscapeReplacements() {
+  return [
+    { from: /&/g, to: '&amp;' },
+    { from: /</g, to: '&lt;' },
+    { from: />/g, to: '&gt;' },
+    { from: /"/g, to: '&quot;' },
+    { from: /'/g, to: '&#039;' },
+  ];
+}
 
 // HTML utilities
 
@@ -39,12 +49,24 @@ export function join(parts) {
 }
 
 // HTML tag and attribute symbols
-export const TAG_OPEN = '<';
-export const TAG_CLOSE = '>';
-export const SPACE = ' ';
-export const SLASH = '/';
-export const EQUALS = '=';
-export const QUOTE = '"';
+export function tagOpen() {
+  return '<';
+}
+export function tagClose() {
+  return '>';
+}
+export function space() {
+  return ' ';
+}
+export function slash() {
+  return '/';
+}
+export function equals() {
+  return '=';
+}
+export function quote() {
+  return '"';
+}
 
 /**
  * Get the parts that make up an opening HTML tag
@@ -54,9 +76,9 @@ export const QUOTE = '"';
  */
 export function getOpeningTagParts(name, attributes) {
   if (attributes) {
-    return [TAG_OPEN, name, SPACE, attributes, TAG_CLOSE];
+    return [tagOpen(), name, space(), attributes, tagClose()];
   }
-  return [TAG_OPEN, name, TAG_CLOSE];
+  return [tagOpen(), name, tagClose()];
 }
 
 /**
@@ -76,7 +98,7 @@ export function createOpeningTag(tagName, attributes = '') {
  * @returns {Array<string>} - Array of tag parts
  */
 export function getClosingTagParts(name) {
-  return [TAG_OPEN, SLASH, name, TAG_CLOSE];
+  return [tagOpen(), slash(), name, tagClose()];
 }
 
 /**
@@ -110,7 +132,7 @@ export function createTag(tagName, attributes, content) {
  * @returns {Array<string>} - Array of attribute parts
  */
 export function getAttrPairParts(attrName, attrValue) {
-  return [attrName, EQUALS, QUOTE, attrValue, QUOTE];
+  return [attrName, equals(), quote(), attrValue, quote()];
 }
 
 /**
@@ -153,7 +175,7 @@ export function applyAllHtmlEscapeReplacements(text, replacements) {
  * @returns {string} - HTML-escaped text
  */
 export function escapeHtml(text) {
-  return applyAllHtmlEscapeReplacements(text, HTML_ESCAPE_REPLACEMENTS);
+  return applyAllHtmlEscapeReplacements(text, htmlEscapeReplacements());
 }
 
 /**
@@ -162,8 +184,8 @@ export function escapeHtml(text) {
  * @returns {string} - The HTML tag with content
  */
 export function createHtmlTag(content) {
-  const langAttr = createAttrPair(ATTR_NAME.LANG, LANGUAGE.EN);
-  return createTag(HTML_TAG_NAME, langAttr, content);
+  const langAttr = createAttrPair(attrName().LANG, language().EN);
+  return createTag(htmlTagName(), langAttr, content);
 }
 
 /**
@@ -173,5 +195,5 @@ export function createHtmlTag(content) {
  */
 export function wrapHtml(content) {
   const htmlTag = createHtmlTag(content);
-  return join([DOCTYPE, htmlTag]);
+  return join([doctype(), htmlTag]);
 }

--- a/src/generator/styles.js
+++ b/src/generator/styles.js
@@ -1,4 +1,5 @@
-export const styles = `
+export function styles() {
+  return `
   body {
     background-color: #121212;
     background-image: linear-gradient(rgba(255, 255, 255, 0.05) 1px, transparent 1px);
@@ -227,3 +228,4 @@ export const styles = `
     display: none;
   }
 `;
+}

--- a/src/generator/title.js
+++ b/src/generator/title.js
@@ -7,13 +7,15 @@
  * ASCII art banner for the blog header
  * @type {string}
  */
-export const HEADER_BANNER = `<pre aria-label="Matt Heard" role="heading" aria-level="1">
-▗▖  ▗▖ ▗▄▖▗▄▄▄▖▗▄▄▄▖      
-▐▛▚▞▜▌▐▌ ▐▌ █    █        
-▐▌  ▐▌▐▛▀▜▌ █    █        
-▐▌  ▐▌▐▌ ▐▌ █    █        
-▗▖ ▗▖▗▄▄▄▖ ▗▄▖ ▗▄▄▖ ▗▄▄▄  
-▐▌ ▐▌▐▌   ▐▌ ▐▌▐▌ ▐▌▐▌  █ 
-▐▛▀▜▌▐▛▀▀▘▐▛▀▜▌▐▛▀▚▖▐▌  █ 
+export function headerBanner() {
+  return `<pre aria-label="Matt Heard" role="heading" aria-level="1">
+▗▖  ▗▖ ▗▄▖▗▄▄▄▖▗▄▄▄▖
+▐▛▚▞▜▌▐▌ ▐▌ █    █
+▐▌  ▐▌▐▛▀▜▌ █    █
+▐▌  ▐▌▐▌ ▐▌ █    █
+▗▖ ▗▖▗▄▄▄▖ ▗▄▖ ▗▄▄▖ ▗▄▄▄
+▐▌ ▐▌▐▌   ▐▌ ▐▌▐▌ ▐▌▐▌  █
+▐▛▀▜▌▐▛▀▀▘▐▛▀▜▌▐▛▀▚▖▐▌  █
 ▐▌ ▐▌▐▙▄▄▖▐▌ ▐▌▐▌ ▐▌▐▙▄▄▀
 </pre>`;
+}


### PR DESCRIPTION
## Summary
- refactor Markdown constants to nonary functions
- convert generator constants like `fullWidthElement`, `headElement`, `headerBanner` and HTML helpers to functions
- update generator code to call new functions

## Testing
- `npm test` *(fails: Cannot find module 'jest')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6846ec300c68832e974d39d3331477c8