### PR TITLE
Add test to kill observer callback mutant

### DIFF
--- a/test/browser/makeObserverCallback.logInfo.test.js
+++ b/test/browser/makeObserverCallback.logInfo.test.js
@@ -27,4 +27,31 @@ describe('makeObserverCallback logging', () => {
       moduleInfo.modulePath
     );
   });
+
+  it('logs observer callback for each entry', () => {
+    const dom = {
+      removeAllChildren: jest.fn(),
+      importModule: jest.fn(),
+      disconnectObserver: jest.fn(),
+      isIntersecting: () => true,
+      error: jest.fn(),
+      contains: () => true,
+    };
+    const logInfo = jest.fn();
+    const env = { loggers: { logInfo, logError: jest.fn() } };
+    const moduleInfo = {
+      modulePath: 'mod.js',
+      article: { id: 'art' },
+      functionName: 'fn',
+    };
+    const observerCallback = makeObserverCallback(moduleInfo, env, dom);
+    const observer = {};
+
+    observerCallback([{}, {}], observer);
+
+    const observerLogCalls = logInfo.mock.calls.filter(
+      call => call[0] === 'Observer callback for article'
+    );
+    expect(observerLogCalls).toHaveLength(2);
+  });
 });


### PR DESCRIPTION
## Summary
- add new test verifying `makeObserverCallback` logs a message for each entry

## Testing
- `npm test`
- `npm run lint` *(warnings only)*

------
https://chatgpt.com/codex/tasks/task_e_684a7c76e5a8832e8cae759e77f27172