### PR TITLE
Remove duplicate test case

### DIFF
--- a/test/presenters/battleshipSolitaireFleet.test.js
+++ b/test/presenters/battleshipSolitaireFleet.test.js
@@ -135,22 +135,30 @@ describe('createBattleshipFleetBoardElement', () => {
     expect(lines[2].replace(/ /g, '')).toBe('···');
   });
 
-  test('skips ships with non-number length', () => {
-    const fleet = {
-      width: 3,
-      height: 3,
-      ships: [
+  test.each([
+    [
+      [
         { start: { x: 0, y: 0 }, length: '2', direction: 'H' },
         { start: { x: 1, y: 1 }, length: 2, direction: 'V' },
       ],
-    };
+      ['···', '·#·', '·#·'],
+    ],
+    [
+      [
+        { start: { x: 0, y: 0 }, length: 2, direction: 'H' },
+        { start: { x: 1, y: 1 }, length: '2', direction: 'H' },
+      ],
+      ['##·', '···', '···'],
+    ],
+  ])('skips ships with non-number length', (ships, expected) => {
+    const fleet = { width: 3, height: 3, ships };
     const input = JSON.stringify(fleet);
     const el = createBattleshipFleetBoardElement(input, dom);
     expect(el.tag).toBe('pre');
     const lines = el.text.trim().split('\n');
-    expect(lines[0].replace(/ /g, '')).toBe('···');
-    expect(lines[1].replace(/ /g, '')).toBe('·#·');
-    expect(lines[2].replace(/ /g, '')).toBe('·#·');
+    expect(lines[0].replace(/ /g, '')).toBe(expected[0]);
+    expect(lines[1].replace(/ /g, '')).toBe(expected[1]);
+    expect(lines[2].replace(/ /g, '')).toBe(expected[2]);
   });
 
   test('skips ships missing the start property', () => {
@@ -233,21 +241,4 @@ describe('createBattleshipFleetBoardElement', () => {
     expect(lines[2].replace(/ /g, '')).toBe('···');
   });
 
-  test('skips ships with non-number length', () => {
-    const fleet = {
-      width: 3,
-      height: 3,
-      ships: [
-        { start: { x: 0, y: 0 }, length: 2, direction: 'H' },
-        { start: { x: 1, y: 1 }, length: '2', direction: 'H' },
-      ],
-    };
-    const input = JSON.stringify(fleet);
-    const el = createBattleshipFleetBoardElement(input, dom);
-    expect(el.tag).toBe('pre');
-    const lines = el.text.trim().split('\n');
-    expect(lines[0].replace(/ /g, '')).toBe('##·');
-    expect(lines[1].replace(/ /g, '')).toBe('···');
-    expect(lines[2].replace(/ /g, '')).toBe('···');
-  });
 });


### PR DESCRIPTION
## Summary
- merge two "non-number length" fleet board tests into one parameterized test

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_6847bd43afcc832ea3a0779bd434b303