### PR TITLE
Add regex capture tests

### DIFF
--- a/test/utils/regexUtils.test.js
+++ b/test/utils/regexUtils.test.js
@@ -33,6 +33,12 @@ describe('createPattern', () => {
     expect('*TEST*'.match(pattern)?.[0]).toBe('*TEST*');
   });
 
+  test('captures content between markers', () => {
+    const pattern = createPattern('*');
+    const match = pattern.exec('*hello*');
+    expect(match?.[1]).toBe('hello');
+  });
+
   test('handles special characters in the marker', () => {
     const pattern = createPattern('*+?');
     expect('*+?test*+?'.match(pattern)?.[0]).toBe('*+?test*+?');
@@ -42,6 +48,12 @@ describe('createPattern', () => {
     const pattern = createPattern('*', { isDouble: true });
     expect('**test**'.match(pattern)?.[0]).toBe('**test**');
     expect('*test*'.match(pattern)).toBeNull();
+  });
+
+  test('captures content between double markers', () => {
+    const pattern = createPattern('*', { isDouble: true });
+    const match = pattern.exec('**value**');
+    expect(match?.[1]).toBe('value');
   });
 });
 


### PR DESCRIPTION
## Summary
- extend `regexUtils` tests to verify captured content

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684af432b41c832eb2470c88f7f8caf0