### PR TITLE
Add test for dropdown handler

### DIFF
--- a/test/browser/createOutputDropdownHandler.returnValue.test.js
+++ b/test/browser/createOutputDropdownHandler.returnValue.test.js
@@ -1,0 +1,13 @@
+import { test, expect, jest } from "@jest/globals";
+import { createOutputDropdownHandler } from "../../src/browser/toys.js";
+
+test("createOutputDropdownHandler returns handler result", () => {
+  const handleDropdownChange = jest.fn(() => "result");
+  const getData = jest.fn();
+  const dom = {};
+  const handler = createOutputDropdownHandler(handleDropdownChange, getData, dom);
+  const evt = { currentTarget: { id: "x" } };
+  const value = handler(evt);
+  expect(value).toBe("result");
+  expect(handleDropdownChange).toHaveBeenCalledWith(evt.currentTarget, getData, dom);
+});


### PR DESCRIPTION
## Summary
- add a unit test that verifies `createOutputDropdownHandler` returns the value from the delegated function

## Testing
- `npm test` *(fails: Cannot find module './util')*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68471926fc08832e8c6e279bb9891bf8