### PR TITLE
Fix ESLint unused vars warning

### DIFF
--- a/test/inputHandlers/kvHandler.test.js
+++ b/test/inputHandlers/kvHandler.test.js
@@ -1,7 +1,6 @@
 import { describe, test, expect, jest } from '@jest/globals';
 import {
-  kvHandler,
-  handleKVType,
+  // kvHandler is complex to mock and isn't needed for these tests
   maybeRemoveNumber,
   maybeRemoveDendrite,
 } from '../../src/inputHandlers/kv.js';


### PR DESCRIPTION
## Summary
- remove unused imports from `kvHandler.test.js`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684c82116b90832e8af64935a3a09945