### PR TITLE
Add random kill test for output dropdown handler

### DIFF
--- a/test/browser/createOutputDropdownHandler.randomKill.test.js
+++ b/test/browser/createOutputDropdownHandler.randomKill.test.js
@@ -1,0 +1,27 @@
+import { test, expect, jest } from '@jest/globals';
+import { createOutputDropdownHandler } from '../../src/browser/toys.js';
+
+test('createOutputDropdownHandler forwards events via unary handler', () => {
+  const handleDropdownChange = jest.fn().mockReturnValue('ok');
+  const getData = jest.fn();
+  const dom = {};
+
+  expect(createOutputDropdownHandler.length).toBe(3);
+  const handler = createOutputDropdownHandler(
+    handleDropdownChange,
+    getData,
+    dom
+  );
+  expect(typeof handler).toBe('function');
+  expect(handler.length).toBe(1);
+
+  const event = { currentTarget: { id: 'x' } };
+  const result = handler(event);
+
+  expect(result).toBe('ok');
+  expect(handleDropdownChange).toHaveBeenCalledWith(
+    event.currentTarget,
+    getData,
+    dom
+  );
+});


### PR DESCRIPTION
## Summary
- test createOutputDropdownHandler with a new spec to ensure the handler
  forwards the event target to the dropdown change callback

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6847192b80f4832ea520e23da0d27000