### PR TITLE
Simplify wrapIfPresent

### DIFF
--- a/src/generator/generator.js
+++ b/src/generator/generator.js
@@ -770,8 +770,6 @@ function formatBaseLink(type, url, title) {
 function wrapIfPresent(prefix, value, suffix) {
   if (value) {
     return prefix + value + suffix;
-  } else {
-    return '';
   }
 }
 


### PR DESCRIPTION
## Summary
- simplify `wrapIfPresent` by removing redundant `else` branch

## Testing
- `npm test` *(fails: Cannot find module '/workspace/dadeto/node_modules/.bin/jest')*
- `npm run lint` *(fails: npm ERR! canceled)*

------
https://chatgpt.com/codex/tasks/task_e_6847192b3fac832e8f8004e66475b9e4