### PR TITLE
Add test to check option order

### DIFF
--- a/test/generator/toyOutputDropdown.order.test.js
+++ b/test/generator/toyOutputDropdown.order.test.js
@@ -1,0 +1,36 @@
+import { describe, test, expect } from '@jest/globals';
+import { generateBlog } from '../../src/generator/generator.js';
+
+const header = '<body>';
+const footer = '</body>';
+const wrapHtml = c => `<html>${c}</html>`;
+
+describe('toy output dropdown option order', () => {
+  test('dropdown options appear in fixed order', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'ORDER',
+          title: 'Toy Post',
+          publicationDate: '2024-01-01',
+          toy: {
+            modulePath: './toys/2024-01-01/example.js',
+            functionName: 'example',
+          },
+        },
+      ],
+    };
+
+    const html = generateBlog({ blog, header, footer }, wrapHtml);
+    const match = html.match(/<select class="output">([\s\S]*?)<\/select>/);
+    expect(match).not.toBeNull();
+    const options = match[1].replace(/\n/g, '').trim();
+    const expected =
+      '<option value="text">text</option>' +
+      '<option value="pre">pre</option>' +
+      '<option value="tic-tac-toe">tic-tac-toe</option>' +
+      '<option value="battleship-solitaire-fleet">battleship-solitaire-fleet</option>' +
+      '<option value="battleship-solitaire-clues-presenter">battleship-solitaire-clues-presenter</option>';
+    expect(options).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Summary
- verify dropdown options appear in the expected order

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6847bd517d08832ea060c41b3e6cbddf