### PR TITLE
Add normalization test for primitives

### DIFF
--- a/test/generator/getContentNormalizer.mutantKill.test.js
+++ b/test/generator/getContentNormalizer.mutantKill.test.js
@@ -1,0 +1,26 @@
+import { describe, test, expect } from '@jest/globals';
+import { generateBlog } from '../../src/generator/generator.js';
+
+const header = '<body>';
+const footer = '</body>';
+const wrapHtml = c => c;
+
+describe('getContentNormalizer mutant kill', () => {
+  test('renders primitive content types correctly', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'GN',
+          title: 'Normalizer',
+          publicationDate: '2024-01-01',
+          content: ['str', 1, true, null],
+        },
+      ],
+    };
+    const html = generateBlog({ blog, header, footer }, wrapHtml);
+    expect(html).toContain('<p class="value">str</p>');
+    expect(html).toContain('<p class="value">1</p>');
+    expect(html).toContain('<p class="value">true</p>');
+    expect(html).toContain('<p class="value">null</p>');
+  });
+});


### PR DESCRIPTION
## Summary
- add a unit test verifying primitive content normalization in the blog generator

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684713901398832e9a3a26f6b1d2ae92