### PR TITLE
Add test for null input in generateClues

### DIFF
--- a/test/toys/2025-05-11/generateClues.nullValue.mutantKill.test.js
+++ b/test/toys/2025-05-11/generateClues.nullValue.mutantKill.test.js
@@ -1,0 +1,8 @@
+import { test, expect } from '@jest/globals';
+import { generateClues } from '../../../src/toys/2025-05-11/battleshipSolitaireClues.js';
+
+test('generateClues handles null value input', () => {
+  const call = () => generateClues(null);
+  expect(call).not.toThrow();
+  expect(call()).toBe('{"error":"Invalid fleet structure"}');
+});


### PR DESCRIPTION
## Summary
- add a regression test for `generateClues` handling a `null` value input

## Testing
- `npm test`
- `npm run lint` *(produces warnings)*

------
https://chatgpt.com/codex/tasks/task_e_684af437bd2c832ea291c1cda722ecc0