### PR TITLE
Add missing test for createKeyValueRow

### DIFF
--- a/test/browser/createKeyValueRow.appendChild.test.js
+++ b/test/browser/createKeyValueRow.appendChild.test.js
@@ -1,0 +1,47 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { createKeyValueRow } from '../../src/browser/toys.js';
+
+describe('createKeyValueRow DOM appends', () => {
+  it('appends key, value and button elements to the row and container', () => {
+    const rowEl = {};
+    const keyInput = {};
+    const valueInput = {};
+    const button = {};
+    const container = {};
+
+    const dom = {
+      createElement: jest
+        .fn()
+        .mockReturnValueOnce(rowEl)
+        .mockReturnValueOnce(keyInput)
+        .mockReturnValueOnce(valueInput)
+        .mockReturnValueOnce(button),
+      setClassName: jest.fn(),
+      appendChild: jest.fn(),
+      setType: jest.fn(),
+      setPlaceholder: jest.fn(),
+      setTextContent: jest.fn(),
+      setValue: jest.fn(),
+      setDataAttribute: jest.fn(),
+      addEventListener: jest.fn(),
+    };
+
+    const rowCreator = createKeyValueRow(
+      dom,
+      [],
+      {},
+      {},
+      () => {},
+      [],
+      () => {},
+      container
+    );
+
+    rowCreator(['a', 'b'], 0);
+
+    expect(dom.appendChild).toHaveBeenNthCalledWith(1, rowEl, keyInput);
+    expect(dom.appendChild).toHaveBeenNthCalledWith(2, rowEl, valueInput);
+    expect(dom.appendChild).toHaveBeenNthCalledWith(3, rowEl, button);
+    expect(dom.appendChild).toHaveBeenNthCalledWith(4, container, rowEl);
+  });
+});


### PR DESCRIPTION
## Summary
- add test covering DOM append behavior of `createKeyValueRow`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6847e5afe48c832e8e6c1f798377568e