### PR TITLE
Add numeric fleet input test

### DIFF
--- a/test/toys/2025-05-11/battleshipSolitaireClues.test.js
+++ b/test/toys/2025-05-11/battleshipSolitaireClues.test.js
@@ -9,6 +9,11 @@ describe('generateClues', () => {
     expect(output).toHaveProperty('error', 'Invalid input JSON');
   });
 
+  it('returns an error when JSON is a number', () => {
+    const output = JSON.parse(generateClues('42'));
+    expect(output).toEqual({ error: 'Invalid fleet structure' });
+  });
+
   it('returns an error when required properties are missing', () => {
     const badFleet = JSON.stringify({ width: 5, ships: [] });
     const output = JSON.parse(generateClues(badFleet));


### PR DESCRIPTION
## Summary
- extend battleshipSolitaireClues tests with numeric JSON case

## Testing
- `npm test` *(failed: Cannot find module '/workspace/dadeto/node_modules/.bin/jest')*
- `npm run lint` *(failed: needed eslint install)*

------
https://chatgpt.com/codex/tasks/task_e_684713979a04832eb38e856708933811