### PR TITLE
Add test for observer logging

### DIFF
--- a/test/browser/makeObserverCallback.logInfo.test.js
+++ b/test/browser/makeObserverCallback.logInfo.test.js
@@ -27,4 +27,29 @@ describe('makeObserverCallback logging', () => {
       moduleInfo.modulePath
     );
   });
+
+  it('logs observer callback message before processing', () => {
+    const dom = {
+      removeAllChildren: jest.fn(),
+      importModule: jest.fn(),
+      disconnectObserver: jest.fn(),
+      isIntersecting: () => true,
+      error: jest.fn(),
+      contains: () => true,
+    };
+    const logInfo = jest.fn();
+    const env = { loggers: { logInfo, logError: jest.fn() } };
+    const moduleInfo = { modulePath: 'mod.js', article: { id: 'art' }, functionName: 'fn' };
+    const observerCallback = makeObserverCallback(moduleInfo, env, dom);
+    const observer = {};
+    const entry = {};
+
+    observerCallback([entry], observer);
+
+    const observerCalls = logInfo.mock.calls.filter(
+      call => call[0] === 'Observer callback for article'
+    );
+    expect(observerCalls.length).toBe(1);
+    expect(observerCalls[0][1]).toBe(moduleInfo.article.id);
+  });
 });


### PR DESCRIPTION
## Summary
- verify that `makeObserverCallback` logs when handling an entry

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684a7c7b1a60832eb844c01bfda3b112