### PR TITLE
Add test to kill createRemoveAddListener mutant

### DIFF
--- a/test/browser/createRemoveAddListener.direct.test.js
+++ b/test/browser/createRemoveAddListener.direct.test.js
@@ -1,0 +1,25 @@
+import { test, expect, jest } from '@jest/globals';
+import { setupAddButton } from '../../src/browser/toys.js';
+
+test('createRemoveAddListener returns disposer that removes click handler', () => {
+  const dom = {
+    setTextContent: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+  };
+  const btn = {};
+  const rows = {};
+  const render = jest.fn();
+  const disposers = [];
+
+  setupAddButton(dom, btn, rows, render, disposers);
+
+  expect(disposers).toHaveLength(1);
+  const dispose = disposers[0];
+  expect(typeof dispose).toBe('function');
+
+  const [, , handler] = dom.addEventListener.mock.calls[0];
+  const result = dispose();
+  expect(result).toBeUndefined();
+  expect(dom.removeEventListener).toHaveBeenCalledWith(btn, 'click', handler);
+});


### PR DESCRIPTION
## Summary
- test setupAddButton directly to ensure createRemoveAddListener returns a disposer

## Testing
- `npx jest test/browser/createRemoveAddListener.direct.test.js`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6847192c91e4832e85536fe1d537b93b