### PR TITLE
Add test for missing logInfo

### DIFF
--- a/test/browser/makeObserverCallback.noLoggersObject.test.js
+++ b/test/browser/makeObserverCallback.noLoggersObject.test.js
@@ -1,0 +1,24 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { makeObserverCallback } from '../../src/browser/toys.js';
+
+describe('makeObserverCallback missing loggers.logInfo', () => {
+  it('falls back to a noop logger and still imports the module', () => {
+    const dom = {
+      removeAllChildren: jest.fn(),
+      importModule: jest.fn(),
+      disconnectObserver: jest.fn(),
+      isIntersecting: () => true,
+      error: jest.fn(),
+      contains: () => true,
+    };
+    const env = { loggers: { logError: jest.fn() } };
+    const moduleInfo = { modulePath: 'mod.js', article: { id: 'art' }, functionName: 'fn' };
+    const callback = makeObserverCallback(moduleInfo, env, dom);
+    const observer = {};
+    const entry = {};
+
+    expect(() => callback([entry], observer)).not.toThrow();
+    expect(dom.importModule).toHaveBeenCalledWith('mod.js', expect.any(Function), expect.any(Function));
+    expect(dom.disconnectObserver).toHaveBeenCalledWith(observer);
+  });
+});


### PR DESCRIPTION
## Summary
- extend makeObserverCallback tests for loggers without logInfo

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684c6b3f80f0832e8d11380c3beb19f7