### PR TITLE
Add test for createAddDropdownListener return value

### DIFF
--- a/test/browser/createAddDropdownListener.returnValue.test.js
+++ b/test/browser/createAddDropdownListener.returnValue.test.js
@@ -1,0 +1,18 @@
+import { test, expect, jest } from '@jest/globals';
+import { createAddDropdownListener } from '../../src/browser/toys.js';
+
+test('createAddDropdownListener ignores addEventListener return value', () => {
+  const onChange = jest.fn();
+  const dom = { addEventListener: jest.fn(() => 'listener-id') };
+  const dropdown = {};
+
+  const addListener = createAddDropdownListener(onChange, dom);
+  const result = addListener(dropdown);
+
+  expect(result).toBeUndefined();
+  expect(dom.addEventListener).toHaveBeenCalledWith(
+    dropdown,
+    'change',
+    onChange
+  );
+});


### PR DESCRIPTION
## Summary
- add test verifying `createAddDropdownListener` ignores the return value from `dom.addEventListener`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68472a415d8c832eb4516005a68dc894