### PR TITLE
Add function input test

### DIFF
--- a/test/browser/toys.isValidParsedRequest.functionInput.test.js
+++ b/test/browser/toys.isValidParsedRequest.functionInput.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from '@jest/globals';
+import { isValidParsedRequest } from '../../src/browser/toys.js';
+
+describe('isValidParsedRequest additional case', () => {
+  it('returns false for function input', () => {
+    const fn = () => {};
+    expect(isValidParsedRequest(fn)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add additional case for `isValidParsedRequest` to handle function inputs

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6849e441e5d4832e8e6f09f398c51446