### PR TITLE
Add test for audio controls attribute

### DIFF
--- a/test/generator/mediaContentConfig.controls.additionalKill.test.js
+++ b/test/generator/mediaContentConfig.controls.additionalKill.test.js
@@ -1,0 +1,31 @@
+import { describe, test, expect } from '@jest/globals';
+import { generateBlog } from '../../src/generator/generator.js';
+
+const header = '<body>';
+const footer = '</body>';
+const wrapHtml = html => html;
+
+describe('MEDIA_CONTENT_CONFIG audio controls additional kill', () => {
+  test('audio tags always include controls attribute', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'AC1',
+          title: 'Audio One',
+          publicationDate: '2024-07-01',
+          audio: { fileType: 'mp3' },
+        },
+        {
+          key: 'TXT',
+          title: 'Just Text',
+          publicationDate: '2024-07-02',
+          content: ['text'],
+        },
+      ],
+    };
+    const html = generateBlog({ blog, header, footer }, wrapHtml);
+    const audioMatch = html.match(/<audio[^>]*>/);
+    expect(audioMatch).not.toBeNull();
+    expect(audioMatch[0]).toContain('controls');
+  });
+});


### PR DESCRIPTION
## Summary
- add `mediaContentConfig.controls.additionalKill.test.js` to assert that audio tags include the `controls` attribute

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6847f684aa14832ea7b264e320c552a7