### PR TITLE
Add audio-only media section test

### DIFF
--- a/test/generator/mediaDisplayRules.test.js
+++ b/test/generator/mediaDisplayRules.test.js
@@ -34,4 +34,21 @@ describe('MEDIA_DISPLAY_RULES integration', () => {
     // Ensure media sections include the correct key class
     expect(html).toContain('class="key media"');
   });
+
+  test('generateBlog includes only audio section when post has only audio', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'AUDIO1',
+          title: 'Audio Only',
+          publicationDate: '2024-06-01',
+          audio: { fileType: 'mp3' },
+        },
+      ],
+    };
+    const html = generateBlog({ blog, header, footer }, wrapHtml);
+    expect(html).toContain('<audio');
+    expect(html).not.toContain('<img');
+    expect(html).not.toContain('<iframe');
+  });
 });


### PR DESCRIPTION
## Summary
- cover audio-only posts to ensure media section generation

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684af4380210832e936dbb80dd08fba4