### PR TITLE
Fix lint complexity in test

### DIFF
--- a/test/toys/2025-05-08/battleshipSolitaireFleet.segmentBounds.test.js
+++ b/test/toys/2025-05-08/battleshipSolitaireFleet.segmentBounds.test.js
@@ -4,6 +4,17 @@ import { describe, test, expect } from '@jest/globals';
 /**
  * Ensure generated ship segments stay within board bounds.
  */
+function assertSegmentInsideBoard(ship, fleet) {
+  for (let i = 0; i < ship.length; i++) {
+    const sx = ship.start.x + i * Number(ship.direction === 'H');
+    const sy = ship.start.y + i * Number(ship.direction === 'V');
+    expect(sx).toBeGreaterThanOrEqual(0);
+    expect(sx).toBeLessThan(fleet.width);
+    expect(sy).toBeGreaterThanOrEqual(0);
+    expect(sy).toBeLessThan(fleet.height);
+  }
+}
+
 describe('generateFleet segment bounds', () => {
   test('all ship segments remain inside the board', () => {
     const cfg = { width: 3, height: 2, ships: [3] };
@@ -11,13 +22,6 @@ describe('generateFleet segment bounds', () => {
     const fleet = JSON.parse(generateFleet(JSON.stringify(cfg), env));
     expect(Array.isArray(fleet.ships)).toBe(true);
     const ship = fleet.ships[0];
-    for (let i = 0; i < ship.length; i++) {
-      const sx = ship.start.x + (ship.direction === 'H' ? i : 0);
-      const sy = ship.start.y + (ship.direction === 'V' ? i : 0);
-      expect(sx).toBeGreaterThanOrEqual(0);
-      expect(sx).toBeLessThan(fleet.width);
-      expect(sy).toBeGreaterThanOrEqual(0);
-      expect(sy).toBeLessThan(fleet.height);
-    }
+    assertSegmentInsideBoard(ship, fleet);
   });
 });


### PR DESCRIPTION
## Summary
- refactor battleshipSolitaireFleet segment bounds test to lower complexity

## Testing
- `npm test`
- `npm run lint` *(fails: 150 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_684c8212492c832eb58b17732ddb6053