### PR TITLE
Add test for startLocalDendriteStory temporary append

### DIFF
--- a/test/toys/2025-06-09/startLocalDendriteStory.test.js
+++ b/test/toys/2025-06-09/startLocalDendriteStory.test.js
@@ -86,6 +86,31 @@ describe('startLocalDendriteStory', () => {
     ]);
   });
 
+  test('appends to existing temporary array', () => {
+    const existing = { id: 'old', title: 'Old', content: 'Old', options: [] };
+    const uuids = ['id-new', 'id-a', 'id-b'];
+    let idx = 0;
+    const env = new Map([
+      ['getUuid', () => uuids[idx++]],
+      ['getData', () => ({ temporary: { DEND1: [existing] } })],
+      ['setData', jest.fn()],
+    ]);
+
+    const inputObj = {
+      title: 'Title',
+      content: 'Body',
+      firstOption: 'A',
+      secondOption: 'B',
+    };
+    const output = JSON.parse(
+      startLocalDendriteStory(JSON.stringify(inputObj), env)
+    );
+
+    expect(env.get('setData')).toHaveBeenCalledWith({
+      temporary: { DEND1: [existing, output] },
+    });
+  });
+
   test('returns empty object string on parse error', () => {
     const mockSetData = jest.fn();
     const env = new Map([


### PR DESCRIPTION
## Summary
- ensure startLocalDendriteStory appends to existing temporary entries

## Testing
- `npm test --silent`
- `npm run lint --silent`

------
https://chatgpt.com/codex/tasks/task_e_6847bd4fa648832ea406912cca7ffaa0