### PR TITLE
Extend test coverage for safeTrim whitespace

### DIFF
--- a/test/utils/stringUtils.test.js
+++ b/test/utils/stringUtils.test.js
@@ -63,6 +63,10 @@ describe('safeTrim', () => {
     expect(safeTrim('   ')).toBe('');
   });
 
+  test('handles whitespace with newlines and tabs', () => {
+    expect(safeTrim('\n\t  \t')).toBe('');
+  });
+
   test('preserves internal spacing', () => {
     const str = 'te st';
     expect(safeTrim(str)).toBe(str);


### PR DESCRIPTION
## Summary
- add a regression test for `safeTrim` with newlines and tabs

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68472a42ec70832e8ba24bd6108ba995