### PR TITLE
Add test for startLocalDendriteStory temporary handling

### DIFF
--- a/test/toys/2025-06-09/startLocalDendriteStory.append.test.js
+++ b/test/toys/2025-06-09/startLocalDendriteStory.append.test.js
@@ -1,0 +1,25 @@
+import { startLocalDendriteStory } from '../../../src/toys/2025-06-09/startLocalDendriteStory.js';
+import { test, expect, jest } from '@jest/globals';
+
+test('startLocalDendriteStory appends to existing temporary array', () => {
+  const existing = { id: 'old', title: 'Old', content: 'Old', options: [] };
+  const uuids = ['id-new', 'id-a', 'id-b'];
+  let idx = 0;
+  const env = new Map([
+    ['getUuid', () => uuids[idx++]],
+    ['getData', () => ({ temporary: { DEND1: [existing] } })],
+    ['setData', jest.fn()],
+  ]);
+
+  const inputObj = {
+    title: 'Title',
+    content: 'Body',
+    firstOption: 'A',
+    secondOption: 'B',
+  };
+  const output = JSON.parse(startLocalDendriteStory(JSON.stringify(inputObj), env));
+
+  expect(env.get('setData')).toHaveBeenCalledWith({
+    temporary: { DEND1: [existing, output] },
+  });
+});


### PR DESCRIPTION
## Summary
- verify startLocalDendriteStory preserves existing `temporary.DEND1` data

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6847305d2f7c832eba1840598056d39f