### PR TITLE
Add test covering null fleet case

### DIFF
--- a/test/toys/2025-05-11/generateClues.nullFleet.new.test.js
+++ b/test/toys/2025-05-11/generateClues.nullFleet.new.test.js
@@ -1,0 +1,7 @@
+import { test, expect } from '@jest/globals';
+import { generateClues } from '../../../src/toys/2025-05-11/battleshipSolitaireClues.js';
+
+test('generateClues handles \"null\" input without throwing', () => {
+  const result = generateClues('null');
+  expect(result).toBe('{"error":"Invalid fleet structure"}');
+});


### PR DESCRIPTION
## Summary
- add a test ensuring `generateClues` handles a `"null"` fleet string

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684c6b41b5b8832e84df7987575f0b3b