### PR TITLE
Fix ESLint warning in kvHandler test

### DIFF
--- a/test/inputHandlers/kvHandler.test.js
+++ b/test/inputHandlers/kvHandler.test.js
@@ -1,10 +1,5 @@
 import { describe, test, expect, jest } from '@jest/globals';
-import {
-  kvHandler,
-  handleKVType,
-  maybeRemoveNumber,
-  maybeRemoveDendrite,
-} from '../../src/inputHandlers/kv.js';
+import { maybeRemoveNumber, maybeRemoveDendrite } from '../../src/inputHandlers/kv.js';
 
 // kvHandler relies on ensureKeyValueInput which is complex to mock in ES modules.
 // These tests focus on the removable helper functions to achieve full branch coverage.


### PR DESCRIPTION
## Summary
- remove unused imports in kvHandler.test.js

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684c821086f4832eac7f5d577f4ff2fe