### PR TITLE
Add test for dendrite wrapper creation

### DIFF
--- a/test/inputHandlers/dendriteStoryHandler.formElement.test.js
+++ b/test/inputHandlers/dendriteStoryHandler.formElement.test.js
@@ -30,4 +30,34 @@ describe('dendriteStoryHandler form element', () => {
     const firstCall = dom.createElement.mock.calls[0][0];
     expect(firstCall).toBe('div');
   });
+
+  test('uses a div wrapper for each form field', () => {
+    const dom = {
+      hide: jest.fn(),
+      disable: jest.fn(),
+      querySelector: jest.fn(() => null),
+      removeChild: jest.fn(),
+      createElement: jest.fn(() => ({})),
+      setClassName: jest.fn(),
+      getNextSibling: jest.fn(() => ({})),
+      insertBefore: jest.fn(),
+      setType: jest.fn(),
+      setPlaceholder: jest.fn(),
+      setTextContent: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      appendChild: jest.fn(),
+      getValue: jest.fn(() => '{}'),
+      setValue: jest.fn(),
+    };
+    const container = {};
+    const textInput = { value: '{}' };
+
+    dendriteStoryHandler(dom, container, textInput);
+
+    const divCalls = dom.createElement.mock.calls.filter(
+      ([tag]) => tag === 'div'
+    );
+    expect(divCalls).toHaveLength(7);
+  });
 });


### PR DESCRIPTION
## Summary
- extend dendrite story handler tests to verify wrappers are created with `div` elements

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684c6b3e8460832e8a209e7f6154561b