### PR TITLE
Add comprehensive tests for input handlers

### DIFF
--- a/src/inputHandlers/kv.js
+++ b/src/inputHandlers/kv.js
@@ -1,6 +1,6 @@
 import { ensureKeyValueInput } from '../browser/toys.js';
 
-function maybeRemoveNumber(container, dom) {
+export function maybeRemoveNumber(container, dom) {
   const numberInput = dom.querySelector(container, 'input[type="number"]');
   if (numberInput && typeof numberInput._dispose === 'function') {
     numberInput._dispose();
@@ -8,7 +8,7 @@ function maybeRemoveNumber(container, dom) {
   }
 }
 
-function maybeRemoveDendrite(container, dom) {
+export function maybeRemoveDendrite(container, dom) {
   const dendriteForm = dom.querySelector(container, '.dendrite-form');
   if (dendriteForm && typeof dendriteForm._dispose === 'function') {
     dendriteForm._dispose();

--- a/test/inputHandlers/defaultHandler.test.js
+++ b/test/inputHandlers/defaultHandler.test.js
@@ -1,0 +1,30 @@
+import { defaultHandler } from '../../src/inputHandlers/default.js';
+import { describe, test, expect, jest } from '@jest/globals';
+
+describe('defaultHandler', () => {
+  test('removes existing elements and ignores missing ones', () => {
+    const container = {};
+    const textInput = {};
+    const number = { _dispose: jest.fn() };
+    const kv = {};
+    const querySelector = jest
+      .fn()
+      .mockReturnValueOnce(number)
+      .mockReturnValueOnce(kv)
+      .mockReturnValueOnce(null);
+    const dom = {
+      hide: jest.fn(),
+      disable: jest.fn(),
+      querySelector,
+      removeChild: jest.fn(),
+    };
+
+    defaultHandler(dom, container, textInput);
+
+    expect(dom.hide).toHaveBeenCalledWith(textInput);
+    expect(dom.disable).toHaveBeenCalledWith(textInput);
+    expect(number._dispose).toHaveBeenCalled();
+    expect(dom.removeChild).toHaveBeenCalledWith(container, number);
+    expect(dom.removeChild).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/inputHandlers/dendriteStoryHandler.test.js
+++ b/test/inputHandlers/dendriteStoryHandler.test.js
@@ -77,8 +77,12 @@ describe('dendriteStoryHandler', () => {
     const numberInput = { _dispose: jest.fn() };
     const kvContainer = { _dispose: jest.fn() };
     const querySelector = jest.fn((container, selector) => {
-      if (selector === 'input[type="number"]') {return numberInput;}
-      if (selector === '.kv-container') {return kvContainer;}
+      if (selector === 'input[type="number"]') {
+        return numberInput;
+      }
+      if (selector === '.kv-container') {
+        return kvContainer;
+      }
       return null;
     });
     const dom = {
@@ -106,4 +110,55 @@ describe('dendriteStoryHandler', () => {
     expect(kvContainer._dispose).toHaveBeenCalled();
     expect(dom.removeChild).toHaveBeenCalledWith({}, kvContainer);
   });
+});
+
+test('removes existing form without dispose method', () => {
+  const existing = {};
+  const dom = {
+    hide: jest.fn(),
+    disable: jest.fn(),
+    querySelector: jest.fn(() => existing),
+    removeChild: jest.fn(),
+    createElement: jest.fn(() => ({})),
+    setClassName: jest.fn(),
+    getNextSibling: jest.fn(() => ({})),
+    insertBefore: jest.fn(),
+    setType: jest.fn(),
+    setPlaceholder: jest.fn(),
+    setTextContent: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    appendChild: jest.fn(),
+    getValue: jest.fn(el => el.value),
+    setValue: jest.fn(),
+  };
+
+  dendriteStoryHandler(dom, {}, {});
+  expect(dom.removeChild).toHaveBeenCalledWith({}, existing);
+});
+
+test('handles invalid JSON input', () => {
+  const textInput = { value: '{invalid}' };
+  const dom = {
+    hide: jest.fn(),
+    disable: jest.fn(),
+    querySelector: jest.fn(() => null),
+    removeChild: jest.fn(),
+    createElement: jest.fn(() => ({})),
+    setClassName: jest.fn(),
+    getNextSibling: jest.fn(() => ({})),
+    insertBefore: jest.fn(),
+    setType: jest.fn(),
+    setPlaceholder: jest.fn(),
+    setTextContent: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    appendChild: jest.fn(),
+    getValue: jest.fn(el => el.value),
+    setValue: jest.fn(),
+  };
+
+  const form = dendriteStoryHandler(dom, {}, textInput);
+  expect(form).toBeDefined();
+  expect(dom.setValue).toHaveBeenCalledWith(textInput, '{}');
 });

--- a/test/inputHandlers/kvHandler.test.js
+++ b/test/inputHandlers/kvHandler.test.js
@@ -1,0 +1,60 @@
+import { describe, test, expect, jest } from '@jest/globals';
+import {
+  kvHandler,
+  handleKVType,
+  maybeRemoveNumber,
+  maybeRemoveDendrite,
+} from '../../src/inputHandlers/kv.js';
+
+// kvHandler relies on ensureKeyValueInput which is complex to mock in ES modules.
+// These tests focus on the removable helper functions to achieve full branch coverage.
+
+describe('kv input handlers', () => {
+  test('maybeRemoveNumber removes existing number input', () => {
+    const numberInput = { _dispose: jest.fn() };
+    const dom = {
+      querySelector: jest.fn(() => numberInput),
+      removeChild: jest.fn(),
+    };
+
+    maybeRemoveNumber({}, dom);
+
+    expect(numberInput._dispose).toHaveBeenCalled();
+    expect(dom.removeChild).toHaveBeenCalledWith({}, numberInput);
+  });
+
+  test('maybeRemoveNumber does nothing when element missing', () => {
+    const dom = {
+      querySelector: jest.fn(() => null),
+      removeChild: jest.fn(),
+    };
+
+    maybeRemoveNumber({}, dom);
+
+    expect(dom.removeChild).not.toHaveBeenCalled();
+  });
+
+  test('maybeRemoveDendrite removes existing form', () => {
+    const dendriteForm = { _dispose: jest.fn() };
+    const dom = {
+      querySelector: jest.fn(() => dendriteForm),
+      removeChild: jest.fn(),
+    };
+
+    maybeRemoveDendrite({}, dom);
+
+    expect(dendriteForm._dispose).toHaveBeenCalled();
+    expect(dom.removeChild).toHaveBeenCalledWith({}, dendriteForm);
+  });
+
+  test('maybeRemoveDendrite does nothing when element missing', () => {
+    const dom = {
+      querySelector: jest.fn(() => null),
+      removeChild: jest.fn(),
+    };
+
+    maybeRemoveDendrite({}, dom);
+
+    expect(dom.removeChild).not.toHaveBeenCalled();
+  });
+});

--- a/test/inputHandlers/numberHandler.test.js
+++ b/test/inputHandlers/numberHandler.test.js
@@ -1,0 +1,57 @@
+import { describe, test, expect, jest } from '@jest/globals';
+import { numberHandler } from '../../src/inputHandlers/number.js';
+
+describe('numberHandler', () => {
+  test('removes kv and dendrite elements and leaves existing number input', () => {
+    const container = {};
+    const textInput = {};
+    const numberInput = {};
+    const kvContainer = { _dispose: jest.fn() };
+    const dendriteForm = { _dispose: jest.fn() };
+    const querySelector = jest.fn((el, selector) => {
+      if (selector === '.kv-container') {return kvContainer;}
+      if (selector === '.dendrite-form') {return dendriteForm;}
+      if (selector === 'input[type="number"]') {return numberInput;}
+      return null;
+    });
+    const removeChild = jest.fn();
+    const dom = {
+      hide: jest.fn(),
+      disable: jest.fn(),
+      querySelector,
+      removeChild,
+      // methods used by ensureNumberInput when number input exists are none
+    };
+
+    numberHandler(dom, container, textInput);
+
+    expect(dom.hide).toHaveBeenCalledWith(textInput);
+    expect(dom.disable).toHaveBeenCalledWith(textInput);
+    expect(kvContainer._dispose).toHaveBeenCalled();
+    expect(dendriteForm._dispose).toHaveBeenCalled();
+    expect(removeChild).toHaveBeenCalledWith(container, kvContainer);
+    expect(removeChild).toHaveBeenCalledWith(container, dendriteForm);
+    expect(querySelector).toHaveBeenCalledWith(
+      container,
+      'input[type="number"]'
+    );
+  });
+
+  test('no elements to remove', () => {
+    const numberInput = {};
+    const querySelector = jest.fn((_, selector) =>
+      selector === 'input[type="number"]' ? numberInput : null
+    );
+    const dom = {
+      hide: jest.fn(),
+      disable: jest.fn(),
+      querySelector,
+      removeChild: jest.fn(),
+    };
+
+    numberHandler(dom, {}, {});
+
+    expect(dom.removeChild).not.toHaveBeenCalled();
+    expect(querySelector).toHaveBeenCalledWith({}, 'input[type="number"]');
+  });
+});

--- a/test/inputHandlers/textHandler.test.js
+++ b/test/inputHandlers/textHandler.test.js
@@ -1,0 +1,48 @@
+import { textHandler } from '../../src/inputHandlers/text.js';
+import { describe, test, expect, jest } from '@jest/globals';
+
+describe('textHandler', () => {
+  test('removes number, kv and dendrite inputs', () => {
+    const container = {};
+    const textInput = {};
+    const numberInput = { _dispose: jest.fn() };
+    const kvContainer = { _dispose: jest.fn() };
+    const dendriteForm = { _dispose: jest.fn() };
+    const querySelector = jest.fn((el, selector) => {
+      if (selector === 'input[type="number"]') {return numberInput;}
+      if (selector === '.kv-container') {return kvContainer;}
+      if (selector === '.dendrite-form') {return dendriteForm;}
+      return null;
+    });
+    const dom = {
+      reveal: jest.fn(),
+      enable: jest.fn(),
+      querySelector,
+      removeChild: jest.fn(),
+    };
+
+    textHandler(dom, container, textInput);
+
+    expect(dom.reveal).toHaveBeenCalledWith(textInput);
+    expect(dom.enable).toHaveBeenCalledWith(textInput);
+    expect(numberInput._dispose).toHaveBeenCalled();
+    expect(kvContainer._dispose).toHaveBeenCalled();
+    expect(dendriteForm._dispose).toHaveBeenCalled();
+    expect(dom.removeChild).toHaveBeenCalledWith(container, numberInput);
+    expect(dom.removeChild).toHaveBeenCalledWith(container, kvContainer);
+    expect(dom.removeChild).toHaveBeenCalledWith(container, dendriteForm);
+  });
+
+  test('does nothing when elements missing', () => {
+    const dom = {
+      reveal: jest.fn(),
+      enable: jest.fn(),
+      querySelector: jest.fn(() => null),
+      removeChild: jest.fn(),
+    };
+
+    textHandler(dom, {}, {});
+
+    expect(dom.removeChild).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- export helper functions from `src/inputHandlers/kv.js` for testing
- add tests for `defaultHandler`, `kv` helpers, `numberHandler`, and `textHandler`
- improve dendrite story handler tests to cover additional branches

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684947ff2e2c832e8a73ad422757968f