### PR TITLE
Add test to kill mutant for createKeyValueRow

### DIFF
--- a/test/browser/createKeyValueRow.args.test.js
+++ b/test/browser/createKeyValueRow.args.test.js
@@ -1,0 +1,51 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { createKeyValueRow } from '../../src/browser/toys.js';
+
+describe('createKeyValueRow argument handling', () => {
+  it('creates elements using provided key and value', () => {
+    const rowEl = {};
+    const keyInput = {};
+    const valueInput = {};
+    const button = {};
+
+    const dom = {
+      createElement: jest
+        .fn()
+        .mockReturnValueOnce(rowEl)
+        .mockReturnValueOnce(keyInput)
+        .mockReturnValueOnce(valueInput)
+        .mockReturnValueOnce(button),
+      setClassName: jest.fn(),
+      appendChild: jest.fn(),
+      setType: jest.fn(),
+      setPlaceholder: jest.fn(),
+      setTextContent: jest.fn(),
+      setValue: jest.fn(),
+      setDataAttribute: jest.fn(),
+      addEventListener: jest.fn(),
+    };
+    const entries = [];
+    const textInput = {};
+    const rows = {};
+    const syncHiddenField = jest.fn();
+    const disposers = [];
+    const render = jest.fn();
+    const container = {};
+
+    const rowCreator = createKeyValueRow(
+      dom,
+      entries,
+      textInput,
+      rows,
+      syncHiddenField,
+      disposers,
+      render,
+      container
+    );
+
+    rowCreator(['alpha', 'beta'], 0);
+
+    expect(dom.setValue).toHaveBeenNthCalledWith(1, keyInput, 'alpha');
+    expect(dom.setValue).toHaveBeenNthCalledWith(2, valueInput, 'beta');
+  });
+});


### PR DESCRIPTION
## Summary
- extend browser tests for `createKeyValueRow`
- verify key and value are passed to the DOM helpers

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6847192a9100832e9a75ba3f8afb1e8c