### PR TITLE
Add selector check for dendrite form

### DIFF
--- a/test/inputHandlers/dendriteStoryHandler.test.js
+++ b/test/inputHandlers/dendriteStoryHandler.test.js
@@ -35,6 +35,7 @@ describe('dendriteStoryHandler', () => {
     };
 
     const form = dendriteStoryHandler(dom, container, textInput);
+    expect(dom.querySelector).toHaveBeenCalledWith(container, '.dendrite-form');
     expect(dom.hide).toHaveBeenCalledWith(textInput);
     expect(dom.disable).toHaveBeenCalledWith(textInput);
     expect(dom.createElement).toHaveBeenCalledTimes(19);


### PR DESCRIPTION
## Summary
- increase coverage for `dendriteStoryHandler`
- assert the selector used when locating existing dendrite form

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849e440e604832e80964367d5ca2778