### PR TITLE
Improve logInfo coverage

### DIFF
--- a/test/browser/makeObserverCallback.logInfo.test.js
+++ b/test/browser/makeObserverCallback.logInfo.test.js
@@ -13,12 +13,21 @@ describe('makeObserverCallback logging', () => {
     };
     const logInfo = jest.fn();
     const env = { loggers: { logInfo, logError: jest.fn() } };
-    const moduleInfo = { modulePath: 'mod.js', article: { id: 'art' }, functionName: 'fn' };
+    const moduleInfo = {
+      modulePath: 'mod.js',
+      article: { id: 'art' },
+      functionName: 'fn',
+    };
     const observerCallback = makeObserverCallback(moduleInfo, env, dom);
     const observer = {};
     const entry = {};
 
     observerCallback([entry], observer);
+
+    expect(logInfo).toHaveBeenCalledWith(
+      'Observer callback for article',
+      moduleInfo.article.id
+    );
 
     expect(logInfo).toHaveBeenCalledWith(
       'Starting module import for article',


### PR DESCRIPTION
## Summary
- extend makeObserverCallback logging test to verify both log messages

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684a7c74d58c832eb8c7844a027aea81