### PR TITLE
Remove duplicate tests

### DIFF
--- a/test/presenters/battleshipSolitaireFleet.test.js
+++ b/test/presenters/battleshipSolitaireFleet.test.js
@@ -135,23 +135,37 @@ describe('createBattleshipFleetBoardElement', () => {
     expect(lines[2].replace(/ /g, '')).toBe('···');
   });
 
-  test('skips ships with non-number length', () => {
-    const fleet = {
-      width: 3,
-      height: 3,
-      ships: [
+  test.each([
+    [
+      'first',
+      [
         { start: { x: 0, y: 0 }, length: '2', direction: 'H' },
         { start: { x: 1, y: 1 }, length: 2, direction: 'V' },
       ],
-    };
-    const input = JSON.stringify(fleet);
-    const el = createBattleshipFleetBoardElement(input, dom);
-    expect(el.tag).toBe('pre');
-    const lines = el.text.trim().split('\n');
-    expect(lines[0].replace(/ /g, '')).toBe('···');
-    expect(lines[1].replace(/ /g, '')).toBe('·#·');
-    expect(lines[2].replace(/ /g, '')).toBe('·#·');
-  });
+      ['···', '·#·', '·#·'],
+    ],
+    [
+      'second',
+      [
+        { start: { x: 0, y: 0 }, length: 2, direction: 'H' },
+        { start: { x: 1, y: 1 }, length: '2', direction: 'H' },
+      ],
+      ['##·', '···', '···'],
+    ],
+  ])(
+    'skips ships with non-number length (%s invalid)',
+    (_, ships, expected) => {
+      const fleet = { width: 3, height: 3, ships };
+      const input = JSON.stringify(fleet);
+      const el = createBattleshipFleetBoardElement(input, dom);
+      expect(el.tag).toBe('pre');
+      const lines = el.text
+        .trim()
+        .split('\n')
+        .map(l => l.replace(/ /g, ''));
+      expect(lines).toEqual(expected);
+    }
+  );
 
   test('skips ships missing the start property', () => {
     const fleet = {
@@ -222,24 +236,6 @@ describe('createBattleshipFleetBoardElement', () => {
       ships: [
         { start: { x: 0, y: 0 }, length: 2, direction: 'H' },
         { start: { x: 1, y: 1 }, length: 2, direction: 'X' },
-      ],
-    };
-    const input = JSON.stringify(fleet);
-    const el = createBattleshipFleetBoardElement(input, dom);
-    expect(el.tag).toBe('pre');
-    const lines = el.text.trim().split('\n');
-    expect(lines[0].replace(/ /g, '')).toBe('##·');
-    expect(lines[1].replace(/ /g, '')).toBe('···');
-    expect(lines[2].replace(/ /g, '')).toBe('···');
-  });
-
-  test('skips ships with non-number length', () => {
-    const fleet = {
-      width: 3,
-      height: 3,
-      ships: [
-        { start: { x: 0, y: 0 }, length: 2, direction: 'H' },
-        { start: { x: 1, y: 1 }, length: '2', direction: 'H' },
       ],
     };
     const input = JSON.stringify(fleet);

--- a/test/utils/objectUtils.test.js
+++ b/test/utils/objectUtils.test.js
@@ -1,17 +1,22 @@
 import { describe, test, expect } from '@jest/globals';
 import { pick, mapValues } from '../../src/utils/objectUtils.js';
 
+describe.each([
+  ['pick', obj => pick(obj, ['a'])],
+  ['mapValues', obj => mapValues(obj, v => v)],
+])('%s', (name, fn) => {
+  test('returns empty object if source is not an object', () => {
+    expect(fn(null)).toEqual({});
+    expect(fn(undefined)).toEqual({});
+    expect(fn('test')).toEqual({});
+    expect(fn(123)).toEqual({});
+  });
+});
+
 describe('pick', () => {
   test('picks specified properties from an object', () => {
     const obj = { a: 1, b: 2, c: 3 };
     expect(pick(obj, ['a', 'c'])).toEqual({ a: 1, c: 3 });
-  });
-
-  test('returns empty object if source is not an object', () => {
-    expect(pick(null, ['a'])).toEqual({});
-    expect(pick(undefined, ['a'])).toEqual({});
-    expect(pick('test', ['a'])).toEqual({});
-    expect(pick(123, ['a'])).toEqual({});
   });
 
   test('ignores non-existent properties', () => {
@@ -43,13 +48,6 @@ describe('mapValues', () => {
     const obj = { a: 1, b: 2 };
     const result = mapValues(obj, (value, key) => `${key}_${value}`);
     expect(result).toEqual({ a: 'a_1', b: 'b_2' });
-  });
-
-  test('returns empty object if source is not an object', () => {
-    expect(mapValues(null, v => v)).toEqual({});
-    expect(mapValues(undefined, v => v)).toEqual({});
-    expect(mapValues('test', v => v)).toEqual({});
-    expect(mapValues(123, v => v)).toEqual({});
   });
 
   test('handles empty objects', () => {

--- a/test/utils/stringUtils.test.js
+++ b/test/utils/stringUtils.test.js
@@ -24,24 +24,6 @@ describe('isEmpty', () => {
   });
 });
 
-describe('isValidText', () => {
-  test('returns true for non-empty strings', () => {
-    expect(isValidText('test')).toBe(true);
-    expect(isValidText(' ')).toBe(true);
-    expect(isValidText('0')).toBe(true);
-  });
-
-  test('returns false for empty or non-string values', () => {
-    expect(isValidText('')).toBe(false);
-    expect(isValidText(null)).toBe(false);
-    expect(isValidText(undefined)).toBe(false);
-    expect(isValidText(0)).toBe(false);
-    expect(isValidText(false)).toBe(false);
-    expect(isValidText({})).toBe(false);
-    expect(isValidText([])).toBe(false);
-  });
-});
-
 describe('safeTrim', () => {
   test('trims whitespace from strings', () => {
     expect(safeTrim(' test ')).toBe('test');

--- a/test/utils/stringValidationFunctions.test.js
+++ b/test/utils/stringValidationFunctions.test.js
@@ -1,0 +1,22 @@
+import { describe, test, expect } from '@jest/globals';
+import { isValidText } from '../../src/utils/stringUtils.js';
+import { isValidString } from '../../src/utils/validation.js';
+
+describe.each([
+  ['isValidText', isValidText],
+  ['isValidString', isValidString],
+])('%s', (name, fn) => {
+  test('returns true for non-empty strings', () => {
+    const values = ['test', ' ', '0', 'false'];
+    for (const val of values) {
+      expect(fn(val)).toBe(true);
+    }
+  });
+
+  test('returns false for empty or non-string values', () => {
+    const values = ['', null, undefined, 0, false, {}, []];
+    for (const v of values) {
+      expect(fn(v)).toBe(false);
+    }
+  });
+});

--- a/test/utils/validation.test.js
+++ b/test/utils/validation.test.js
@@ -1,5 +1,9 @@
 import { describe, test, expect } from '@jest/globals';
-import { isType, isValidString, isValidBoolean } from '../../src/utils/validation.js';
+import {
+  isType,
+  isValidString,
+  isValidBoolean,
+} from '../../src/utils/validation.js';
 
 describe('isType', () => {
   test('returns true for matching types', () => {
@@ -21,25 +25,6 @@ describe('isType', () => {
     expect(isType(true, 'number')).toBe(false);
     expect(isType(null, 'undefined')).toBe(false);
     expect(isType(undefined, 'null')).toBe(false);
-  });
-});
-
-describe('isValidString', () => {
-  test('returns true for non-empty strings', () => {
-    expect(isValidString('test')).toBe(true);
-    expect(isValidString(' ')).toBe(true);
-    expect(isValidString('0')).toBe(true);
-    expect(isValidString('false')).toBe(true);
-  });
-
-  test('returns false for non-string or empty values', () => {
-    expect(isValidString('')).toBe(false);
-    expect(isValidString(null)).toBe(false);
-    expect(isValidString(undefined)).toBe(false);
-    expect(isValidString(0)).toBe(false);
-    expect(isValidString(false)).toBe(false);
-    expect(isValidString({})).toBe(false);
-    expect(isValidString([])).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- combine duplicate tests in objectUtils
- combine string validation tests
- combine battleshipSolitaireFleet tests for invalid length

## Testing
- `npm test` *(fails: Cannot find module 'jest')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6847bd44ee40832e9cba25848aca851a