### PR TITLE
Add block count tests for fullWidthElement

### DIFF
--- a/test/generator/fullWidthElement.blockCount.test.js
+++ b/test/generator/fullWidthElement.blockCount.test.js
@@ -1,0 +1,19 @@
+import { describe, test, expect } from '@jest/globals';
+import { fullWidthElement } from '../../src/generator/full-width.js';
+
+describe('fullWidthElement block characters', () => {
+  test('contains expected number of block characters', () => {
+    const html = fullWidthElement();
+    const count = (html.match(/▄/g) || []).length;
+    expect(count).toBe(136);
+  });
+
+  test('key and value block counts are correct', () => {
+    const html = fullWidthElement();
+    const match = html.match(
+      /<div class="key full-width">(.*?)<\/div><div class="value full-width">(.*?)<\/div>/
+    );
+    expect(match[1].length).toBe(10);
+    expect(match[2].length).toBe(126);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests counting block characters in the `fullWidthElement` output

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684719255ca4832e83a1995ed6477a68