### PR TITLE
Add test for createOutputDropdownHandler

### DIFF
--- a/test/browser/createOutputDropdownHandler.length.test.js
+++ b/test/browser/createOutputDropdownHandler.length.test.js
@@ -1,0 +1,17 @@
+import { describe, test, expect, jest } from '@jest/globals';
+import { createOutputDropdownHandler } from '../../src/browser/toys.js';
+
+describe('createOutputDropdownHandler additional', () => {
+  test('returns unary handler that delegates to handleDropdownChange', () => {
+    const handle = jest.fn().mockReturnValue('x');
+    const getData = jest.fn();
+    const dom = {};
+    const handler = createOutputDropdownHandler(handle, getData, dom);
+    expect(typeof handler).toBe('function');
+    expect(handler.length).toBe(1);
+    const evt = { currentTarget: { value: 'v' } };
+    const result = handler(evt);
+    expect(result).toBe('x');
+    expect(handle).toHaveBeenCalledWith(evt.currentTarget, getData, dom);
+  });
+});


### PR DESCRIPTION
## Summary
- add an additional test for `createOutputDropdownHandler`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6847f68319cc832e9d1ab6ba5417e03e