### PR TITLE
Fix lint warnings

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -24,7 +24,7 @@ const config = {
   // Ensure coverage is collected for all files, including those not tested
   collectCoverage: Boolean(process.env.STRYKER_TEST_ENV),
   // Ensure all files are included in coverage, even if not required
-  forceCoverageMatch: process.env.STRYKER_TEST_ENV ? ['**/*.js'] : []
+  forceCoverageMatch: process.env.STRYKER_TEST_ENV && ['**/*.js'] || []
 };
 
 export default config;

--- a/src/browser/main.js
+++ b/src/browser/main.js
@@ -9,7 +9,6 @@ import {
 import {
   createOutputDropdownHandler,
   createInputDropdownHandler,
-  createAddDropdownListener,
   handleDropdownChange,
   getComponentInitializer,
   makeCreateIntersectionObserver,
@@ -17,10 +16,8 @@ import {
   createDropdownInitializer,
 } from './toys.js';
 
-import { dom } from './document.js';
-import { revealBetaArticles } from './beta.js';
-
 import {
+  dom,
   getElementById,
   log,
   warn,
@@ -31,6 +28,7 @@ import {
   getInteractiveComponentCount,
   getInteractiveComponents,
 } from './document.js';
+import { revealBetaArticles } from './beta.js';
 
 const globalState = {
   blog: null, // Holds the fetched blog data


### PR DESCRIPTION
## Summary
- combine document utilities import in `main.js`
- remove unused import in `main.js`
- avoid ternary operator in `jest.config.mjs`

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c821328c8832eb75ce7792a8426f6