### PR TITLE
Add media sections test

### DIFF
--- a/test/generator/mediaSections.mutantKill.test.js
+++ b/test/generator/mediaSections.mutantKill.test.js
@@ -1,0 +1,27 @@
+import { describe, test, expect } from '@jest/globals';
+import { generateBlog } from '../../src/generator/generator.js';
+
+const header = '<body>';
+const footer = '</body>';
+const wrapHtml = c => c;
+
+describe('MEDIA_SECTIONS mapping', () => {
+  test('generateBlog includes sections for all media types', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'MEDIA1',
+          title: 'Media Example',
+          publicationDate: '2024-01-01',
+          illustration: { fileType: 'png', altText: 'image' },
+          audio: { fileType: 'mp3' },
+          youtube: { id: 'id', timestamp: 0, title: 'video' },
+        },
+      ],
+    };
+    const html = generateBlog({ blog, header, footer }, wrapHtml);
+    expect(html).toContain('<div class="key media">illus</div>');
+    expect(html).toContain('<div class="key media">audio</div>');
+    expect(html).toContain('<div class="key media">video</div>');
+  });
+});


### PR DESCRIPTION
## Summary
- add a regression test ensuring media sections render for all types

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684af43488f8832e8a499e6b1ca5fdb7