### PR TITLE
Add test for default content normalizer

### DIFF
--- a/test/generator/normalizeContentItem.noTypeObject.test.js
+++ b/test/generator/normalizeContentItem.noTypeObject.test.js
@@ -1,0 +1,23 @@
+import { describe, test, expect } from '@jest/globals';
+import { generateBlog } from '../../src/generator/generator.js';
+
+const header = '<body>';
+const footer = '</body>';
+const wrapHtml = c => c;
+
+describe('normalizeContentItem object without type', () => {
+  test('generateBlog throws when content object lacks type', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'NT1',
+          title: 'No Type',
+          publicationDate: '2025-02-02',
+          content: [{ content: 'missing type' }],
+        },
+      ],
+    };
+    const call = () => generateBlog({ blog, header, footer }, wrapHtml);
+    expect(call).toThrow('renderer is not a function');
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test covering content objects without a `type` property to kill surviving array declaration mutant

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684d7ddce0b4832e80bf974c28d80b17