### PR TITLE
Add missing generateClues null input test

### DIFF
--- a/test/toys/2025-05-11/generateClues.nullInput.parse.test.js
+++ b/test/toys/2025-05-11/generateClues.nullInput.parse.test.js
@@ -1,0 +1,10 @@
+import { test, expect } from '@jest/globals';
+import { generateClues } from '../../../src/toys/2025-05-11/battleshipSolitaireClues.js';
+
+// Additional coverage to ensure null input does not trigger runtime errors
+// and returns the expected error JSON string.
+test('generateClues returns error JSON for null input', () => {
+  const result = generateClues('null');
+  expect(result).toBe('{"error":"Invalid fleet structure"}');
+  expect(() => JSON.parse(result)).not.toThrow();
+});


### PR DESCRIPTION
## Summary
- add unit test covering `generateClues('null')`

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6847305e210c832e81589d4d1e56b776