### PR TITLE
Improve dropdown tests

### DIFF
--- a/test/generator/toyOutputDropdown.test.js
+++ b/test/generator/toyOutputDropdown.test.js
@@ -53,4 +53,24 @@ describe('toy output dropdown', () => {
     const expected = `<select class="output">${OPTIONS.join('')}</select>`;
     expect(html).toContain(expected);
   });
+
+  test('parsed dropdown options match expected pairs', () => {
+    const html = generateBlog({ blog, header, footer }, wrapHtml);
+    const match = html.match(/<select class="output">([\s\S]*?)<\/select>/);
+    expect(match).not.toBeNull();
+    const optionRegex = /<option value="([^\"]+)">([^<]*)<\/option>/g;
+    const pairs = [];
+    let m;
+    while ((m = optionRegex.exec(match[1])) !== null) {
+      pairs.push([m[1], m[2]]);
+    }
+    const expectedPairs = [
+      ['text', 'text'],
+      ['pre', 'pre'],
+      ['tic-tac-toe', 'tic-tac-toe'],
+      ['battleship-solitaire-fleet', 'battleship-solitaire-fleet'],
+      ['battleship-solitaire-clues-presenter', 'battleship-solitaire-clues-presenter'],
+    ];
+    expect(pairs).toEqual(expectedPairs);
+  });
 });


### PR DESCRIPTION
## Summary
- add detailed parsing test for toy output dropdown

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6849e442e3d8832e885b129eac6131e9