### PR TITLE
Add test for null dropdown target

### DIFF
--- a/test/browser/createOutputDropdownHandler.nullTarget.test.js
+++ b/test/browser/createOutputDropdownHandler.nullTarget.test.js
@@ -1,0 +1,17 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { createOutputDropdownHandler } from '../../src/browser/toys.js';
+
+describe('createOutputDropdownHandler null target', () => {
+  it('forwards null currentTarget to handler', () => {
+    const handleDropdownChange = jest.fn(() => 'ok');
+    const getData = jest.fn();
+    const dom = {};
+
+    const handler = createOutputDropdownHandler(handleDropdownChange, getData, dom);
+    const event = { currentTarget: null };
+    const result = handler(event);
+
+    expect(result).toBe('ok');
+    expect(handleDropdownChange).toHaveBeenCalledWith(null, getData, dom);
+  });
+});


### PR DESCRIPTION
## Summary
- extend coverage for `createOutputDropdownHandler` to handle null `currentTarget`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6847139670fc832ea94c423654a5f9e7