### PR TITLE
Improve error handling test coverage

### DIFF
--- a/test/browser/createHandleInputError.test.js
+++ b/test/browser/createHandleInputError.test.js
@@ -39,7 +39,11 @@ describe('createHandleSubmit error handling via createHandleInputError', () => {
 
     const handler = createHandleSubmit(elements, processingFunction, env);
 
-    expect(() => handler({})).not.toThrow();
+    let result;
+    expect(() => {
+      result = handler({});
+    }).not.toThrow();
+    expect(result).toBeUndefined();
 
     expect(env.errorFn).toHaveBeenCalledWith(
       'Error processing input:',


### PR DESCRIPTION
## Summary
- extend `createHandleSubmit` error handling test to check the returned value

## Testing
- `CI=true npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68472a3ffbf8832ea1057296079dd0fe