### PR TITLE
Fix lint warnings

### DIFF
--- a/src/browser/toys.js
+++ b/src/browser/toys.js
@@ -99,7 +99,7 @@ export const createAddDropdownListener = (onChange, dom) => dropdown => {
 
 import { textHandler } from '../inputHandlers/text.js';
 import { numberHandler } from '../inputHandlers/number.js';
-import { kvHandler, handleKVType } from '../inputHandlers/kv.js';
+import { kvHandler } from '../inputHandlers/kv.js';
 import { defaultHandler } from '../inputHandlers/default.js';
 import { dendriteStoryHandler } from '../inputHandlers/dendriteStory.js';
 

--- a/test/inputHandlers/kvHandler.test.js
+++ b/test/inputHandlers/kvHandler.test.js
@@ -1,7 +1,5 @@
 import { describe, test, expect, jest } from '@jest/globals';
 import {
-  kvHandler,
-  handleKVType,
   maybeRemoveNumber,
   maybeRemoveDendrite,
 } from '../../src/inputHandlers/kv.js';


### PR DESCRIPTION
## Summary
- remove unused imports in kvHandler test
- avoid unused `handleKVType` import in toys.js

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684c8211c094832ea069aa65c19232d3