### PR TITLE
Add test for logging when initializing components

### DIFF
--- a/test/browser/initializeInteractiveComponent.logInfo.test.js
+++ b/test/browser/initializeInteractiveComponent.logInfo.test.js
@@ -1,0 +1,69 @@
+import { describe, it, expect, jest } from '@jest/globals';
+
+// Dynamically import the module to ensure Stryker tracks coverage correctly
+
+describe('initializeInteractiveComponent logging', () => {
+  it('logs the input and button elements when found', async () => {
+    const { initializeInteractiveComponent } = await import(
+      '../../src/browser/toys.js'
+    );
+
+    const inputElement = {};
+    const submitButton = {};
+    const outputParent = {};
+    const outputSelect = {};
+    const logInfo = jest.fn();
+
+    const querySelector = jest.fn((_, selector) => {
+      switch (selector) {
+      case 'input[type="text"]':
+        return inputElement;
+      case 'button[type="submit"]':
+        return submitButton;
+      case 'div.output':
+        return outputParent;
+      case 'select.output':
+        return outputSelect;
+      default:
+        return {};
+      }
+    });
+
+    const dom = {
+      removeAllChildren: jest.fn(),
+      createElement: jest.fn(() => ({ textContent: '' })),
+      setTextContent: jest.fn(),
+      stopDefault: jest.fn(),
+      addWarning: jest.fn(),
+      addWarningFn: jest.fn(),
+      addEventListener: jest.fn(),
+      removeChild: jest.fn(),
+      appendChild: jest.fn(),
+      querySelector,
+      removeWarning: jest.fn(),
+      enable: jest.fn(),
+      contains: () => true,
+    };
+
+    const config = {
+      globalState: {},
+      createEnvFn: () => ({}),
+      errorFn: jest.fn(),
+      fetchFn: jest.fn(),
+      dom,
+      loggers: {
+        logInfo,
+        logError: jest.fn(),
+        logWarning: jest.fn(),
+      },
+    };
+
+    const article = { id: 'post' };
+    const processingFunction = jest.fn();
+
+    initializeInteractiveComponent(article, processingFunction, config);
+
+    expect(logInfo).toHaveBeenCalledWith('Found input element:', inputElement);
+    expect(logInfo).toHaveBeenCalledWith('Found button element:', submitButton);
+  });
+});


### PR DESCRIPTION
## Summary
- add test verifying `initializeInteractiveComponent` logs discovered input and button elements

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684af432bd60832ea4b48e5a9813e5a7