### PR TITLE
Add mutant-killing test for generateClues

### DIFF
--- a/test/toys/2025-05-11/generateClues.iteratorThrow.mutantKill.test.js
+++ b/test/toys/2025-05-11/generateClues.iteratorThrow.mutantKill.test.js
@@ -1,0 +1,21 @@
+import { test, expect } from '@jest/globals';
+import { generateClues } from '../../../src/toys/2025-05-11/battleshipSolitaireClues.js';
+
+test('generateClues does not iterate over strings when calculating ship cells', () => {
+  const fleet = {
+    width: 2,
+    height: 2,
+    ships: [{ start: { x: 0, y: 0 }, length: 1, direction: 'H' }],
+  };
+  const input = JSON.stringify(fleet);
+  const originalIterator = String.prototype[Symbol.iterator];
+  String.prototype[Symbol.iterator] = function* () {
+    throw new Error('iterated');
+  };
+  let result;
+  expect(() => {
+    result = generateClues(input);
+  }).not.toThrow();
+  String.prototype[Symbol.iterator] = originalIterator;
+  expect(JSON.parse(result)).toEqual({ rowClues: [1, 0], colClues: [1, 0] });
+});


### PR DESCRIPTION
## Summary
- guard against a Stryker survivor in `getHorizontalCells`
- ensure `generateClues` does not iterate over strings when building ship cells

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684c6b3ef8e8832e8024f7ee5be9a532