### PR TITLE
Fix dendrite story input cleanup

### DIFF
--- a/src/inputHandlers/dendriteStory.js
+++ b/src/inputHandlers/dendriteStory.js
@@ -1,6 +1,25 @@
+function maybeRemoveNumber(container, dom) {
+  const numberInput = dom.querySelector(container, 'input[type="number"]');
+  if (numberInput && typeof numberInput._dispose === 'function') {
+    numberInput._dispose();
+    dom.removeChild(container, numberInput);
+  }
+}
+
+function maybeRemoveKV(container, dom) {
+  const kvContainer = dom.querySelector(container, '.kv-container');
+  if (kvContainer && typeof kvContainer._dispose === 'function') {
+    kvContainer._dispose();
+    dom.removeChild(container, kvContainer);
+  }
+}
+
 export function dendriteStoryHandler(dom, container, textInput) {
   dom.hide(textInput);
   dom.disable(textInput);
+
+  maybeRemoveNumber(container, dom);
+  maybeRemoveKV(container, dom);
 
   const existing = dom.querySelector(container, '.dendrite-form');
   if (existing) {

--- a/test/inputHandlers/dendriteStoryHandler.test.js
+++ b/test/inputHandlers/dendriteStoryHandler.test.js
@@ -72,4 +72,38 @@ describe('dendriteStoryHandler', () => {
     expect(existing._dispose).toHaveBeenCalled();
     expect(dom.removeChild).toHaveBeenCalledWith({}, existing);
   });
+
+  test('removes number and kv inputs', () => {
+    const numberInput = { _dispose: jest.fn() };
+    const kvContainer = { _dispose: jest.fn() };
+    const querySelector = jest.fn((container, selector) => {
+      if (selector === 'input[type="number"]') {return numberInput;}
+      if (selector === '.kv-container') {return kvContainer;}
+      return null;
+    });
+    const dom = {
+      hide: jest.fn(),
+      disable: jest.fn(),
+      querySelector,
+      removeChild: jest.fn(),
+      createElement: jest.fn(() => ({})),
+      setClassName: jest.fn(),
+      getNextSibling: jest.fn(() => ({})),
+      insertBefore: jest.fn(),
+      setType: jest.fn(),
+      setPlaceholder: jest.fn(),
+      setTextContent: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      appendChild: jest.fn(),
+      getValue: jest.fn(() => '{}'),
+      setValue: jest.fn(),
+    };
+
+    dendriteStoryHandler(dom, {}, {});
+    expect(numberInput._dispose).toHaveBeenCalled();
+    expect(dom.removeChild).toHaveBeenCalledWith({}, numberInput);
+    expect(kvContainer._dispose).toHaveBeenCalled();
+    expect(dom.removeChild).toHaveBeenCalledWith({}, kvContainer);
+  });
 });


### PR DESCRIPTION
## Summary
- ensure dendrite story input removes number and kv inputs
- test cleanup logic

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684824360ab8832e9e48ce95aa8cb6ac