### PR TITLE
Fix ESLint ternary warning

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -24,7 +24,8 @@ const config = {
   // Ensure coverage is collected for all files, including those not tested
   collectCoverage: Boolean(process.env.STRYKER_TEST_ENV),
   // Ensure all files are included in coverage, even if not required
-  forceCoverageMatch: process.env.STRYKER_TEST_ENV ? ['**/*.js'] : []
+  forceCoverageMatch: [],
+  ...(process.env.STRYKER_TEST_ENV && { forceCoverageMatch: ['**/*.js'] })
 };
 
 export default config;


### PR DESCRIPTION
## Summary
- remove ternary in `jest.config.mjs` to satisfy lint rules

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684c82155cb8832e8e7bae264eede2ad