### PR TITLE
Add missing dendrite form element test

### DIFF
--- a/test/inputHandlers/dendriteStoryHandler.formElement.test.js
+++ b/test/inputHandlers/dendriteStoryHandler.formElement.test.js
@@ -1,0 +1,33 @@
+import { dendriteStoryHandler } from '../../src/inputHandlers/dendriteStory.js';
+import { describe, test, expect, jest } from '@jest/globals';
+
+describe('dendriteStoryHandler form element', () => {
+  test('creates form container using a div element', () => {
+    const dom = {
+      hide: jest.fn(),
+      disable: jest.fn(),
+      querySelector: jest.fn(() => null),
+      removeChild: jest.fn(),
+      createElement: jest.fn(() => ({})),
+      setClassName: jest.fn(),
+      getNextSibling: jest.fn(() => ({})),
+      insertBefore: jest.fn(),
+      setType: jest.fn(),
+      setPlaceholder: jest.fn(),
+      setTextContent: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      appendChild: jest.fn(),
+      getValue: jest.fn(() => '{}'),
+      setValue: jest.fn(),
+    };
+    const container = {};
+    const textInput = { value: '{}' };
+
+    dendriteStoryHandler(dom, container, textInput);
+
+    expect(dom.createElement).toHaveBeenCalled();
+    const firstCall = dom.createElement.mock.calls[0][0];
+    expect(firstCall).toBe('div');
+  });
+});


### PR DESCRIPTION
## Summary
- add a test checking the dendrite form uses a `div` element

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684af43a1920832ebf7b28e4d907f5e6