### PR TITLE
Add test for BLOG_STATUS values

### DIFF
--- a/test/browser/blogStatus.validValues.test.js
+++ b/test/browser/blogStatus.validValues.test.js
@@ -1,0 +1,33 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { fetchAndCacheBlogData } from '../../src/browser/data.js';
+
+describe('BLOG_STATUS runtime values', () => {
+  it('only assigns recognized status strings during fetch flow', async () => {
+    const valid = ['idle', 'loading', 'loaded', 'error'];
+    const state = {
+      blog: null,
+      blogStatus: 'idle',
+      blogError: null,
+      blogFetchPromise: null,
+    };
+    const successFetch = jest.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    );
+    const loggers = { logInfo: jest.fn(), logError: jest.fn() };
+
+    const promise = fetchAndCacheBlogData(state, successFetch, loggers);
+    expect(valid).toContain(state.blogStatus);
+    await promise;
+    expect(valid).toContain(state.blogStatus);
+
+    const failState = {
+      blog: null,
+      blogStatus: 'idle',
+      blogError: null,
+      blogFetchPromise: null,
+    };
+    const failFetch = jest.fn(() => Promise.reject(new Error('boom')));
+    await fetchAndCacheBlogData(failState, failFetch, loggers);
+    expect(valid).toContain(failState.blogStatus);
+  });
+});


### PR DESCRIPTION
## Summary
- add a runtime test verifying that `fetchAndCacheBlogData` only assigns
  recognized `BLOG_STATUS` values

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684c6b4382d0832eb293be1e7f17282c