### PR TITLE
Add test for dendrite form query selector

### DIFF
--- a/test/inputHandlers/dendriteStoryHandler.test.js
+++ b/test/inputHandlers/dendriteStoryHandler.test.js
@@ -162,3 +162,28 @@ test('handles invalid JSON input', () => {
   expect(form).toBeDefined();
   expect(dom.setValue).toHaveBeenCalledWith(textInput, '{}');
 });
+
+
+test('queries for existing dendrite form using correct selector', () => {
+  const dom = {
+    hide: jest.fn(),
+    disable: jest.fn(),
+    querySelector: jest.fn(() => null),
+    removeChild: jest.fn(),
+    createElement: jest.fn(() => ({})),
+    setClassName: jest.fn(),
+    getNextSibling: jest.fn(() => ({})),
+    insertBefore: jest.fn(),
+    setType: jest.fn(),
+    setPlaceholder: jest.fn(),
+    setTextContent: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    appendChild: jest.fn(),
+    getValue: jest.fn(() => '{}'),
+    setValue: jest.fn(),
+  };
+  const container = {};
+  dendriteStoryHandler(dom, container, {});
+  expect(dom.querySelector).toHaveBeenCalledWith(container, '.dendrite-form');
+});


### PR DESCRIPTION
## Summary
- add regression test ensuring dendriteStoryHandler queries with the correct `.dendrite-form` selector

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6849e43faa40832e89fbf2d9a96b6205