### PR TITLE
Add test to ensure createOnRemove handler is idempotent

### DIFF
--- a/test/browser/toys.createOnRemove.test.js
+++ b/test/browser/toys.createOnRemove.test.js
@@ -124,4 +124,18 @@ describe('createOnRemove', () => {
     expect(localRows).toEqual({ b: 2 });
     expect(localRender).toHaveBeenCalled();
   });
+
+  it('can be called multiple times safely', () => {
+    const rowsObj = { x: 1 };
+    const renderFn = jest.fn();
+    const evt = { preventDefault: jest.fn() };
+    const handler = createOnRemove(rowsObj, renderFn, 'x');
+
+    handler(evt);
+    handler(evt);
+
+    expect(rowsObj).toEqual({});
+    expect(renderFn).toHaveBeenCalledTimes(2);
+    expect(evt.preventDefault).toHaveBeenCalledTimes(2);
+  });
 });


### PR DESCRIPTION
## Summary
- add a new test covering repeated calls to `createOnRemove`

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684a7c7229a4832e8f7b70f0ac9cfbea