### PR TITLE
Add test for output dropdown result propagation

### DIFF
--- a/test/browser/createOutputDropdownHandler.resultPropagation.test.js
+++ b/test/browser/createOutputDropdownHandler.resultPropagation.test.js
@@ -1,0 +1,16 @@
+import { test, expect, jest } from '@jest/globals';
+import { createOutputDropdownHandler } from '../../src/browser/toys.js';
+
+test('createOutputDropdownHandler forwards handler result and parameters', () => {
+  const expected = 'done';
+  const handleDropdownChange = jest.fn(() => expected);
+  const getData = jest.fn();
+  const dom = {};
+  const handler = createOutputDropdownHandler(handleDropdownChange, getData, dom);
+
+  const evt = { currentTarget: { value: 'x' } };
+  const result = handler(evt);
+
+  expect(result).toBe(expected);
+  expect(handleDropdownChange).toHaveBeenCalledWith(evt.currentTarget, getData, dom);
+});


### PR DESCRIPTION
## Summary
- test that createOutputDropdownHandler returns the value from the handler and passes parameters through

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6847c7ce33fc832e94598c29d49eceb2