### PR TITLE
Add test for footer warning link

### DIFF
--- a/test/generator/footerWarningMessage.link.test.js
+++ b/test/generator/footerWarningMessage.link.test.js
@@ -1,0 +1,12 @@
+import { describe, test, expect } from '@jest/globals';
+import { generateBlogOuter } from '../../src/generator/generator.js';
+
+describe('footer warning message anchor link', () => {
+  test('includes copyright anchor exactly once', () => {
+    const html = generateBlogOuter({ posts: [] });
+    const anchor =
+      '<a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">CC BY-NC-SA 4.0</a>';
+    const matches = html.match(new RegExp(anchor, 'g')) || [];
+    expect(matches).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure the Creative Commons footer anchor appears exactly once

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6849e440ba2c832e9d2bea25238647b2