### PR TITLE
Add default input methods

### DIFF
--- a/public/blog.json
+++ b/public/blog.json
@@ -138,7 +138,8 @@
       },
       "toy": {
         "modulePath": "/2025-05-08/battleshipSolitaireFleet.js",
-        "functionName": "generateFleet"
+        "functionName": "generateFleet",
+        "defaultInputMethod": "kv"
       },
       "tags": ["toy", "battleship", "puzzle", "generator"]
     },
@@ -181,7 +182,8 @@
       },
       "toy": {
         "modulePath": "/2025-04-06/ticTacToe.js",
-        "functionName": "ticTacToeMove"
+        "functionName": "ticTacToeMove",
+        "defaultInputMethod": "kv"
       },
       "tags": ["toy", "game", "tic-tac-toe"]
     },
@@ -242,7 +244,8 @@
       },
       "toy": {
         "modulePath": "/2025-03-29/setTemporary.js",
-        "functionName": "setTemporary"
+        "functionName": "setTemporary",
+        "defaultInputMethod": "kv"
       },
       "tags": ["toy", "data", "state"]
     },
@@ -312,7 +315,8 @@
       ],
       "toy": {
         "modulePath": "/2025-03-26/prettyFloat.js",
-        "functionName": "decomposeFloat"
+        "functionName": "decomposeFloat",
+        "defaultInputMethod": "number"
       },
       "tags": ["toy", "float", "number"]
     },

--- a/public/index.html
+++ b/public/index.html
@@ -806,7 +806,7 @@
           <select class="input">
             <option value="text">text</option>
             <option value="number">number</option>
-            <option value="kv">kv</option>
+            <option value="kv" selected>kv</option>
             <option value="dendrite-story">dendrite-story</option></select
           ><input type="text" disabled />
         </div>
@@ -966,7 +966,7 @@
           <select class="input">
             <option value="text">text</option>
             <option value="number">number</option>
-            <option value="kv">kv</option>
+            <option value="kv" selected>kv</option>
             <option value="dendrite-story">dendrite-story</option></select
           ><input type="text" disabled />
         </div>
@@ -1196,7 +1196,7 @@
           <select class="input">
             <option value="text">text</option>
             <option value="number">number</option>
-            <option value="kv">kv</option>
+            <option value="kv" selected>kv</option>
             <option value="dendrite-story">dendrite-story</option></select
           ><input type="text" disabled />
         </div>
@@ -1446,7 +1446,7 @@
         <div class="value">
           <select class="input">
             <option value="text">text</option>
-            <option value="number">number</option>
+            <option value="number" selected>number</option>
             <option value="kv">kv</option>
             <option value="dendrite-story">dendrite-story</option></select
           ><input type="text" disabled />

--- a/src/blog.json
+++ b/src/blog.json
@@ -138,7 +138,8 @@
       },
       "toy": {
         "modulePath": "/2025-05-08/battleshipSolitaireFleet.js",
-        "functionName": "generateFleet"
+        "functionName": "generateFleet",
+        "defaultInputMethod": "kv"
       },
       "tags": ["toy", "battleship", "puzzle", "generator"]
     },
@@ -181,7 +182,8 @@
       },
       "toy": {
         "modulePath": "/2025-04-06/ticTacToe.js",
-        "functionName": "ticTacToeMove"
+        "functionName": "ticTacToeMove",
+        "defaultInputMethod": "kv"
       },
       "tags": ["toy", "game", "tic-tac-toe"]
     },
@@ -242,7 +244,8 @@
       },
       "toy": {
         "modulePath": "/2025-03-29/setTemporary.js",
-        "functionName": "setTemporary"
+        "functionName": "setTemporary",
+        "defaultInputMethod": "kv"
       },
       "tags": ["toy", "data", "state"]
     },
@@ -312,7 +315,8 @@
       ],
       "toy": {
         "modulePath": "/2025-03-26/prettyFloat.js",
-        "functionName": "decomposeFloat"
+        "functionName": "decomposeFloat",
+        "defaultInputMethod": "number"
       },
       "tags": ["toy", "float", "number"]
     },


### PR DESCRIPTION
## Summary
- set default input method to `kv` for BATT2, TICT1 and SETT1
- set default input method to `number` for PRET1
- update generated index to reflect defaults

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6849c8760ad4832ea49c3d3c261777c2