### PR TITLE
Add test to cover primitive content normalization

### DIFF
--- a/test/generator/normalizeContentItem.predicateKill.test.js
+++ b/test/generator/normalizeContentItem.predicateKill.test.js
@@ -1,0 +1,24 @@
+import { describe, test, expect } from '@jest/globals';
+import { generateBlog } from '../../src/generator/generator.js';
+
+const header = '<body>';
+const footer = '</body>';
+const wrapHtml = c => c;
+
+describe('normalizeContentItem predicate kill', () => {
+  test('generateBlog does not throw for primitive string content', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'PKL',
+          title: 'Predicate',
+          publicationDate: '2024-07-07',
+          content: ['a'],
+        },
+      ],
+    };
+    const call = () => generateBlog({ blog, header, footer }, wrapHtml);
+    expect(call).not.toThrow();
+    expect(call()).toContain('<p class="value">a</p>');
+  });
+});


### PR DESCRIPTION
## Summary
- add predicate kill test for normalizeContentItem

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684713945488832e91e6f5ccb3124712