### PR TITLE
Add test for toy output dropdown options

### DIFF
--- a/test/generator/toyOutputDropdown.optionCount.test.js
+++ b/test/generator/toyOutputDropdown.optionCount.test.js
@@ -1,0 +1,26 @@
+import { describe, test, expect } from '@jest/globals';
+import { generateBlog } from '../../src/generator/generator.js';
+
+const header = '<body>';
+const footer = '</body>';
+const wrapHtml = c => `<html>${c}</html>`;
+
+describe('toy output dropdown option count', () => {
+  test('output dropdown contains expected number of options', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'COUNT',
+          title: 'Count',
+          publicationDate: '2024-01-01',
+          toy: { modulePath: './toys/2024-01-01/example.js', functionName: 'example' }
+        }
+      ]
+    };
+    const html = generateBlog({ blog, header, footer }, wrapHtml);
+    const match = html.match(/<select class="output">([\s\S]*?)<\/select>/);
+    expect(match).not.toBeNull();
+    const optionCount = (match[1].match(/<option/g) || []).length;
+    expect(optionCount).toBe(5);
+  });
+});


### PR DESCRIPTION
## Summary
- add new unit test verifying the toy output dropdown contains five options

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6847192406cc832ebd27e0c397942f67