### PR TITLE
Add test for makeObserverCallback loggers fallback

### DIFF
--- a/test/browser/makeObserverCallback.noLogger.test.js
+++ b/test/browser/makeObserverCallback.noLogger.test.js
@@ -1,0 +1,31 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { makeObserverCallback } from '../../src/browser/toys.js';
+
+describe('makeObserverCallback logInfo fallback', () => {
+  it('uses noop when logInfo is missing', () => {
+    const dom = {
+      removeAllChildren: jest.fn(),
+      importModule: jest.fn(),
+      disconnectObserver: jest.fn(),
+      isIntersecting: () => true,
+      error: jest.fn(),
+      contains: () => true,
+    };
+    const env = { loggers: { logError: jest.fn(), logWarning: jest.fn() } };
+    const moduleInfo = {
+      modulePath: 'mod.js',
+      article: { id: 'art2' },
+      functionName: 'fn',
+    };
+    const observerCallback = makeObserverCallback(moduleInfo, env, dom);
+    const observer = {};
+    const entry = {};
+    expect(() => observerCallback([entry], observer)).not.toThrow();
+    expect(dom.importModule).toHaveBeenCalledWith(
+      moduleInfo.modulePath,
+      expect.any(Function),
+      expect.any(Function)
+    );
+    expect(dom.disconnectObserver).toHaveBeenCalledWith(observer);
+  });
+});


### PR DESCRIPTION
## Summary
- extend `makeObserverCallback` tests to cover missing `logInfo`

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684af4338b74832ebb3c528fd143f640