### PR TITLE
Add isolated test for BLOG_STATUS constant

### DIFF
--- a/test/browser/blogStatus.objectLiteral.isolated.test.js
+++ b/test/browser/blogStatus.objectLiteral.isolated.test.js
@@ -1,0 +1,44 @@
+import { describe, it, expect, jest } from '@jest/globals';
+
+describe('BLOG_STATUS isolated import', () => {
+  it('exposes correct values via functions', async () => {
+    await jest.isolateModulesAsync(async () => {
+      const {
+        fetchAndCacheBlogData,
+        shouldUseExistingFetch,
+        shouldCopyStateForFetch,
+      } = await import('../../src/browser/data.js');
+
+      const state = {
+        blog: null,
+        blogStatus: 'idle',
+        blogError: null,
+        blogFetchPromise: null,
+      };
+      const fetchFn = jest.fn(() =>
+        Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+      );
+      const loggers = {
+        logInfo: jest.fn(),
+        logError: jest.fn(),
+        logWarning: jest.fn(),
+      };
+
+      expect(shouldCopyStateForFetch('idle')).toBe(true);
+      expect(shouldCopyStateForFetch('error')).toBe(true);
+      expect(shouldCopyStateForFetch('loading')).toBe(false);
+      expect(shouldCopyStateForFetch('loaded')).toBe(false);
+
+      const promise = fetchAndCacheBlogData(state, fetchFn, loggers);
+      expect(state.blogStatus).toBe('loading');
+      await promise;
+      expect(state.blogStatus).toBe('loaded');
+
+      const existingState = {
+        blogStatus: 'loading',
+        blogFetchPromise: Promise.resolve(),
+      };
+      expect(shouldUseExistingFetch(existingState, jest.fn())).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a new isolated test to import `data.js` within the test
- ensure BLOG_STATUS constant is validated at runtime and covered by Stryker

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684af433e29c832e9cd79ee52ab3c33d