### PR TITLE
Switch dendrite story content input to textarea

### DIFF
--- a/public/inputHandlers/dendriteStory.js
+++ b/public/inputHandlers/dendriteStory.js
@@ -54,8 +54,13 @@ export function dendriteStoryHandler(dom, container, textInput) {
     const wrapper = dom.createElement('div');
     const label = dom.createElement('label');
     dom.setTextContent(label, placeholder);
-    const input = dom.createElement('input');
-    dom.setType(input, 'text');
+    const input =
+      key === 'content'
+        ? dom.createElement('textarea')
+        : dom.createElement('input');
+    if (key !== 'content') {
+      dom.setType(input, 'text');
+    }
     dom.setPlaceholder(input, placeholder);
     if (Object.prototype.hasOwnProperty.call(data, key)) {
       dom.setValue(input, data[key]);

--- a/src/inputHandlers/dendriteStory.js
+++ b/src/inputHandlers/dendriteStory.js
@@ -54,8 +54,13 @@ export function dendriteStoryHandler(dom, container, textInput) {
     const wrapper = dom.createElement('div');
     const label = dom.createElement('label');
     dom.setTextContent(label, placeholder);
-    const input = dom.createElement('input');
-    dom.setType(input, 'text');
+    const input =
+      key === 'content'
+        ? dom.createElement('textarea')
+        : dom.createElement('input');
+    if (key !== 'content') {
+      dom.setType(input, 'text');
+    }
     dom.setPlaceholder(input, placeholder);
     if (Object.prototype.hasOwnProperty.call(data, key)) {
       dom.setValue(input, data[key]);


### PR DESCRIPTION
## Summary
- update dendrite story handler to create a `<textarea>` for the `content` field
- copy change to built script

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68488822ac38832e8136528cbb12639f