### PR TITLE
Fix lint warning

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -24,7 +24,7 @@ const config = {
   // Ensure coverage is collected for all files, including those not tested
   collectCoverage: Boolean(process.env.STRYKER_TEST_ENV),
   // Ensure all files are included in coverage, even if not required
-  forceCoverageMatch: process.env.STRYKER_TEST_ENV ? ['**/*.js'] : []
+  forceCoverageMatch: process.env.STRYKER_TEST_ENV && ['**/*.js'] || []
 };
 
 export default config;


### PR DESCRIPTION
## Summary
- remove ternary usage in `jest.config.mjs` to satisfy `no-ternary` rule

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684c8217ae28832ea13a99d3ab3daaa0