### PR TITLE
Add coverage for missing logInfo

### DIFF
--- a/test/browser/makeObserverCallback.noLogInfo.test.js
+++ b/test/browser/makeObserverCallback.noLogInfo.test.js
@@ -1,0 +1,23 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { makeObserverCallback } from '../../src/browser/toys.js';
+
+describe('makeObserverCallback without logInfo', () => {
+  it('handles missing logInfo without throwing', () => {
+    const dom = {
+      removeAllChildren: jest.fn(),
+      importModule: jest.fn(),
+      disconnectObserver: jest.fn(),
+      isIntersecting: () => true,
+      error: jest.fn(),
+      contains: () => true,
+    };
+    const env = { loggers: { logError: jest.fn() } };
+    const moduleInfo = { modulePath: 'mod.js', article: { id: 'art' }, functionName: 'fn' };
+    const callback = makeObserverCallback(moduleInfo, env, dom);
+    const observer = {};
+    const entry = {};
+    expect(() => callback([entry], observer)).not.toThrow();
+    expect(dom.importModule).toHaveBeenCalledWith('mod.js', expect.any(Function), expect.any(Function));
+    expect(dom.disconnectObserver).toHaveBeenCalledWith(observer);
+  });
+});


### PR DESCRIPTION
## Summary
- add a test for `makeObserverCallback` when `logInfo` is absent to prevent surviving mutants

## Testing
- `npm test --silent`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684af438d754832eb07230c8e13a81e8