### PR TITLE
Add test to ensure footer warning class appears once

### DIFF
--- a/test/generator/footerWarningClass.count.test.js
+++ b/test/generator/footerWarningClass.count.test.js
@@ -1,0 +1,8 @@
+import { test, expect } from '@jest/globals';
+import { generateBlogOuter } from '../../src/generator/generator.js';
+
+test('footer warning class appears exactly once', () => {
+  const html = generateBlogOuter({ posts: [] });
+  const matches = html.match(/<div class="footer value warning">/g) || [];
+  expect(matches.length).toBe(1);
+});


### PR DESCRIPTION
## Summary
- add a regression test checking the footer `warning` class appears exactly once

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6847305c7ccc832e9c1d40e910c81970