### PR TITLE
Add escapeHtml no-op test

### DIFF
--- a/test/generator/html.escapeHtml.noop.test.js
+++ b/test/generator/html.escapeHtml.noop.test.js
@@ -1,0 +1,8 @@
+import { test, expect } from '@jest/globals';
+import { escapeHtml } from '../../src/generator/html.js';
+
+test('escapeHtml returns original string when no characters need escaping', () => {
+  const input = 'Hello World';
+  const result = escapeHtml(input);
+  expect(result).toBe('Hello World');
+});


### PR DESCRIPTION
## Summary
- add coverage for escapeHtml when input has no special characters

## Testing
- `npm install` *(fails: ECONNRESET)*
- `npm test` *(fails: cannot find module jest)*

------
https://chatgpt.com/codex/tasks/task_e_68471395749c832e8e7d5d0a87f00fad