### PR TITLE
Add test to verify illustration wrapper tag

### DIFF
--- a/test/generator/mediaContentConfig.wrapperTagClose.test.js
+++ b/test/generator/mediaContentConfig.wrapperTagClose.test.js
@@ -1,0 +1,24 @@
+import { describe, test, expect } from '@jest/globals';
+import { generateBlog } from '../../src/generator/generator.js';
+
+const header = '<body>';
+const footer = '</body>';
+const wrapHtml = c => ['<html>', c, '</html>'].join('');
+
+describe('MEDIA_CONTENT_CONFIG wrapper tag', () => {
+  test('illustration section uses div wrapper', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'ILLW1',
+          title: 'With Illustration',
+          publicationDate: '2024-01-01',
+          illustration: { fileType: 'png', altText: 'alt' }
+        }
+      ]
+    };
+    const html = generateBlog({ blog, header, footer }, wrapHtml);
+    const match = html.match(/<div class="value"><img[^]*?<\/div>/);
+    expect(match).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- ensure illustration media sections use a `<div>` wrapper

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6847305c064c832ebecdb78d3de32200