### PR TITLE
Add keypress unit test

### DIFF
--- a/test/browser/initializeInteractiveComponent.keypress.test.js
+++ b/test/browser/initializeInteractiveComponent.keypress.test.js
@@ -1,0 +1,73 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { initializeInteractiveComponent } from '../../src/browser/toys.js';
+
+// Test that the keypress handler created inside initializeInteractiveComponent
+// triggers submit only when the Enter key is pressed.
+describe('initializeInteractiveComponent keypress handling', () => {
+  it('invokes handleSubmit on Enter key only', () => {
+    const inputElement = {};
+    const submitButton = {};
+    const outputParent = {};
+    const outputSelect = {};
+    let keypressHandler;
+
+    const dom = {
+      querySelector: jest.fn((_, selector) => {
+        switch (selector) {
+        case 'input':
+          return inputElement;
+        case 'button':
+          return submitButton;
+        case 'div.output':
+          return outputParent;
+        case 'select.output':
+          return outputSelect;
+        default:
+          return {};
+        }
+      }),
+      addEventListener: jest.fn((el, event, handler) => {
+        if (el === inputElement && event === 'keypress') {
+          keypressHandler = handler;
+        }
+      }),
+      removeAllChildren: jest.fn(),
+      createElement: jest.fn(() => ({ textContent: '' })),
+      appendChild: jest.fn(),
+      setTextContent: jest.fn(),
+      removeWarning: jest.fn(),
+      enable: jest.fn(),
+      stopDefault: jest.fn(),
+      removeChild: jest.fn(),
+      addWarning: jest.fn(),
+      contains: () => true,
+    };
+
+    const config = {
+      globalState: {},
+      createEnvFn: () => ({}),
+      errorFn: jest.fn(),
+      fetchFn: jest.fn().mockResolvedValue({ text: jest.fn().mockResolvedValue('{}') }),
+      dom,
+      loggers: {
+        logInfo: jest.fn(),
+        logError: jest.fn(),
+        logWarning: jest.fn(),
+      },
+    };
+    const processingFunction = jest.fn();
+    const article = { id: 'article-1' };
+
+    initializeInteractiveComponent(article, processingFunction, config);
+
+    expect(typeof keypressHandler).toBe('function');
+
+    // Non-Enter key should not trigger submit
+    keypressHandler({ key: 'a' });
+    expect(dom.stopDefault).not.toHaveBeenCalled();
+
+    // Enter key triggers submit
+    keypressHandler({ key: 'Enter' });
+    expect(dom.stopDefault).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add a test for the keypress handler created by `initializeInteractiveComponent`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68472a4222b0832e893be44a236f812a