### PR TITLE
Add test for createOutputDropdownHandler

### DIFF
--- a/test/browser/createOutputDropdownHandler.multipleCalls.test.js
+++ b/test/browser/createOutputDropdownHandler.multipleCalls.test.js
@@ -1,0 +1,19 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { createOutputDropdownHandler } from '../../src/browser/toys.js';
+
+describe('createOutputDropdownHandler multiple calls', () => {
+  it('delegates to handleDropdownChange for each invocation', () => {
+    const handleDropdownChange = jest.fn();
+    const getData = jest.fn();
+    const dom = {};
+    const handler = createOutputDropdownHandler(handleDropdownChange, getData, dom);
+
+    const evt1 = { currentTarget: 1 };
+    const evt2 = { currentTarget: 2 };
+    handler(evt1);
+    handler(evt2);
+
+    expect(handleDropdownChange).toHaveBeenNthCalledWith(1, evt1.currentTarget, getData, dom);
+    expect(handleDropdownChange).toHaveBeenNthCalledWith(2, evt2.currentTarget, getData, dom);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure createOutputDropdownHandler delegates on multiple invocations

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68471397a3a4832ea6b39f2dee1dfa86