### PR TITLE
Add test to kill surviving Stryker mutant

### DIFF
--- a/test/browser/makeObserverCallback.loggersMissing.test.js
+++ b/test/browser/makeObserverCallback.loggersMissing.test.js
@@ -1,0 +1,30 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { makeObserverCallback } from '../../src/browser/toys.js';
+
+describe('makeObserverCallback without loggers', () => {
+  it('handles loggers object without logInfo', () => {
+    const dom = {
+      removeAllChildren: jest.fn(),
+      importModule: jest.fn(),
+      disconnectObserver: jest.fn(),
+      isIntersecting: () => true,
+      error: jest.fn(),
+      contains: () => true,
+    };
+    const env = { loggers: {} };
+    const moduleInfo = {
+      modulePath: 'mod.js',
+      article: { id: 'art' },
+      functionName: 'fn',
+    };
+    const cb = makeObserverCallback(moduleInfo, env, dom);
+    const observer = {};
+    const entry = {};
+    expect(() => cb([entry], observer)).not.toThrow();
+    expect(dom.importModule).toHaveBeenCalledWith(
+      moduleInfo.modulePath,
+      expect.any(Function),
+      expect.any(Function)
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add a test ensuring `makeObserverCallback` works when `loggers.logInfo` is missing

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684af4353398832e8938c3da1c4e9d96