### PR TITLE
Fix lint warning in main.js

### DIFF
--- a/src/browser/main.js
+++ b/src/browser/main.js
@@ -9,7 +9,6 @@ import {
 import {
   createOutputDropdownHandler,
   createInputDropdownHandler,
-  createAddDropdownListener,
   handleDropdownChange,
   getComponentInitializer,
   makeCreateIntersectionObserver,
@@ -17,10 +16,10 @@ import {
   createDropdownInitializer,
 } from './toys.js';
 
-import { dom } from './document.js';
 import { revealBetaArticles } from './beta.js';
 
 import {
+  dom,
   getElementById,
   log,
   warn,


### PR DESCRIPTION
## Summary
- remove unused `createAddDropdownListener` import
- consolidate all `document.js` imports into a single statement

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684c820e6d30832e8ea179ecfd866ae1