### PR TITLE
Add test for remove listener disposer order

### DIFF
--- a/test/browser/createRemoveRemoveListener.order.test.js
+++ b/test/browser/createRemoveRemoveListener.order.test.js
@@ -1,0 +1,33 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { setupRemoveButton } from '../../src/browser/toys.js';
+
+describe('createRemoveRemoveListener order of disposal', () => {
+  it('each disposer only removes its associated listener', () => {
+    const dom = {
+      setTextContent: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    };
+    const buttonA = {};
+    const buttonB = {};
+    const rows = {};
+    const render = jest.fn();
+    const disposers = [];
+
+    setupRemoveButton(dom, buttonA, rows, render, 'a', disposers);
+    const disposeA = disposers.pop();
+    setupRemoveButton(dom, buttonB, rows, render, 'b', disposers);
+    const disposeB = disposers.pop();
+
+    const handlerA = dom.addEventListener.mock.calls[0][2];
+    const handlerB = dom.addEventListener.mock.calls[1][2];
+
+    disposeA();
+    expect(dom.removeEventListener).toHaveBeenCalledTimes(1);
+    expect(dom.removeEventListener).toHaveBeenCalledWith(buttonA, 'click', handlerA);
+
+    disposeB();
+    expect(dom.removeEventListener).toHaveBeenCalledTimes(2);
+    expect(dom.removeEventListener).toHaveBeenNthCalledWith(2, buttonB, 'click', handlerB);
+  });
+});


### PR DESCRIPTION
## Summary
- add regression test for createRemoveRemoveListener to verify each disposer removes its own listener

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684713937514832e9f0ebb93bd298cb1