### PR TITLE
Use RegExp.exec for bold search

### DIFF
--- a/src/toys/2025-03-21/italics.js
+++ b/src/toys/2025-03-21/italics.js
@@ -208,7 +208,8 @@ export function italics(text) {
  * @private
  */
 function findBoldSegments(text) {
-  const boldMatch = text.match(createBoldPattern());
+  const boldPattern = createBoldPattern();
+  const boldMatch = boldPattern.exec(text);
 
   if (!boldMatch) {
     return null;


### PR DESCRIPTION
## Summary
- improve `findBoldSegments` by using `RegExp.exec`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684c7419dc58832e8abe1561b496cb3b