### PR TITLE
Add isolated test for createUpdateTextInputValue

### DIFF
--- a/test/browser/createUpdateTextInputValue.isolated.test.js
+++ b/test/browser/createUpdateTextInputValue.isolated.test.js
@@ -1,0 +1,19 @@
+import { test, expect, jest } from '@jest/globals';
+
+const textInput = {};
+const dom = {
+  getTargetValue: jest.fn(() => 'isolated'),
+  setValue: jest.fn(),
+};
+
+// Use isolateModulesAsync to ensure Stryker instruments the module correctly
+test('createUpdateTextInputValue isolated import forwards the value', async () => {
+  await jest.isolateModulesAsync(async () => {
+    const { createUpdateTextInputValue } = await import('../../src/browser/toys.js');
+    const handler = createUpdateTextInputValue(textInput, dom);
+    const evt = {};
+    handler(evt);
+    expect(dom.getTargetValue).toHaveBeenCalledWith(evt);
+    expect(dom.setValue).toHaveBeenCalledWith(textInput, 'isolated');
+  });
+});


### PR DESCRIPTION
## Summary
- add an isolated test for `createUpdateTextInputValue` to ensure DOM utilities are invoked

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6847192dd020832eaeb54b9ffe27d947