### PR TITLE
Add test for removing dendrite form

### DIFF
--- a/test/inputHandlers/defaultHandler.test.js
+++ b/test/inputHandlers/defaultHandler.test.js
@@ -27,4 +27,33 @@ describe('defaultHandler', () => {
     expect(dom.removeChild).toHaveBeenCalledWith(container, number);
     expect(dom.removeChild).toHaveBeenCalledTimes(1);
   });
+
+  test('removes an existing dendrite form when present', () => {
+    const container = {};
+    const textInput = {};
+    const number = null;
+    const kv = null;
+    const dendrite = { _dispose: jest.fn() };
+    const querySelector = jest
+      .fn()
+      .mockReturnValueOnce(number)
+      .mockReturnValueOnce(kv)
+      .mockReturnValueOnce(dendrite);
+    const dom = {
+      hide: jest.fn(),
+      disable: jest.fn(),
+      querySelector,
+      removeChild: jest.fn(),
+    };
+
+    defaultHandler(dom, container, textInput);
+
+    expect(querySelector).toHaveBeenNthCalledWith(
+      3,
+      container,
+      '.dendrite-form'
+    );
+    expect(dendrite._dispose).toHaveBeenCalled();
+    expect(dom.removeChild).toHaveBeenCalledWith(container, dendrite);
+  });
 });


### PR DESCRIPTION
## Summary
- add unit test to ensure `defaultHandler` removes a dendrite form if present

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684a7c7be854832ebe9ad12b62155a60