### PR TITLE
Fix lint warning

### DIFF
--- a/test/inputHandlers/kvHandler.test.js
+++ b/test/inputHandlers/kvHandler.test.js
@@ -1,10 +1,8 @@
 import { describe, test, expect, jest } from '@jest/globals';
 import {
-  kvHandler,
-  handleKVType,
   maybeRemoveNumber,
   maybeRemoveDendrite,
-} from '../../src/inputHandlers/kv.js';
+} from "../../src/inputHandlers/kv.js";
 
 // kvHandler relies on ensureKeyValueInput which is complex to mock in ES modules.
 // These tests focus on the removable helper functions to achieve full branch coverage.


### PR DESCRIPTION
## Summary
- remove unused imports in kvHandler tests

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c8214089c832e926b150d73296b2d