### PR TITLE
Add missing assertion for dendriteStoryHandler

### DIFF
--- a/test/inputHandlers/dendriteStoryHandler.test.js
+++ b/test/inputHandlers/dendriteStoryHandler.test.js
@@ -40,6 +40,8 @@ describe('dendriteStoryHandler', () => {
     expect(dom.disable).toHaveBeenCalledWith(textInput);
     expect(dom.querySelector).toHaveBeenCalledWith(container, '.dendrite-form');
     expect(dom.createElement).toHaveBeenCalledTimes(19);
+    const [firstCallTag] = dom.createElement.mock.calls[0];
+    expect(firstCallTag).toBe('div');
     const textareaCalls = dom.createElement.mock.calls.filter(
       ([tag]) => tag === 'textarea'
     ).length;


### PR DESCRIPTION
## Summary
- extend dendriteStoryHandler test to verify form element tag

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684af4373d40832e9629f055c7d20f1f