### PR TITLE
Add test covering text input handler

### DIFF
--- a/test/browser/createInputDropdownHandler.textOnly.mutant.test.js
+++ b/test/browser/createInputDropdownHandler.textOnly.mutant.test.js
@@ -1,0 +1,30 @@
+import { test, expect, jest } from '@jest/globals';
+import { createInputDropdownHandler } from '../../src/browser/toys.js';
+
+test('createInputDropdownHandler shows text input when value is "text"', () => {
+  const select = {};
+  const container = {};
+  const textInput = {};
+  const event = {};
+
+  const dom = {
+    getCurrentTarget: jest.fn(() => select),
+    getParentElement: jest.fn(() => container),
+    querySelector: jest.fn((_, selector) =>
+      selector === 'input[type="text"]' ? textInput : null
+    ),
+    getValue: jest.fn(() => 'text'),
+    reveal: jest.fn(),
+    enable: jest.fn(),
+    hide: jest.fn(),
+    disable: jest.fn(),
+  };
+
+  const handler = createInputDropdownHandler(dom);
+  handler(event);
+
+  expect(dom.reveal).toHaveBeenCalledWith(textInput);
+  expect(dom.enable).toHaveBeenCalledWith(textInput);
+  expect(dom.hide).not.toHaveBeenCalled();
+  expect(dom.disable).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- add regression test for `createInputDropdownHandler` text branch

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6847c7cc4a2c832e852f7cc10c2f0bff