### PR TITLE
Switch to Object.hasOwn in data.js

### DIFF
--- a/public/browser/data.js
+++ b/public/browser/data.js
@@ -160,8 +160,13 @@ export function shouldCopyStateForFetch(status) {
   return status === BLOG_STATUS.IDLE || status === BLOG_STATUS.ERROR;
 }
 
+/**
+ * Determine if an object includes its own `temporary` property.
+ * @param {object} obj
+ * @returns {boolean}
+ */
 function hasTemporaryProperty(obj) {
-  return Object.prototype.hasOwnProperty.call(obj, 'temporary');
+  return Object.hasOwn(obj, 'temporary');
 }
 
 function isNonNullObject(value) {

--- a/src/browser/data.js
+++ b/src/browser/data.js
@@ -160,8 +160,13 @@ export function shouldCopyStateForFetch(status) {
   return status === BLOG_STATUS.IDLE || status === BLOG_STATUS.ERROR;
 }
 
+/**
+ * Determine if an object includes its own `temporary` property.
+ * @param {object} obj
+ * @returns {boolean}
+ */
 function hasTemporaryProperty(obj) {
-  return Object.prototype.hasOwnProperty.call(obj, 'temporary');
+  return Object.hasOwn(obj, 'temporary');
 }
 
 function isNonNullObject(value) {


### PR DESCRIPTION
## Summary
- add JSDoc comments explaining use of `Object.hasOwn`
- use `Object.hasOwn` to check for the `temporary` property

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684c768d4a6c832e95951513d8e31fb8