### PR TITLE
Fix lint warnings in tests

### DIFF
--- a/test/generator/dateFormatOptions.runtime.test.js
+++ b/test/generator/dateFormatOptions.runtime.test.js
@@ -1,4 +1,4 @@
-import { describe, test, expect, jest } from '@jest/globals';
+import { describe, test, expect } from '@jest/globals';
 import { generateBlog } from '../../src/generator/generator.js';
 
 const header = '<body>';

--- a/test/inputHandlers/kvHandler.test.js
+++ b/test/inputHandlers/kvHandler.test.js
@@ -1,7 +1,5 @@
 import { describe, test, expect, jest } from '@jest/globals';
 import {
-  kvHandler,
-  handleKVType,
   maybeRemoveNumber,
   maybeRemoveDendrite,
 } from '../../src/inputHandlers/kv.js';

--- a/test/inputHandlers/textHandler.test.js
+++ b/test/inputHandlers/textHandler.test.js
@@ -9,10 +9,12 @@ describe('textHandler', () => {
     const kvContainer = { _dispose: jest.fn() };
     const dendriteForm = { _dispose: jest.fn() };
     const querySelector = jest.fn((el, selector) => {
-      if (selector === 'input[type="number"]') {return numberInput;}
-      if (selector === '.kv-container') {return kvContainer;}
-      if (selector === '.dendrite-form') {return dendriteForm;}
-      return null;
+      const mapping = {
+        'input[type="number"]': numberInput,
+        '.kv-container': kvContainer,
+        '.dendrite-form': dendriteForm,
+      };
+      return mapping[selector] ?? null;
     });
     const dom = {
       reveal: jest.fn(),
@@ -51,10 +53,12 @@ describe('textHandler', () => {
     const kvContainer = {};
     const dendriteForm = {};
     const querySelector = jest.fn((_, selector) => {
-      if (selector === 'input[type="number"]') {return numberInput;}
-      if (selector === '.kv-container') {return kvContainer;}
-      if (selector === '.dendrite-form') {return dendriteForm;}
-      return null;
+      const mapping = {
+        'input[type="number"]': numberInput,
+        '.kv-container': kvContainer,
+        '.dendrite-form': dendriteForm,
+      };
+      return mapping[selector] ?? null;
     });
     const dom = {
       reveal: jest.fn(),


### PR DESCRIPTION
## Summary
- remove unused imports in `kvHandler.test.js`
- drop unused `jest` import in `dateFormatOptions.runtime.test.js`

## Testing
- `npm install`
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684c82102dd0832e873e88272258f704