### PR TITLE
Add test for makeObserverCallback without loggers

### DIFF
--- a/test/browser/makeObserverCallback.logInfo.test.js
+++ b/test/browser/makeObserverCallback.logInfo.test.js
@@ -68,4 +68,32 @@ describe('makeObserverCallback logging', () => {
       moduleInfo.article.id
     );
   });
+
+  it('handles missing loggers without throwing', () => {
+    const dom = {
+      removeAllChildren: jest.fn(),
+      importModule: jest.fn(),
+      disconnectObserver: jest.fn(),
+      isIntersecting: () => true,
+      error: jest.fn(),
+      contains: () => true,
+    };
+    const env = { loggers: {} }; // loggers without logInfo
+    const moduleInfo = {
+      modulePath: 'mod.js',
+      article: { id: 'art' },
+      functionName: 'fn',
+    };
+    const observerCallback = makeObserverCallback(moduleInfo, env, dom);
+    const observer = {};
+    const entry = {};
+
+    expect(() => observerCallback([entry], observer)).not.toThrow();
+    expect(dom.importModule).toHaveBeenCalledWith(
+      moduleInfo.modulePath,
+      expect.any(Function),
+      expect.any(Function)
+    );
+    expect(dom.disconnectObserver).toHaveBeenCalledWith(observer);
+  });
 });


### PR DESCRIPTION
## Summary
- extend `makeObserverCallback.logInfo.test.js` to ensure the observer callback runs without loggers

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684af4362d88832eae3ae1a7774cbb60