### PR TITLE
Add test for createOutputDropdownHandler string output

### DIFF
--- a/test/browser/createOutputDropdownHandler.toString.test.js
+++ b/test/browser/createOutputDropdownHandler.toString.test.js
@@ -1,0 +1,10 @@
+import { test, expect, jest } from '@jest/globals';
+import { createOutputDropdownHandler } from '../../src/browser/toys.js';
+
+test('createOutputDropdownHandler string contains expected implementation details', () => {
+  const handler = createOutputDropdownHandler(jest.fn(), jest.fn(), {});
+  const fnString = handler.toString();
+  expect(fnString.startsWith('event =>')).toBe(true);
+  expect(fnString).toContain('handleDropdownChange(event.currentTarget, getData, dom)');
+  expect(handler.length).toBe(1);
+});


### PR DESCRIPTION
## Summary
- add a test that inspects the returned handler string from `createOutputDropdownHandler`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684af4395560832e9fce849c0bc61c29