### PR TITLE
Add test for invalid parsed request handling

### DIFF
--- a/test/browser/processInputAndSetOutput.test.js
+++ b/test/browser/processInputAndSetOutput.test.js
@@ -77,6 +77,19 @@ describe('processInputAndSetOutput', () => {
     );
   });
 
+  it('sets text content when parsed result lacks request url', () => {
+    const json = JSON.stringify({ request: {} });
+    processingFunction.mockReturnValue(json);
+
+    processInputAndSetOutput(elements, processingFunction, env);
+
+    expect(env.fetchFn).not.toHaveBeenCalled();
+    expect(env.dom.appendChild).toHaveBeenCalledWith(
+      elements.outputParentElement,
+      expect.anything()
+    );
+  });
+
   it('stores the result keyed by article id', () => {
     const result = 'ok';
     processingFunction.mockReturnValue(result);


### PR DESCRIPTION
## Summary
- extend `processInputAndSetOutput` tests to verify text content is set when the parsed result is missing a request URL

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68472a412a0c832e9108c92e39d691f4