### PR TITLE
Add test for observer logging

### DIFF
--- a/test/browser/makeObserverCallback.logInfo.test.js
+++ b/test/browser/makeObserverCallback.logInfo.test.js
@@ -1,0 +1,30 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { makeObserverCallback } from '../../src/browser/toys.js';
+
+describe('makeObserverCallback logging', () => {
+  it('logs module import when entry is intersecting', () => {
+    const dom = {
+      removeAllChildren: jest.fn(),
+      importModule: jest.fn(),
+      disconnectObserver: jest.fn(),
+      isIntersecting: () => true,
+      error: jest.fn(),
+      contains: () => true,
+    };
+    const logInfo = jest.fn();
+    const env = { loggers: { logInfo, logError: jest.fn() } };
+    const moduleInfo = { modulePath: 'mod.js', article: { id: 'art' }, functionName: 'fn' };
+    const observerCallback = makeObserverCallback(moduleInfo, env, dom);
+    const observer = {};
+    const entry = {};
+
+    observerCallback([entry], observer);
+
+    expect(logInfo).toHaveBeenCalledWith(
+      'Starting module import for article',
+      moduleInfo.article.id,
+      'module',
+      moduleInfo.modulePath
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- cover intersection observer logging via `makeObserverCallback`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684a5dca322c832e8bdfb868cd01837d