### PR TITLE
Add assertion for handleInputProcessing

### DIFF
--- a/test/browser/createHandleSubmit.string.test.js
+++ b/test/browser/createHandleSubmit.string.test.js
@@ -28,5 +28,8 @@ describe('createHandleSubmit string representation', () => {
     expect(typeof handler).toBe('function');
     expect(handler.length).toBe(1);
     expect(handler.toString()).toContain('stopDefault');
+    // Additional assertion to help eliminate mutation that removes
+    // the handleInputProcessing call within the handler
+    expect(handler.toString()).toContain('handleInputProcessing');
   });
 });


### PR DESCRIPTION
## Summary
- strengthen `createHandleSubmit` string test by asserting that the handler includes `handleInputProcessing`

## Testing
- `npm test --silent`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6847305d5b7c832ea6e93d289f54bf24