### PR TITLE
Add null input test for generateClues

### DIFF
--- a/test/toys/2025-05-11/generateClues.nullInput.mutantKill.test.js
+++ b/test/toys/2025-05-11/generateClues.nullInput.mutantKill.test.js
@@ -1,0 +1,8 @@
+import { test, expect } from '@jest/globals';
+import { generateClues } from '../../../src/toys/2025-05-11/battleshipSolitaireClues.js';
+
+test('generateClues handles null input without throwing', () => {
+  const call = () => generateClues('null');
+  expect(call).not.toThrow();
+  expect(call()).toBe('{"error":"Invalid fleet structure"}');
+});


### PR DESCRIPTION
## Summary
- add a regression test ensuring `generateClues` handles `null` JSON input

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684a5dcffc28832e9589298c21faf3ec