### PR TITLE
Add test for primitive content normalization

### DIFF
--- a/test/generator/normalizeContentItem.predicateKill.test.js
+++ b/test/generator/normalizeContentItem.predicateKill.test.js
@@ -1,0 +1,28 @@
+import { describe, test, expect } from '@jest/globals';
+import { generateBlog } from '../../src/generator/generator.js';
+
+const header = '<body>';
+const footer = '</body>';
+const wrapHtml = c => c;
+
+describe('normalizeContentItem predicate kill', () => {
+  test('generateBlog handles primitive content types without throwing', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'PRIM',
+          title: 'Primitives',
+          publicationDate: '2024-01-01',
+          content: ['a', 1, true, null],
+        },
+      ],
+    };
+    const call = () => generateBlog({ blog, header, footer }, wrapHtml);
+    expect(call).not.toThrow();
+    const html = call();
+    expect(html).toContain('<p class="value">a</p>');
+    expect(html).toContain('<p class="value">1</p>');
+    expect(html).toContain('<p class="value">true</p>');
+    expect(html).toContain('<p class="value">null</p>');
+  });
+});


### PR DESCRIPTION
## Summary
- ensure primitive content arrays render without errors

## Testing
- `npm test --silent`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68471392340c832eb7b7286013b81875