### PR TITLE
Add test for content renderers mapping

### DIFF
--- a/test/generator/contentRenderers.mapping.test.js
+++ b/test/generator/contentRenderers.mapping.test.js
@@ -1,0 +1,25 @@
+import { describe, test, expect } from '@jest/globals';
+import { generateBlog } from '../../src/generator/generator.js';
+
+const header = '<body>';
+const footer = '</body>';
+const wrapHtml = c => c;
+
+describe('content renderers mapping', () => {
+  test('generateBlog renders text and quote content', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'CR1',
+          title: 'Content',
+          publicationDate: '2024-01-01',
+          content: ['hello', { type: 'quote', content: 'q' }],
+        },
+      ],
+    };
+    const html = generateBlog({ blog, header, footer }, wrapHtml);
+    expect(html).toContain('<p class="value">hello</p>');
+    expect(html).toContain('<blockquote class="value">');
+    expect(html).toContain('<p>q</p>');
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test verifying that `generateBlog` renders both text and quote content correctly

## Testing
- `npm test --silent test/generator/contentRenderers.mapping.test.js`
- `npm run lint` (with warnings)

------
https://chatgpt.com/codex/tasks/task_e_6847192de784832e8d0fe79ca68690ed