### PR TITLE
Add test for generateClues false input

### DIFF
--- a/test/toys/2025-05-11/generateClues.falseInput.test.js
+++ b/test/toys/2025-05-11/generateClues.falseInput.test.js
@@ -1,0 +1,8 @@
+import { test, expect } from '@jest/globals';
+import { generateClues } from '../../../src/toys/2025-05-11/battleshipSolitaireClues.js';
+
+test('generateClues gracefully handles "false" input', () => {
+  const call = () => generateClues('false');
+  expect(call).not.toThrow();
+  expect(call()).toBe('{"error":"Invalid fleet structure"}');
+});


### PR DESCRIPTION
## Summary
- add additional test covering `generateClues('false')` to kill surviving mutant

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684713986ed8832ea0915ffca51d34e1