### PR TITLE
Add multiple remove button disposer test

### DIFF
--- a/test/browser/createRemoveRemoveListener.tripleCalls.test.js
+++ b/test/browser/createRemoveRemoveListener.tripleCalls.test.js
@@ -1,0 +1,30 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { setupRemoveButton } from '../../src/browser/toys.js';
+
+describe('createRemoveRemoveListener triple calls', () => {
+  it('returns functional disposers for multiple buttons', () => {
+    const dom = {
+      setTextContent: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    };
+    const rows = {};
+    const render = jest.fn();
+    const disposers = [];
+    const buttons = [{}, {}, {}];
+
+    buttons.forEach((btn, idx) => {
+      setupRemoveButton(dom, btn, rows, render, 'k' + idx, disposers);
+      const disposer = disposers[idx];
+      expect(typeof disposer).toBe('function');
+      const handler = dom.addEventListener.mock.calls[idx][2];
+      disposer();
+      expect(dom.removeEventListener).toHaveBeenNthCalledWith(
+        idx + 1,
+        btn,
+        'click',
+        handler
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add new test to verify disposers from setupRemoveButton for several buttons

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684719280b8c832e847fd3e0dc023643