### PR TITLE
Add exact related link attribute test

### DIFF
--- a/test/generator/defaultRelatedLinkAttrs.exact.test.js
+++ b/test/generator/defaultRelatedLinkAttrs.exact.test.js
@@ -1,0 +1,26 @@
+import { test, expect } from '@jest/globals';
+import { generateBlog } from '../../src/generator/generator.js';
+
+const header = '<body>';
+const footer = '</body>';
+const wrapHtml = c => c;
+
+test('DEFAULT_RELATED_LINK_ATTRS anchor exact match', () => {
+  const blog = {
+    posts: [
+      {
+        key: 'EXACT',
+        title: 'Exact',
+        publicationDate: '2024-01-01',
+        content: ['x'],
+        relatedLinks: [
+          { url: 'https://exact.com', type: 'article', title: 'Exact' },
+        ],
+      },
+    ],
+  };
+  const html = generateBlog({ blog, header, footer }, wrapHtml);
+  expect(html).toContain(
+    '<a href="https://exact.com" target="_blank" rel="noopener">"Exact"</a>'
+  );
+});


### PR DESCRIPTION
## Summary
- add a new unit test to check the exact anchor HTML for related links

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68471390dbb0832e9bb05d25f9260401