### PR TITLE
Add extra media output checks

### DIFF
--- a/test/generator/mediaLabels.test.js
+++ b/test/generator/mediaLabels.test.js
@@ -23,5 +23,10 @@ describe('MEDIA_CONFIG labels', () => {
     expect(html).toContain('<div class="key media">illus</div>');
     expect(html).toContain('<div class="key media">audio</div>');
     expect(html).toContain('<div class="key media">video</div>');
+
+    // Verify media sections render expected HTML elements
+    expect(html).toContain('<img');
+    expect(html).toContain('<audio');
+    expect(html).toContain('<iframe');
   });
 });


### PR DESCRIPTION
## Summary
- extend `mediaLabels` test to verify media output elements

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684a5dd5c2e8832ebcc64fb029f1499d