### PR TITLE
Add parseJSONResult empty string test

### DIFF
--- a/test/browser/parseJSONResult.emptyString.test.js
+++ b/test/browser/parseJSONResult.emptyString.test.js
@@ -1,0 +1,8 @@
+import { describe, test, expect } from '@jest/globals';
+import { parseJSONResult } from '../../src/browser/toys.js';
+
+describe('parseJSONResult empty string', () => {
+  test('returns null when given an empty string', () => {
+    expect(parseJSONResult('')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add a test for `parseJSONResult` handling empty string input

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6847fe480824832e9fe72994f46ff341