### PR TITLE
Improve coverage for dendriteStoryHandler

### DIFF
--- a/test/inputHandlers/dendriteStoryHandler.test.js
+++ b/test/inputHandlers/dendriteStoryHandler.test.js
@@ -37,6 +37,7 @@ describe('dendriteStoryHandler', () => {
     const form = dendriteStoryHandler(dom, container, textInput);
     expect(dom.hide).toHaveBeenCalledWith(textInput);
     expect(dom.disable).toHaveBeenCalledWith(textInput);
+    expect(dom.querySelector).toHaveBeenCalledWith(container, '.dendrite-form');
     expect(dom.createElement).toHaveBeenCalledTimes(19);
     const firstInput = elements[3];
     expect(firstInput.value).toBe('Existing');


### PR DESCRIPTION
## Summary
- add assertion for form selector to cover querySelector call in dendriteStoryHandler

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6849e43e99f0832e81fd77e1d1a4b735