### PR TITLE
Trigger default input handler

### DIFF
--- a/public/browser/main.js
+++ b/public/browser/main.js
@@ -125,18 +125,5 @@ const initializeDropdowns = createDropdownInitializer(
 window.addEventListener('DOMContentLoaded', () => {
   initializeDropdowns();
 
-  // Get all dropdowns and add event listeners with the dom parameter
-  const outputDropdowns = Array.from(
-    document.querySelectorAll('article.entry .value > select.output')
-  );
-  outputDropdowns.forEach(
-    createAddDropdownListener(onOutputDropdownChange, dom)
-  );
-
-  const inputDropdowns = Array.from(
-    document.querySelectorAll('article.entry .value > select.input')
-  );
-  inputDropdowns.forEach(createAddDropdownListener(onInputDropdownChange, dom));
-
   revealBetaArticles(dom);
 });

--- a/public/browser/toys.js
+++ b/public/browser/toys.js
@@ -737,44 +737,44 @@ export const createKeyValueRow =
     render,
     container
   ) =>
-    ([key, value], idx) => {
-      const rowEl = dom.createElement('div');
-      dom.setClassName(rowEl, 'kv-row');
+  ([key, value], idx) => {
+    const rowEl = dom.createElement('div');
+    dom.setClassName(rowEl, 'kv-row');
 
-      // Create key and value elements
-      const keyEl = createKeyElement(
-        dom,
-        key,
-        textInput,
-        rows,
-        syncHiddenField,
-        disposers
-      );
-      const valueEl = createValueElement(
-        dom,
-        value,
-        keyEl,
-        textInput,
-        rows,
-        syncHiddenField,
-        disposers
-      );
+    // Create key and value elements
+    const keyEl = createKeyElement(
+      dom,
+      key,
+      textInput,
+      rows,
+      syncHiddenField,
+      disposers
+    );
+    const valueEl = createValueElement(
+      dom,
+      value,
+      keyEl,
+      textInput,
+      rows,
+      syncHiddenField,
+      disposers
+    );
 
-      // Create and set up the appropriate button type
-      const btnEl = createButton(
-        dom,
-        idx === entries.length - 1,
-        rows,
-        render,
-        key,
-        disposers
-      );
+    // Create and set up the appropriate button type
+    const btnEl = createButton(
+      dom,
+      idx === entries.length - 1,
+      rows,
+      render,
+      key,
+      disposers
+    );
 
-      dom.appendChild(rowEl, keyEl);
-      dom.appendChild(rowEl, valueEl);
-      dom.appendChild(rowEl, btnEl);
-      dom.appendChild(container, rowEl);
-    };
+    dom.appendChild(rowEl, keyEl);
+    dom.appendChild(rowEl, valueEl);
+    dom.appendChild(rowEl, btnEl);
+    dom.appendChild(container, rowEl);
+  };
 
 const createButton = (dom, isAddButton, rows, render, key, disposers) => {
   const button = dom.createElement('button');
@@ -1179,13 +1179,19 @@ export const createDropdownInitializer = (
     const outputDropdowns = Array.from(
       dom.querySelectorAll('article.entry .value > select.output')
     );
-    outputDropdowns.forEach(createAddDropdownListener(onOutputChange, dom));
+    outputDropdowns.forEach(dropdown => {
+      onOutputChange({ currentTarget: dropdown });
+      createAddDropdownListener(onOutputChange, dom)(dropdown);
+    });
 
     // Add event listeners to toy input dropdowns
     const inputDropdowns = Array.from(
       dom.querySelectorAll('article.entry .value > select.input')
     );
-    inputDropdowns.forEach(createAddDropdownListener(onInputChange, dom));
+    inputDropdowns.forEach(dropdown => {
+      onInputChange({ currentTarget: dropdown });
+      createAddDropdownListener(onInputChange, dom)(dropdown);
+    });
   };
 };
 

--- a/src/browser/main.js
+++ b/src/browser/main.js
@@ -125,18 +125,5 @@ const initializeDropdowns = createDropdownInitializer(
 window.addEventListener('DOMContentLoaded', () => {
   initializeDropdowns();
 
-  // Get all dropdowns and add event listeners with the dom parameter
-  const outputDropdowns = Array.from(
-    document.querySelectorAll('article.entry .value > select.output')
-  );
-  outputDropdowns.forEach(
-    createAddDropdownListener(onOutputDropdownChange, dom)
-  );
-
-  const inputDropdowns = Array.from(
-    document.querySelectorAll('article.entry .value > select.input')
-  );
-  inputDropdowns.forEach(createAddDropdownListener(onInputDropdownChange, dom));
-
   revealBetaArticles(dom);
 });

--- a/src/browser/toys.js
+++ b/src/browser/toys.js
@@ -737,44 +737,44 @@ export const createKeyValueRow =
     render,
     container
   ) =>
