### PR TITLE
Add mutant-killing test

### DIFF
--- a/test/browser/createRemoveAddListener.handlerUse.test.js
+++ b/test/browser/createRemoveAddListener.handlerUse.test.js
@@ -1,0 +1,28 @@
+import { test, expect, jest } from '@jest/globals';
+import { setupAddButton } from '../../src/browser/toys.js';
+
+test('setupAddButton disposer removes the exact click handler after invocation', () => {
+  const dom = {
+    setTextContent: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+  };
+  const btn = {};
+  const rows = {};
+  const render = jest.fn();
+  const disposers = [];
+
+  setupAddButton(dom, btn, rows, render, disposers);
+
+  expect(disposers).toHaveLength(1);
+  const dispose = disposers[0];
+  expect(typeof dispose).toBe('function');
+
+  const [, , handler] = dom.addEventListener.mock.calls[0];
+  handler();
+  expect(rows).toHaveProperty('');
+  expect(render).toHaveBeenCalled();
+
+  dispose();
+  expect(dom.removeEventListener).toHaveBeenCalledWith(btn, 'click', handler);
+});


### PR DESCRIPTION
## Summary
- add missing test to ensure add button disposer removes the correct event listener

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6847f68373c8832eab615ecd15e00360