### PR TITLE
Prefix logs with post id

### DIFF
--- a/src/browser/document.js
+++ b/src/browser/document.js
@@ -63,6 +63,28 @@ export const log = (...args) => console.log(...args);
 export const warn = (...args) => console.warn(...args);
 export const logError = (...args) => console.error(...args);
 
+/**
+ * Creates a logging function that prefixes messages with the given prefix.
+ * Returns a no-op function if the base logger is falsy.
+ * @param {Function} logger - The base logging function
+ * @param {string} prefix - The prefix string to prepend
+ * @returns {Function} The prefixed logger function
+ */
+export const createPrefixedLogger = (logger, prefix) =>
+  logger ? (...args) => logger(prefix, ...args) : () => {};
+
+/**
+ * Creates a loggers object with each logger prefixed using the given prefix.
+ * @param {object} loggers - Object containing logInfo, logError, and logWarning
+ * @param {string} prefix - The prefix string to prepend to all log messages
+ * @returns {object} The new loggers object with prefixed functions
+ */
+export const createPrefixedLoggers = (loggers, prefix) => ({
+  logInfo: createPrefixedLogger(loggers.logInfo, prefix),
+  logError: createPrefixedLogger(loggers.logError, prefix),
+  logWarning: createPrefixedLogger(loggers.logWarning, prefix),
+});
+
 // Utility functions
 export const getClasses = el => Array.from(el.classList);
 export const getRandomNumber = () => Math.random();

--- a/src/browser/toys.js
+++ b/src/browser/toys.js
@@ -1,4 +1,5 @@
 import { createParagraphElement } from '../presenters/paragraph.js';
