### PR TITLE
Add createOnRemove repeat call test

### DIFF
--- a/test/browser/toys.createOnRemove.additional.test.js
+++ b/test/browser/toys.createOnRemove.additional.test.js
@@ -25,4 +25,18 @@ describe('createOnRemove additional tests', () => {
   it('createOnRemove expects three arguments', () => {
     expect(createOnRemove.length).toBe(3);
   });
+
+  it('can be called multiple times on the same handler', () => {
+    const rows = { a: '1' };
+    const render = jest.fn();
+    const event = { preventDefault: jest.fn() };
+    const handler = createOnRemove(rows, render, 'a');
+
+    handler(event);
+    handler(event);
+
+    expect(event.preventDefault).toHaveBeenCalledTimes(2);
+    expect(render).toHaveBeenCalledTimes(2);
+    expect(rows).toEqual({});
+  });
 });


### PR DESCRIPTION
## Summary
- add a new test for `createOnRemove` to verify behaviour on repeated calls

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684a7c7a3410832ea73815a6a9f602c4