### PR TITLE
Add test for missing key in createOnRemove

### DIFF
--- a/test/browser/toys.createOnRemove.additional.test.js
+++ b/test/browser/toys.createOnRemove.additional.test.js
@@ -39,4 +39,17 @@ describe('createOnRemove additional tests', () => {
     expect(render).toHaveBeenCalledTimes(2);
     expect(rows).toEqual({});
   });
+
+  it('handles missing key without error', () => {
+    const rows = { a: '1' };
+    const render = jest.fn();
+    const event = { preventDefault: jest.fn() };
+    const handler = createOnRemove(rows, render, 'b');
+
+    handler(event);
+
+    expect(rows).toEqual({ a: '1' });
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(render).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
## Summary
- extend `createOnRemove` tests to cover the case where the key does not exist

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684af4326584832e875017cf30a9a4e5