### PR TITLE
Remove duplicate constant tests

### DIFF
--- a/test/constants/markdown.mutant.test.js
+++ b/test/constants/markdown.mutant.test.js
@@ -9,87 +9,97 @@ import {
 // Additional coverage to kill Stryker mutants around CSS_CLASSES values
 
 describe('markdown constants mutants', () => {
-  test('CSS_CLASSES object has expected values', () => {
-    const CSS_CLASSES = cssClasses();
-    expect(CSS_CLASSES).toEqual({
-      CONTAINER: 'markdown-container',
-      HEADING: 'markdown-heading',
-      PARAGRAPH: 'markdown-paragraph',
-      LIST: 'markdown-list',
-      LIST_ITEM: 'markdown-list-item',
-      BLOCKQUOTE: 'markdown-blockquote',
-      CODE: 'markdown-code',
-      INLINE_CODE: 'markdown-inline-code',
-      LINK: 'markdown-link',
-      IMAGE: 'markdown-image',
-      HORIZONTAL_RULE: 'markdown-hr',
-    });
-  });
+  const constantTests = [
+    [
+      'CSS_CLASSES',
+      cssClasses,
+      {
+        CONTAINER: 'markdown-container',
+        HEADING: 'markdown-heading',
+        PARAGRAPH: 'markdown-paragraph',
+        LIST: 'markdown-list',
+        LIST_ITEM: 'markdown-list-item',
+        BLOCKQUOTE: 'markdown-blockquote',
+        CODE: 'markdown-code',
+        INLINE_CODE: 'markdown-inline-code',
+        LINK: 'markdown-link',
+        IMAGE: 'markdown-image',
+        HORIZONTAL_RULE: 'markdown-hr',
+      },
+    ],
+    [
+      'MARKDOWN_MARKERS',
+      markdownMarkers,
+      {
+        ASTERISK: '*',
+        UNDERSCORE: '_',
+        BACKTICK: '`',
+        TILDE: '~',
+        DASH: '-',
+        EQUAL: '=',
+        HASH: '#',
+        GREATER_THAN: '>',
+        PIPE: '|',
+        BACKSLASH: '\\',
+        SLASH: '/',
+        EXCLAMATION: '!',
+        BRACKET_OPEN: '[',
+        BRACKET_CLOSE: ']',
+        PAREN_OPEN: '(',
+        PAREN_CLOSE: ')',
+      },
+    ],
+    [
+      'HTML_TAGS',
+      htmlTags,
+      {
+        EMPHASIS: 'em',
+        STRONG: 'strong',
+        CODE: 'code',
+        PARAGRAPH: 'p',
+        BLOCKQUOTE: 'blockquote',
+        LIST: 'ul',
+        LIST_ITEM: 'li',
+        ORDERED_LIST: 'ol',
+        HORIZONTAL_RULE: 'hr',
+        LINE_BREAK: 'br',
+        LINK: 'a',
+        IMAGE: 'img',
+        DIV: 'div',
+        SPAN: 'span',
+        PRE: 'pre',
+      },
+    ],
+    [
+      'DEFAULT_OPTIONS',
+      defaultOptions,
+      {
+        gfm: true,
+        tables: true,
+        breaks: false,
+        pedantic: false,
+        sanitize: false,
+        smartLists: true,
+        smartypants: false,
+        xhtml: false,
+        highlight: null,
+        langPrefix: 'language-',
+        headerIds: true,
+        headerPrefix: '',
+        mangle: true,
+        baseUrl: null,
+        linkTarget: null,
+        renderer: null,
+      },
+    ],
+  ];
 
-  test('MARKDOWN_MARKERS object has expected values', () => {
-    const MARKDOWN_MARKERS = markdownMarkers();
-    expect(MARKDOWN_MARKERS).toEqual({
-      ASTERISK: '*',
-      UNDERSCORE: '_',
-      BACKTICK: '`',
-      TILDE: '~',
-      DASH: '-',
-      EQUAL: '=',
-      HASH: '#',
-      GREATER_THAN: '>',
-      PIPE: '|',
-      BACKSLASH: '\\',
-      SLASH: '/',
-      EXCLAMATION: '!',
-      BRACKET_OPEN: '[',
-      BRACKET_CLOSE: ']',
-      PAREN_OPEN: '(',
-      PAREN_CLOSE: ')',
-    });
-  });
-
-  test('HTML_TAGS object has expected values', () => {
-    const HTML_TAGS = htmlTags();
-    expect(HTML_TAGS).toEqual({
-      EMPHASIS: 'em',
-      STRONG: 'strong',
-      CODE: 'code',
-      PARAGRAPH: 'p',
-      BLOCKQUOTE: 'blockquote',
-      LIST: 'ul',
-      LIST_ITEM: 'li',
-      ORDERED_LIST: 'ol',
-      HORIZONTAL_RULE: 'hr',
-      LINE_BREAK: 'br',
-      LINK: 'a',
-      IMAGE: 'img',
-      DIV: 'div',
-      SPAN: 'span',
-      PRE: 'pre',
-    });
-  });
-
-  test('DEFAULT_OPTIONS object has expected values', () => {
-    const DEFAULT_OPTIONS = defaultOptions();
-    expect(DEFAULT_OPTIONS).toEqual({
-      gfm: true,
-      tables: true,
-      breaks: false,
-      pedantic: false,
-      sanitize: false,
-      smartLists: true,
-      smartypants: false,
-      xhtml: false,
-      highlight: null,
-      langPrefix: 'language-',
-      headerIds: true,
-      headerPrefix: '',
-      mangle: true,
-      baseUrl: null,
-      linkTarget: null,
-      renderer: null,
-    });
-  });
+  test.each(constantTests)(
+    '%s object has expected values',
+    (_name, fn, expected) => {
+      expect(fn()).toEqual(expected);
+    }
+  );
 
   test('constant objects are frozen', () => {
     const MARKDOWN_MARKERS = markdownMarkers();
@@ -119,48 +129,5 @@ describe('markdown constants mutants', () => {
     expect(() => {
       DEFAULT_OPTIONS.gfm = false;
     }).toThrow();
-  });
-
-  test('MARKDOWN_MARKERS object has expected values', () => {
-    const MARKDOWN_MARKERS = markdownMarkers();
-    expect(MARKDOWN_MARKERS).toEqual({
-      ASTERISK: '*',
-      UNDERSCORE: '_',
-      BACKTICK: '`',
-      TILDE: '~',
-      DASH: '-',
-      EQUAL: '=',
-      HASH: '#',
-      GREATER_THAN: '>',
-      PIPE: '|',
-      BACKSLASH: '\\',
-      SLASH: '/',
-      EXCLAMATION: '!',
-      BRACKET_OPEN: '[',
-      BRACKET_CLOSE: ']',
-      PAREN_OPEN: '(',
-      PAREN_CLOSE: ')',
-    });
-  });
-
-  test('HTML_TAGS object has expected values', () => {
-    const HTML_TAGS = htmlTags();
-    expect(HTML_TAGS).toEqual({
-      EMPHASIS: 'em',
-      STRONG: 'strong',
-      CODE: 'code',
-      PARAGRAPH: 'p',
-      BLOCKQUOTE: 'blockquote',
-      LIST: 'ul',
-      LIST_ITEM: 'li',
-      ORDERED_LIST: 'ol',
-      HORIZONTAL_RULE: 'hr',
-      LINE_BREAK: 'br',
-      LINK: 'a',
-      IMAGE: 'img',
-      DIV: 'div',
-      SPAN: 'span',
-      PRE: 'pre',
-    });
   });
 });


### PR DESCRIPTION
## Summary
- combine repeated markdown constant tests in a single table-driven block

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684b345f6dfc832eb453c8d5ad319620