### PR TITLE
Add default input method support

### DIFF
--- a/public/blog.json
+++ b/public/blog.json
@@ -12,7 +12,8 @@
       },
       "toy": {
         "modulePath": "/2025-06-09/startLocalDendriteStory.js",
-        "functionName": "startLocalDendriteStory"
+        "functionName": "startLocalDendriteStory",
+        "defaultInputMethod": "dendrite-story"
       },
       "tags": ["toy", "story", "dendrite"]
     },

--- a/src/blog.json
+++ b/src/blog.json
@@ -12,7 +12,8 @@
       },
       "toy": {
         "modulePath": "/2025-06-09/startLocalDendriteStory.js",
-        "functionName": "startLocalDendriteStory"
+        "functionName": "startLocalDendriteStory",
+        "defaultInputMethod": "dendrite-story"
       },
       "tags": ["toy", "story", "dendrite"]
     },

--- a/src/generator/generator.js
+++ b/src/generator/generator.js
@@ -880,15 +880,30 @@ function generateToyScript(post) {
 }
 
 // Unified toy UI section abstraction
-const TOY_UI_SECTIONS = [
-  [
-    'in',
-    () =>
-      '<select class="input"><option value="text">text</option><option value="number">number</option><option value="kv">kv</option><option value="dendrite-story">dendrite-story</option></select><input type="text" disabled>',
-  ],
-  ['', () => '<button type="submit" disabled>Submit</button>'],
-  ['out', getToyOutputValueContent],
-];
+const INPUT_METHODS = ['text', 'number', 'kv', 'dendrite-story'];
+
+/**
+ * Build the input dropdown for a toy
+ * @param {string} defaultMethod - The configured default input method
+ * @returns {string} - HTML for the dropdown and text input
+ */
+function buildToyInputDropdown(defaultMethod) {
+  const selectedMethod =
+    defaultMethod && defaultMethod !== 'text' ? defaultMethod : undefined;
+  const options = INPUT_METHODS.map(method => {
+    const selected = method === selectedMethod ? ' selected' : '';
+    return `<option value="${method}"${selected}>${method}</option>`;
+  }).join('');
+  return `<select class="input">${options}</select><input type="text" disabled>`;
+}
+
+function getToyUISections(defaultMethod) {
+  return [
+    ['in', () => buildToyInputDropdown(defaultMethod)],
+    ['', () => '<button type="submit" disabled>Submit</button>'],
+    ['out', getToyOutputValueContent],
+  ];
+}
 
 function buildToySection(label, buildHTML) {
   return createLabeledSection({ label, valueHTML: buildHTML() });
@@ -903,10 +918,13 @@ function generateToyUISection(post) {
   if (!hasToy(post)) {
     return '';
   }
+  const defaultMethod =
+    post.toy && post.toy.defaultInputMethod
+      ? post.toy.defaultInputMethod
+      : 'text';
+  const sections = getToyUISections(defaultMethod);
   return join(
-    TOY_UI_SECTIONS.map(([label, buildHTML]) =>
-      buildToySection(label, buildHTML)
-    )
+    sections.map(([label, buildHTML]) => buildToySection(label, buildHTML))
   );
 }
 

--- a/test/generator/toyUISections.test.js
+++ b/test/generator/toyUISections.test.js
@@ -25,4 +25,44 @@ describe('TOY_UI_SECTIONS integration', () => {
     expect(html).toContain('<select class="input">');
     expect(html).toContain('<button type="submit" disabled>Submit</button>');
   });
+
+  test('generateBlog selects configured default input method', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'SELDEF',
+          title: 'Select Default',
+          publicationDate: '2024-01-02',
+          content: ['x'],
+          toy: {
+            modulePath: './toys/2024-01-02/example.js',
+            functionName: 'example',
+            defaultInputMethod: 'number',
+          },
+        },
+      ],
+    };
+    const html = generateBlog({ blog, header, footer }, wrapHtml);
+    expect(html).toContain('<option value="number" selected>number</option>');
+  });
+
+  test('generateBlog defaults to text input method', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'NODEFAULT',
+          title: 'No Default',
+          publicationDate: '2024-01-03',
+          content: ['x'],
+          toy: {
+            modulePath: './toys/2024-01-03/example.js',
+            functionName: 'example',
+          },
+        },
+      ],
+    };
+    const html = generateBlog({ blog, header, footer }, wrapHtml);
+    expect(html).toContain('<select class="input">');
+    expect(html).not.toContain('selected');
+  });
 });


### PR DESCRIPTION
## Summary
- support specifying a toy's default input method
- pick text input when no value is provided
- default CreateDendriteStory toy to use the dendrite-story method
- test that default input selection works

## Testing
- `npm install`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68488f2c46a4832e95d0e31c29b6c8f7