### PR TITLE
Add test for dendrite form creation

### DIFF
--- a/test/inputHandlers/dendriteStoryHandler.test.js
+++ b/test/inputHandlers/dendriteStoryHandler.test.js
@@ -35,6 +35,7 @@ describe('dendriteStoryHandler', () => {
     };
 
     const form = dendriteStoryHandler(dom, container, textInput);
+    expect(dom.createElement.mock.calls[0][0]).toBe('div');
     expect(dom.querySelector).toHaveBeenCalledWith(container, '.dendrite-form');
     expect(dom.hide).toHaveBeenCalledWith(textInput);
     expect(dom.disable).toHaveBeenCalledWith(textInput);


### PR DESCRIPTION
## Summary
- assert that dendrite story handler creates a div element for the form

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684af43a2588832e8ac59bb5f86dc4d3