### PR TITLE
Add coverage for createOnRemove

### DIFF
--- a/test/browser/createOnRemove.mutantKill.test.js
+++ b/test/browser/createOnRemove.mutantKill.test.js
@@ -1,0 +1,20 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { createOnRemove } from '../../src/browser/toys.js';
+
+describe('createOnRemove mutant kill', () => {
+  it('removes key and calls render when invoked', () => {
+    const rows = { a: '1' };
+    const render = jest.fn();
+    const event = { preventDefault: jest.fn() };
+    const handler = createOnRemove(rows, render, 'a');
+
+    expect(typeof handler).toBe('function');
+    expect(handler.length).toBe(1);
+
+    handler(event);
+
+    expect(rows).toEqual({});
+    expect(render).toHaveBeenCalledTimes(1);
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add a focused test for `createOnRemove`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684a7c755000832ea79d2f998f04ee97