### PR TITLE
Add test for fetch handling in createHandleSubmit

### DIFF
--- a/test/browser/createHandleSubmit.callsProcess.test.js
+++ b/test/browser/createHandleSubmit.callsProcess.test.js
@@ -1,0 +1,38 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { createHandleSubmit } from '../../src/browser/toys.js';
+
+describe('createHandleSubmit fetch usage', () => {
+  it('does not call fetchFn when processingFunction returns plain data', () => {
+    const fetchFn = jest.fn();
+    const dom = {
+      stopDefault: jest.fn(),
+      removeAllChildren: jest.fn(),
+      appendChild: jest.fn(),
+      createElement: jest.fn(() => ({})),
+      setTextContent: jest.fn(),
+      addWarning: jest.fn(),
+    };
+    const env = {
+      dom,
+      createEnv: jest.fn(() => new Map()),
+      errorFn: jest.fn(),
+      fetchFn,
+    };
+    const elements = {
+      inputElement: { value: 'x' },
+      outputParentElement: {},
+      outputSelect: { value: 'text' },
+      article: { id: 'a1' },
+    };
+    const processingFunction = jest.fn(() => 'result');
+
+    const handler = createHandleSubmit(elements, processingFunction, env);
+    const event = {};
+    const result = handler(event);
+
+    expect(result).toBeUndefined();
+    expect(fetchFn).not.toHaveBeenCalled();
+    expect(dom.stopDefault).toHaveBeenCalledWith(event);
+    expect(processingFunction).toHaveBeenCalledWith('x', expect.any(Map));
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test verifying that `createHandleSubmit` doesn't call `fetchFn` when the processing function returns plain data

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68471392858c832e880b862f44ecf44b