### PR TITLE
Add date formatting test

### DIFF
--- a/test/generator/dateFormat.blogOutput.test.js
+++ b/test/generator/dateFormat.blogOutput.test.js
@@ -1,0 +1,12 @@
+import { test, expect } from '@jest/globals';
+import { generateBlogOuter } from '../../src/generator/generator.js';
+
+test('generateBlogOuter formats publication dates in en-GB style', () => {
+  const blog = {
+    posts: [
+      { key: 'D1', title: 'Date Test', publicationDate: '2022-05-04', content: [] }
+    ]
+  };
+  const html = generateBlogOuter(blog);
+  expect(html).toContain('4 May 2022');
+});


### PR DESCRIPTION
## Summary
- verify generateBlogOuter outputs publication dates with British formatting

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6847f683951c832e845ff315675484e5