### PR TITLE
Add test for makeObserverCallback without logInfo

### DIFF
--- a/test/browser/makeObserverCallback.logInfo.undefined.test.js
+++ b/test/browser/makeObserverCallback.logInfo.undefined.test.js
@@ -1,0 +1,25 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { makeObserverCallback } from '../../src/browser/toys.js';
+
+describe('makeObserverCallback missing logInfo', () => {
+  it('handles absence of logInfo without throwing', () => {
+    const dom = {
+      removeAllChildren: jest.fn(),
+      importModule: jest.fn(),
+      disconnectObserver: jest.fn(),
+      isIntersecting: () => true,
+      error: jest.fn(),
+      contains: () => true,
+    };
+    const env = { loggers: {} };
+    const moduleInfo = {
+      modulePath: 'mod.js',
+      article: { id: 'art' },
+      functionName: 'fn',
+    };
+    const observerCallback = makeObserverCallback(moduleInfo, env, dom);
+    const observer = {};
+    const entry = {};
+    expect(() => observerCallback([entry], observer)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- add regression test for makeObserverCallback when loggers.logInfo is missing

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684af4350d34832ebf534da91c6128f3