### PR TITLE
Refactor getSegmentValueOrError return type

### DIFF
--- a/public/2025-03-29/get.js
+++ b/public/2025-03-29/get.js
@@ -45,8 +45,8 @@ function traverseSegment(currentValue, segment, currentPath) {
   }
 
   const result = getSegmentValueOrError(currentValue, segment, nextPath);
-  if (isErrorString(result)) {
-    return { error: result };
+  if (result.error) {
+    return { error: result.error };
   }
   return { value: result.value, path: result.path, error: null };
 }
@@ -61,9 +61,13 @@ function getNextPath(currentPath, segment) {
 
 function getSegmentValueOrError(currentValue, segment, nextPath) {
   if (hasOwnSegment(currentValue, segment)) {
-    return { value: currentValue[segment], path: nextPath };
+    return { value: currentValue[segment], path: nextPath, error: null };
   }
-  return getSegmentNotFoundError(currentValue, segment, nextPath);
+  return {
+    value: undefined,
+    path: nextPath,
+    error: getSegmentNotFoundError(currentValue, segment, nextPath)
+  };
 }
 
 function getNonObjectSegmentError(currentValue, segment, currentPath) {

--- a/src/toys/2025-03-29/get.js
+++ b/src/toys/2025-03-29/get.js
@@ -45,8 +45,8 @@ function traverseSegment(currentValue, segment, currentPath) {
   }
 
   const result = getSegmentValueOrError(currentValue, segment, nextPath);
-  if (isErrorString(result)) {
-    return { error: result };
+  if (result.error) {
+    return { error: result.error };
   }
   return { value: result.value, path: result.path, error: null };
 }
@@ -61,9 +61,13 @@ function getNextPath(currentPath, segment) {
 
 function getSegmentValueOrError(currentValue, segment, nextPath) {
   if (hasOwnSegment(currentValue, segment)) {
-    return { value: currentValue[segment], path: nextPath };
+    return { value: currentValue[segment], path: nextPath, error: null };
   }
-  return getSegmentNotFoundError(currentValue, segment, nextPath);
+  return {
+    value: undefined,
+    path: nextPath,
+    error: getSegmentNotFoundError(currentValue, segment, nextPath)
+  };
 }
 
 function getNonObjectSegmentError(currentValue, segment, currentPath) {


### PR DESCRIPTION
## Summary
- refactor `getSegmentValueOrError` to always return an object
- update `traverseSegment` to handle new return type

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684c76388fc4832e8a05f64d3caa27d1