### PR TITLE
Add test for observer callback logging

### DIFF
--- a/test/browser/makeObserverCallback.logInfo.test.js
+++ b/test/browser/makeObserverCallback.logInfo.test.js
@@ -13,7 +13,11 @@ describe('makeObserverCallback logging', () => {
     };
     const logInfo = jest.fn();
     const env = { loggers: { logInfo, logError: jest.fn() } };
-    const moduleInfo = { modulePath: 'mod.js', article: { id: 'art' }, functionName: 'fn' };
+    const moduleInfo = {
+      modulePath: 'mod.js',
+      article: { id: 'art' },
+      functionName: 'fn',
+    };
     const observerCallback = makeObserverCallback(moduleInfo, env, dom);
     const observer = {};
     const entry = {};
@@ -25,6 +29,35 @@ describe('makeObserverCallback logging', () => {
       moduleInfo.article.id,
       'module',
       moduleInfo.modulePath
+    );
+  });
+
+  it('logs observer callback when entry is intersecting', () => {
+    const dom = {
+      removeAllChildren: jest.fn(),
+      importModule: jest.fn(),
+      disconnectObserver: jest.fn(),
+      isIntersecting: () => true,
+      error: jest.fn(),
+      contains: () => true,
+    };
+    const logInfo = jest.fn();
+    const env = { loggers: { logInfo, logError: jest.fn() } };
+    const moduleInfo = {
+      modulePath: 'mod.js',
+      article: { id: 'art' },
+      functionName: 'fn',
+    };
+    const observerCallback = makeObserverCallback(moduleInfo, env, dom);
+    const observer = {};
+    const entry = {};
+
+    observerCallback([entry], observer);
+
+    expect(logInfo).toHaveBeenNthCalledWith(
+      1,
+      'Observer callback for article',
+      moduleInfo.article.id
     );
   });
 });


### PR DESCRIPTION
## Summary
- add a new test ensuring `makeObserverCallback` logs when called

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684a7c7b6ea4832eb15ec932cbf068f1