### PR TITLE
Add test for logInfo order

### DIFF
--- a/test/browser/makeObserverCallback.logInfo.order.test.js
+++ b/test/browser/makeObserverCallback.logInfo.order.test.js
@@ -1,0 +1,41 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { makeObserverCallback } from '../../src/browser/toys.js';
+
+describe('makeObserverCallback logging order', () => {
+  it('logs observer callback then module import', () => {
+    const dom = {
+      removeAllChildren: jest.fn(),
+      importModule: jest.fn(),
+      disconnectObserver: jest.fn(),
+      isIntersecting: () => true,
+      error: jest.fn(),
+      contains: () => true,
+    };
+    const logInfo = jest.fn();
+    const env = { loggers: { logInfo, logError: jest.fn() } };
+    const moduleInfo = {
+      modulePath: 'mod.js',
+      article: { id: 'art' },
+      functionName: 'fn',
+    };
+    const observerCallback = makeObserverCallback(moduleInfo, env, dom);
+    const observer = {};
+    const entry = {};
+
+    observerCallback([entry], observer);
+
+    expect(logInfo).toHaveBeenNthCalledWith(
+      1,
+      'Observer callback for article',
+      moduleInfo.article.id
+    );
+    expect(logInfo).toHaveBeenNthCalledWith(
+      2,
+      'Starting module import for article',
+      moduleInfo.article.id,
+      'module',
+      moduleInfo.modulePath
+    );
+    expect(logInfo).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add a test to check that makeObserverCallback logs both before and after importing a module

## Testing
- `npm test --silent`
- `npm run lint --silent`

------
https://chatgpt.com/codex/tasks/task_e_684a7c738290832ea46db58002ed45e9