### PR TITLE
Add test for dropdown default handler order

### DIFF
--- a/test/browser/createInputDropdownHandler.defaultOrder.test.js
+++ b/test/browser/createInputDropdownHandler.defaultOrder.test.js
@@ -1,0 +1,34 @@
+import { test, expect, jest } from '@jest/globals';
+import { createInputDropdownHandler } from '../../src/browser/toys.js';
+
+test('createInputDropdownHandler hides before disabling text input', () => {
+  const select = {};
+  const container = {};
+  const textInput = {};
+  const event = {};
+
+  const dom = {
+    getCurrentTarget: jest.fn(() => select),
+    getParentElement: jest.fn(() => container),
+    querySelector: jest.fn((_, selector) =>
+      selector === 'input[type="text"]' ? textInput : null
+    ),
+    getValue: jest.fn(() => 'unknown'),
+    reveal: jest.fn(),
+    enable: jest.fn(),
+    hide: jest.fn(),
+    disable: jest.fn(),
+    removeChild: jest.fn(),
+    addEventListener: jest.fn(),
+    getNextSibling: jest.fn(() => null),
+  };
+
+  const handler = createInputDropdownHandler(dom);
+  handler(event);
+
+  expect(dom.hide).toHaveBeenCalledWith(textInput);
+  expect(dom.disable).toHaveBeenCalledWith(textInput);
+  const hideOrder = dom.hide.mock.invocationCallOrder[0];
+  const disableOrder = dom.disable.mock.invocationCallOrder[0];
+  expect(hideOrder).toBeLessThan(disableOrder);
+});


### PR DESCRIPTION
## Summary
- add `createInputDropdownHandler.defaultOrder.test.js` to verify hide occurs before disable for unknown dropdown values

## Testing
- `npm test --silent`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68471395f624832ebc444f995f8e273b