+import { createPrefixedLoggers } from './document.js';
 
 /**
  * Parses the existing rows from the text input
@@ -350,6 +351,10 @@ export function makeModuleConfig(env, dom) {
 
 export function makeObserverCallback(moduleInfo, env, dom) {
   const moduleConfig = makeModuleConfig(env, dom);
+  moduleConfig.loggers = createPrefixedLoggers(
+    moduleConfig.loggers,
+    `[${moduleInfo.article.id}]`
+  );
   const handleEntryFactory = getEntryHandler(moduleInfo, moduleConfig);
   const logInfo =
     moduleConfig.loggers && moduleConfig.loggers.logInfo
@@ -751,44 +756,44 @@ export const createKeyValueRow =
     render,
     container
   ) =>
-    ([key, value], idx) => {
-      const rowEl = dom.createElement('div');
-      dom.setClassName(rowEl, 'kv-row');
+  ([key, value], idx) => {
+    const rowEl = dom.createElement('div');
+    dom.setClassName(rowEl, 'kv-row');
 
-      // Create key and value elements
-      const keyEl = createKeyElement(
-        dom,
-        key,
-        textInput,
-        rows,
-        syncHiddenField,
-        disposers
-      );
-      const valueEl = createValueElement(
-        dom,
-        value,
-        keyEl,
-        textInput,
-        rows,
-        syncHiddenField,
-        disposers
-      );
+    // Create key and value elements
+    const keyEl = createKeyElement(
+      dom,
+      key,
+      textInput,
+      rows,
+      syncHiddenField,
+      disposers
+    );
+    const valueEl = createValueElement(
+      dom,
+      value,
+      keyEl,
+      textInput,
+      rows,
+      syncHiddenField,
+      disposers
+    );
 
-      // Create and set up the appropriate button type
-      const btnEl = createButton(
-        dom,
-        idx === entries.length - 1,
-        rows,
-        render,
-        key,
-        disposers
-      );
+    // Create and set up the appropriate button type
+    const btnEl = createButton(
+      dom,
+      idx === entries.length - 1,
+      rows,
+      render,
+      key,
+      disposers
+    );
 
-      dom.appendChild(rowEl, keyEl);
-      dom.appendChild(rowEl, valueEl);
-      dom.appendChild(rowEl, btnEl);
-      dom.appendChild(container, rowEl);
-    };
+    dom.appendChild(rowEl, keyEl);
+    dom.appendChild(rowEl, valueEl);
+    dom.appendChild(rowEl, btnEl);
+    dom.appendChild(container, rowEl);
+  };
 
 const createButton = (dom, isAddButton, rows, render, key, disposers) => {
   const button = dom.createElement('button');

--- a/test/browser/makeObserverCallback.logInfo.order.test.js
+++ b/test/browser/makeObserverCallback.logInfo.order.test.js
@@ -26,11 +26,13 @@ describe('makeObserverCallback logging order', () => {
 
     expect(logInfo).toHaveBeenNthCalledWith(
       1,
+      `[${moduleInfo.article.id}]`,
       'Observer callback for article',
       moduleInfo.article.id
     );
     expect(logInfo).toHaveBeenNthCalledWith(
       2,
+      `[${moduleInfo.article.id}]`,
       'Starting module import for article',
       moduleInfo.article.id,
       'module',

--- a/test/browser/makeObserverCallback.logInfo.test.js
+++ b/test/browser/makeObserverCallback.logInfo.test.js
@@ -25,11 +25,13 @@ describe('makeObserverCallback logging', () => {
     observerCallback([entry], observer);
 
     expect(logInfo).toHaveBeenCalledWith(
+      `[${moduleInfo.article.id}]`,
       'Observer callback for article',
       moduleInfo.article.id
     );
 
     expect(logInfo).toHaveBeenCalledWith(
+      `[${moduleInfo.article.id}]`,
       'Starting module import for article',
       moduleInfo.article.id,
       'module',
@@ -61,6 +63,7 @@ describe('makeObserverCallback logging', () => {
 
     expect(logInfo).toHaveBeenNthCalledWith(
       1,
+      `[${moduleInfo.article.id}]`,
       'Observer callback for article',
       moduleInfo.article.id
     );

--- a/test/browser/makeObserverCallback.observerLog.test.js
+++ b/test/browser/makeObserverCallback.observerLog.test.js
@@ -23,6 +23,7 @@ describe('makeObserverCallback observer log', () => {
     const entry = {};
     observerCallback([entry], observer);
     expect(logInfo).toHaveBeenCalledWith(
+      `[${moduleInfo.article.id}]`,
       'Observer callback for article',
       moduleInfo.article.id
     );

--- a/test/browser/makeObserverCallback.observerMessage.test.js
+++ b/test/browser/makeObserverCallback.observerMessage.test.js
@@ -25,8 +25,9 @@ describe('makeObserverCallback observer message', () => {
     observerCallback([entry], observer);
 
     expect(logInfo).toHaveBeenCalledWith(
+      `[${moduleInfo.article.id}]`,
       'Observer callback for article',
-      moduleInfo.article.id,
+      moduleInfo.article.id
     );
   });
 });

--- a/test/browser/toys.initializeInteractiveComponent.logInfo.test.js
+++ b/test/browser/toys.initializeInteractiveComponent.logInfo.test.js
@@ -7,10 +7,18 @@ describe('initializeInteractiveComponent', () => {
     const submitButton = {};
     const outputParent = {};
     const querySelector = jest.fn((_, selector) => {
-      if (selector === 'input') {return inputElement;}
-      if (selector === 'button') {return submitButton;}
-      if (selector === 'div.output') {return outputParent;}
-      if (selector === 'select.output') {return {};}
+      if (selector === 'input') {
+        return inputElement;
+      }
+      if (selector === 'button') {
+        return submitButton;
+      }
+      if (selector === 'div.output') {
+        return outputParent;
+      }
+      if (selector === 'select.output') {
+        return {};
+      }
       return {};
     });
     const dom = {
@@ -47,9 +55,11 @@ describe('initializeInteractiveComponent', () => {
 
     const { logInfo } = config.loggers;
     const initCalls = logInfo.mock.calls.filter(
-      call => call[0] === 'Initializing interactive component for article'
+      call =>
+        call[0] === `[${article.id}]` &&
+        call[1] === 'Initializing interactive component for article'
     );
     expect(initCalls.length).toBe(1);
-    expect(initCalls[0][1]).toBe(article.id);
+    expect(initCalls[0][2]).toBe(article.id);
   });
 });

--- a/test/browser/toys.test.js
+++ b/test/browser/toys.test.js
@@ -509,7 +509,11 @@ describe('toys', () => {
       };
       const logInfo = jest.fn();
       const env = { loggers: { logInfo, logError: jest.fn() } };
-      const moduleInfo = { modulePath, article: { id: 'art' }, functionName: 'fn' };
+      const moduleInfo = {
+        modulePath,
+        article: { id: 'art' },
+        functionName: 'fn',
+      };
       const callback = makeObserverCallback(moduleInfo, env, dom);
       const obs = {};
       const ent = {};
@@ -517,6 +521,7 @@ describe('toys', () => {
       callback([ent], obs);
 
       expect(logInfo).toHaveBeenCalledWith(
+        `[${moduleInfo.article.id}]`,
         'Starting module import for article',
         moduleInfo.article.id,
         'module',
@@ -1245,7 +1250,6 @@ describe('toys', () => {
       expect(querySelector).toHaveBeenCalledWith(article, 'select.output');
     });
 
-
     it('sets initialising message using setTextContent', () => {
       const createEnvFn = () => ({});
       const errorFn = jest.fn();
@@ -1700,7 +1704,6 @@ describe('createInputDropdownHandler', () => {
       expect(hide).toHaveBeenCalledWith(textInput);
       expect(disable).toHaveBeenCalledWith(textInput);
     });
-
   });
 
   describe('getText', () => {


### PR DESCRIPTION
## Summary
- add helper to create prefixed loggers
- prefix toy logs with the post id
- update tests for new log format

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot find module '/workspace/dadeto/node_modules/.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_6849e3f9884c832e915e46303975dc0c