-    ([key, value], idx) => {
-      const rowEl = dom.createElement('div');
-      dom.setClassName(rowEl, 'kv-row');
+  ([key, value], idx) => {
+    const rowEl = dom.createElement('div');
+    dom.setClassName(rowEl, 'kv-row');
 
-      // Create key and value elements
-      const keyEl = createKeyElement(
-        dom,
-        key,
-        textInput,
-        rows,
-        syncHiddenField,
-        disposers
-      );
-      const valueEl = createValueElement(
-        dom,
-        value,
-        keyEl,
-        textInput,
-        rows,
-        syncHiddenField,
-        disposers
-      );
+    // Create key and value elements
+    const keyEl = createKeyElement(
+      dom,
+      key,
+      textInput,
+      rows,
+      syncHiddenField,
+      disposers
+    );
+    const valueEl = createValueElement(
+      dom,
+      value,
+      keyEl,
+      textInput,
+      rows,
+      syncHiddenField,
+      disposers
+    );
 
-      // Create and set up the appropriate button type
-      const btnEl = createButton(
-        dom,
-        idx === entries.length - 1,
-        rows,
-        render,
-        key,
-        disposers
-      );
+    // Create and set up the appropriate button type
+    const btnEl = createButton(
+      dom,
+      idx === entries.length - 1,
+      rows,
+      render,
+      key,
+      disposers
+    );
 
-      dom.appendChild(rowEl, keyEl);
-      dom.appendChild(rowEl, valueEl);
-      dom.appendChild(rowEl, btnEl);
-      dom.appendChild(container, rowEl);
-    };
+    dom.appendChild(rowEl, keyEl);
+    dom.appendChild(rowEl, valueEl);
+    dom.appendChild(rowEl, btnEl);
+    dom.appendChild(container, rowEl);
+  };
 
 const createButton = (dom, isAddButton, rows, render, key, disposers) => {
   const button = dom.createElement('button');
@@ -1179,13 +1179,19 @@ export const createDropdownInitializer = (
     const outputDropdowns = Array.from(
       dom.querySelectorAll('article.entry .value > select.output')
     );
-    outputDropdowns.forEach(createAddDropdownListener(onOutputChange, dom));
+    outputDropdowns.forEach(dropdown => {
+      onOutputChange({ currentTarget: dropdown });
+      createAddDropdownListener(onOutputChange, dom)(dropdown);
+    });
 
     // Add event listeners to toy input dropdowns
     const inputDropdowns = Array.from(
       dom.querySelectorAll('article.entry .value > select.input')
     );
-    inputDropdowns.forEach(createAddDropdownListener(onInputChange, dom));
+    inputDropdowns.forEach(dropdown => {
+      onInputChange({ currentTarget: dropdown });
+      createAddDropdownListener(onInputChange, dom)(dropdown);
+    });
   };
 };
 

--- a/test/browser/toys.createDropdownInitializer.input.test.js
+++ b/test/browser/toys.createDropdownInitializer.input.test.js
@@ -1,0 +1,36 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { createDropdownInitializer } from '../../src/browser/toys.js';
+
+// Verify that initializeDropdowns triggers handlers for preselected dropdowns
+
+describe('createDropdownInitializer input init', () => {
+  it('calls onInputChange for existing dropdown selection', () => {
+    const dropdown = { value: 'dendrite-story' };
+
+    const dom = {
+      querySelectorAll: jest.fn(selector => {
+        if (selector === 'article.entry .value > select.output') {
+          return [];
+        }
+        if (selector === 'article.entry .value > select.input') {
+          return [dropdown];
+        }
+        return [];
+      }),
+      addEventListener: jest.fn(),
+    };
+
+    const onOutputChange = jest.fn();
+    const onInputChange = jest.fn();
+
+    const init = createDropdownInitializer(onOutputChange, onInputChange, dom);
+    init();
+
+    expect(onInputChange).toHaveBeenCalledWith({ currentTarget: dropdown });
+    expect(dom.addEventListener).toHaveBeenCalledWith(
+      dropdown,
+      'change',
+      onInputChange
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- call change handlers for dropdowns on initialization
- remove duplicate listener setup
- add regression test for dropdown initialization

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68489a236488832e816ea1b957fc3e84