### PR TITLE
Fix lint warnings

### DIFF
--- a/test/browser/toys.createKeyValueRow.test.js
+++ b/test/browser/toys.createKeyValueRow.test.js
@@ -83,7 +83,7 @@ describe('createKeyValueRow', () => {
       .mockReturnValue({}); // Any other calls
 
     // Call the row creator function
-    const rowElement = rowCreator('key1', 'value1', false);
+    rowCreator('key1', 'value1', false);
 
     // Verify the row element was created with the correct class
     expect(mockDom.createElement).toHaveBeenCalledWith('div');

--- a/test/inputHandlers/kvHandler.test.js
+++ b/test/inputHandlers/kvHandler.test.js
@@ -1,7 +1,5 @@
 import { describe, test, expect, jest } from '@jest/globals';
 import {
-  kvHandler,
-  handleKVType,
   maybeRemoveNumber,
   maybeRemoveDendrite,
 } from '../../src/inputHandlers/kv.js';


### PR DESCRIPTION
## Summary
- clean up unused variable in createKeyValueRow test
- remove unused imports in kvHandler test

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684c820fe790832eaf68beacacba2c77