### PR TITLE
Fix param name

### DIFF
--- a/src/browser/data.js
+++ b/src/browser/data.js
@@ -39,11 +39,11 @@ export function shouldUseExistingFetch(globalState, logFn) {
  * Returns a Base64 encoding function using the provided btoa, unescape, and encodeURIComponent.
  * @param {function} btoa - The btoa function
  * @param {function} unescape - The unescape function
- * @param {function} encodeURIComponent - The encodeURIComponent function
+ * @param {function} encodeURIComponentFn - The encodeURIComponent function
  * @returns {function} encodeBase64 - Function that encodes a string to Base64
  */
-export function getEncodeBase64(btoa, unescape, encodeURIComponent) {
-  return str => btoa(unescape(encodeURIComponent(str)));
+export function getEncodeBase64(btoa, unescape, encodeURIComponentFn) {
+  return str => btoa(unescape(encodeURIComponentFn(str)));
 }
 
 /**


### PR DESCRIPTION
## Summary
- rename the encodeURIComponent parameter in `getEncodeBase64`

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684c767c5b14832eb8c866e34c93b913