### PR TITLE
Fix lint warning

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -1,3 +1,8 @@
+const forceCoverageMatch = [];
+if (process.env.STRYKER_TEST_ENV) {
+  forceCoverageMatch.push("**/*.js");
+}
+
 const config = {
   transform: {
     '^.+\\.js$': 'babel-jest'
@@ -24,7 +29,7 @@ const config = {
   // Ensure coverage is collected for all files, including those not tested
   collectCoverage: Boolean(process.env.STRYKER_TEST_ENV),
   // Ensure all files are included in coverage, even if not required
-  forceCoverageMatch: process.env.STRYKER_TEST_ENV ? ['**/*.js'] : []
+  forceCoverageMatch,
 };
 
 export default config;


### PR DESCRIPTION
## Summary
- remove ternary from Jest config to satisfy `no-ternary`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684c8214eb80832e960bbf8560ff801a