### PR TITLE
Add missing element tests

### DIFF
--- a/test/browser/initializeInteractiveComponent.missingElements.test.js
+++ b/test/browser/initializeInteractiveComponent.missingElements.test.js
@@ -38,4 +38,96 @@ describe('initializeInteractiveComponent missing elements', () => {
     expect(dom.addEventListener).not.toHaveBeenCalled();
     expect(dom.enable).not.toHaveBeenCalled();
   });
+
+  it('handles missing input element but existing button', () => {
+    const button = {};
+    const dom = {
+      querySelector: jest.fn((_, selector) => {
+        if (selector === 'input[type="text"]') {
+          return null;
+        }
+        if (selector === 'button[type="submit"]') {
+          return button;
+        }
+        return {};
+      }),
+      removeAllChildren: jest.fn(),
+      createElement: jest.fn(() => ({ textContent: '' })),
+      setTextContent: jest.fn(),
+      addEventListener: jest.fn(),
+      removeWarning: jest.fn(),
+      enable: jest.fn(),
+      stopDefault: jest.fn(),
+      removeChild: jest.fn(),
+      addWarning: jest.fn(),
+      appendChild: jest.fn(),
+      contains: () => true,
+    };
+    const logWarning = jest.fn();
+    const config = {
+      globalState: {},
+      createEnvFn: () => ({}),
+      errorFn: jest.fn(),
+      fetchFn: jest.fn(),
+      dom,
+      loggers: { logInfo: jest.fn(), logError: jest.fn(), logWarning },
+    };
+    const article = { id: 'missing-input' };
+    const processingFunction = jest.fn();
+
+    initializeInteractiveComponent(article, processingFunction, config);
+
+    expect(logWarning).toHaveBeenCalledWith(
+      'Interactive component missing input or button in article',
+      article.id
+    );
+    expect(dom.addEventListener).not.toHaveBeenCalled();
+    expect(dom.enable).not.toHaveBeenCalled();
+  });
+
+  it('handles missing button element but existing input', () => {
+    const input = {};
+    const dom = {
+      querySelector: jest.fn((_, selector) => {
+        if (selector === 'input[type="text"]') {
+          return input;
+        }
+        if (selector === 'button[type="submit"]') {
+          return null;
+        }
+        return {};
+      }),
+      removeAllChildren: jest.fn(),
+      createElement: jest.fn(() => ({ textContent: '' })),
+      setTextContent: jest.fn(),
+      addEventListener: jest.fn(),
+      removeWarning: jest.fn(),
+      enable: jest.fn(),
+      stopDefault: jest.fn(),
+      removeChild: jest.fn(),
+      addWarning: jest.fn(),
+      appendChild: jest.fn(),
+      contains: () => true,
+    };
+    const logWarning = jest.fn();
+    const config = {
+      globalState: {},
+      createEnvFn: () => ({}),
+      errorFn: jest.fn(),
+      fetchFn: jest.fn(),
+      dom,
+      loggers: { logInfo: jest.fn(), logError: jest.fn(), logWarning },
+    };
+    const article = { id: 'missing-button' };
+    const processingFunction = jest.fn();
+
+    initializeInteractiveComponent(article, processingFunction, config);
+
+    expect(logWarning).toHaveBeenCalledWith(
+      'Interactive component missing input or button in article',
+      article.id
+    );
+    expect(dom.addEventListener).not.toHaveBeenCalled();
+    expect(dom.enable).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- test `initializeInteractiveComponent` when only input or button is missing

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684c6b468378832ea1474cf6e3a2f86b