### PR TITLE
Add additional parsed request validation test

### DIFF
--- a/test/browser/toys.isValidParsedRequest.nullRequest.test.js
+++ b/test/browser/toys.isValidParsedRequest.nullRequest.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from '@jest/globals';
+import { isValidParsedRequest } from '../../src/browser/toys.js';
+
+describe('isValidParsedRequest null request field', () => {
+  it('returns false when request property is null', () => {
+    const parsed = { request: null };
+    expect(isValidParsedRequest(parsed)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add a unit test covering null `request` object handling in `isValidParsedRequest`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684a7c7cde5c832e94eb5af3de9230f3