### PR TITLE
Remove duplicate markdown tests

### DIFF
--- a/test/constants/markdown.mutant.test.js
+++ b/test/constants/markdown.mutant.test.js
@@ -121,46 +121,4 @@ describe('markdown constants mutants', () => {
     }).toThrow();
   });
 
-  test('MARKDOWN_MARKERS object has expected values', () => {
-    const MARKDOWN_MARKERS = markdownMarkers();
-    expect(MARKDOWN_MARKERS).toEqual({
-      ASTERISK: '*',
-      UNDERSCORE: '_',
-      BACKTICK: '`',
-      TILDE: '~',
-      DASH: '-',
-      EQUAL: '=',
-      HASH: '#',
-      GREATER_THAN: '>',
-      PIPE: '|',
-      BACKSLASH: '\\',
-      SLASH: '/',
-      EXCLAMATION: '!',
-      BRACKET_OPEN: '[',
-      BRACKET_CLOSE: ']',
-      PAREN_OPEN: '(',
-      PAREN_CLOSE: ')',
-    });
-  });
-
-  test('HTML_TAGS object has expected values', () => {
-    const HTML_TAGS = htmlTags();
-    expect(HTML_TAGS).toEqual({
-      EMPHASIS: 'em',
-      STRONG: 'strong',
-      CODE: 'code',
-      PARAGRAPH: 'p',
-      BLOCKQUOTE: 'blockquote',
-      LIST: 'ul',
-      LIST_ITEM: 'li',
-      ORDERED_LIST: 'ol',
-      HORIZONTAL_RULE: 'hr',
-      LINE_BREAK: 'br',
-      LINK: 'a',
-      IMAGE: 'img',
-      DIV: 'div',
-      SPAN: 'span',
-      PRE: 'pre',
-    });
-  });
 });


### PR DESCRIPTION
## Summary
- revert earlier removal commit
- remove duplicate constant value tests from `markdown.mutant.test.js`

## Testing
- `npm test`
- `npm run lint` *(warnings only)*

------
https://chatgpt.com/codex/tasks/task_e_684b34601928832e8cbe54d63645877d