### PR TITLE
Add full toy UI section test

### DIFF
--- a/test/generator/toyUiSections.fullHtml.test.js
+++ b/test/generator/toyUiSections.fullHtml.test.js
@@ -1,0 +1,26 @@
+import { describe, test, expect } from '@jest/globals';
+import { generateBlog } from '../../src/generator/generator.js';
+
+const header = '<body>';
+const footer = '</body>';
+const wrapHtml = html => html;
+
+describe('TOY_UI_SECTIONS full HTML', () => {
+  test('generateBlog includes full input section markup', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'TUIFULL',
+          title: 'Toy Section',
+          publicationDate: '2024-01-01',
+          content: ['x'],
+          toy: { modulePath: './toys/2024-01-01/example.js', functionName: 'example' },
+        },
+      ],
+    };
+    const html = generateBlog({ blog, header, footer }, wrapHtml);
+    const inSection =
+      '<div class="key">in</div><div class="value"><select class="input"><option value="text">text</option><option value="number">number</option><option value="kv">kv</option></select><input type="text" disabled></div>';
+    expect(html).toContain(inSection);
+  });
+});


### PR DESCRIPTION
## Summary
- add regression test ensuring toy UI "in" section markup is fully generated

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6847fe46e9b0832eb186b30fe6eb616d