### PR TITLE
Improve test coverage for date formatting

### DIFF
--- a/test/generator/dateFormatOptions.additionalKill.test.js
+++ b/test/generator/dateFormatOptions.additionalKill.test.js
@@ -1,0 +1,25 @@
+import { describe, test, expect } from '@jest/globals';
+import { generateBlog } from '../../src/generator/generator.js';
+
+const header = '<body>';
+const footer = '</body>';
+const wrapHtml = html => html;
+
+describe('DATE_FORMAT_OPTIONS additional kill', () => {
+  test('generateBlog outputs date without slashes', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'DF_OK',
+          title: 'Test',
+          publicationDate: '2024-05-04',
+          content: ['X'],
+        },
+      ],
+    };
+
+    const html = generateBlog({ blog, header, footer }, wrapHtml);
+    expect(html).toContain('<p class="value metadata">4 May 2024</p>');
+    expect(html).not.toContain('04/05/2024');
+  });
+});


### PR DESCRIPTION
## Summary
- add test to ensure short month formatting in `generateBlog`

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6847e5b121a4832e8bf8545f07a624cd