### PR TITLE
Add mutation-killing date formatting test

### DIFF
--- a/test/generator/dateFormatOptions.runtime.kill.test.js
+++ b/test/generator/dateFormatOptions.runtime.kill.test.js
@@ -1,0 +1,24 @@
+import { describe, test, expect } from '@jest/globals';
+import { generateBlog } from '../../src/generator/generator.js';
+
+const header = '<body>';
+const footer = '</body>';
+const wrapHtml = html => html;
+
+describe('DATE_FORMAT_OPTIONS mutant killer', () => {
+  test('generateBlog formats dates with short month names', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'DATE_KILL',
+          title: 'Kill Mutant',
+          publicationDate: '2024-05-04',
+          content: ['Entry'],
+        },
+      ],
+    };
+
+    const html = generateBlog({ blog, header, footer }, wrapHtml);
+    expect(html).toContain('<p class="value metadata">4 May 2024</p>');
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test that verifies dates are formatted with short month names

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684713937e24832ea31b4a6494474a7e