### PR TITLE
Add survivor test for dropdown handler

### DIFF
--- a/test/browser/createOutputDropdownHandler.survivor.test.js
+++ b/test/browser/createOutputDropdownHandler.survivor.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { createOutputDropdownHandler } from '../../src/browser/toys.js';
+
+describe('createOutputDropdownHandler survivor check', () => {
+  it('forwards currentTarget and returns handleDropdownChange result', () => {
+    const handleDropdownChange = jest.fn(() => 'ok');
+    const getData = jest.fn();
+    const dom = {};
+
+    const handler = createOutputDropdownHandler(
+      handleDropdownChange,
+      getData,
+      dom
+    );
+    expect(typeof handler).toBe('function');
+
+    const evt = { currentTarget: { val: 1 } };
+    const result = handler(evt);
+
+    expect(result).toBe('ok');
+    expect(handleDropdownChange).toHaveBeenCalledWith(
+      evt.currentTarget,
+      getData,
+      dom
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add test to ensure `createOutputDropdownHandler` forwards events

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684719267e10832e90c45a84acefe49c