### PR TITLE
Add logging check for observer callback

### DIFF
--- a/test/browser/makeObserverCallback.logInfo.test.js
+++ b/test/browser/makeObserverCallback.logInfo.test.js
@@ -27,4 +27,34 @@ describe('makeObserverCallback logging', () => {
       moduleInfo.modulePath
     );
   });
+
+  it('logs observer callback before module import', () => {
+    const dom = {
+      removeAllChildren: jest.fn(),
+      importModule: jest.fn(),
+      disconnectObserver: jest.fn(),
+      isIntersecting: () => true,
+      error: jest.fn(),
+      contains: () => true,
+    };
+    const logInfo = jest.fn();
+    const env = { loggers: { logInfo, logError: jest.fn() } };
+    const moduleInfo = { modulePath: 'mod.js', article: { id: 'art' }, functionName: 'fn' };
+    const observerCallback = makeObserverCallback(moduleInfo, env, dom);
+
+    observerCallback([{}], {});
+
+    expect(logInfo).toHaveBeenNthCalledWith(
+      1,
+      'Observer callback for article',
+      moduleInfo.article.id
+    );
+    expect(logInfo).toHaveBeenNthCalledWith(
+      2,
+      'Starting module import for article',
+      moduleInfo.article.id,
+      'module',
+      moduleInfo.modulePath
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- extend `makeObserverCallback.logInfo` tests to verify the first log message

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684a7c73d4ec832ebfc87df67e7d174f