### PR TITLE
Add repeated disposer test

### DIFF
--- a/test/browser/createRemoveValueListener.multipleCalls.new.test.js
+++ b/test/browser/createRemoveValueListener.multipleCalls.new.test.js
@@ -1,0 +1,29 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { createValueElement } from '../../src/browser/toys.js';
+
+describe('createRemoveValueListener repeated calls', () => {
+  it('calls removeEventListener each time disposer is invoked', () => {
+    const dom = {
+      createElement: jest.fn(() => ({})),
+      setType: jest.fn(),
+      setPlaceholder: jest.fn(),
+      setValue: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      getTargetValue: jest.fn(() => ''),
+      getDataAttribute: jest.fn(() => ''),
+      setDataAttribute: jest.fn(),
+    };
+    const disposers = [];
+    const el = createValueElement(dom, '', {}, {}, {}, jest.fn(), disposers);
+    const dispose = disposers[0];
+    const handler = dom.addEventListener.mock.calls[0][2];
+
+    dispose();
+    dispose();
+
+    expect(dom.removeEventListener).toHaveBeenCalledTimes(2);
+    expect(dom.removeEventListener).toHaveBeenNthCalledWith(1, el, 'input', handler);
+    expect(dom.removeEventListener).toHaveBeenNthCalledWith(2, el, 'input', handler);
+  });
+});


### PR DESCRIPTION
## Summary
- extend `createRemoveValueListener` tests with a case that calls the disposer multiple times

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684713974c6c832e8b56b58a59e755ff