### PR TITLE
Add test for output dropdown handler

### DIFF
--- a/test/browser/createOutputDropdownHandler.additionalScenario.test.js
+++ b/test/browser/createOutputDropdownHandler.additionalScenario.test.js
@@ -1,0 +1,18 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { createOutputDropdownHandler } from '../../src/browser/toys.js';
+
+describe('createOutputDropdownHandler additional scenario', () => {
+  it('delegates to handleDropdownChange with provided dependencies', () => {
+    const handleDropdownChange = jest.fn(() => 'value');
+    const getData = jest.fn();
+    const dom = { helper: () => true };
+
+    const handler = createOutputDropdownHandler(handleDropdownChange, getData, dom);
+
+    const evt = { currentTarget: { id: 'a' } };
+    const result = handler(evt);
+
+    expect(result).toBe('value');
+    expect(handleDropdownChange).toHaveBeenCalledWith(evt.currentTarget, getData, dom);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test covering createOutputDropdownHandler

## Testing
- `npm test --silent`
- `npm run lint --silent`

------
https://chatgpt.com/codex/tasks/task_e_6847c7ccc43c832eb705922425822d60