### PR TITLE
Add source check for inputHandlersMap

### DIFF
--- a/test/browser/inputHandlersMap.source.test.js
+++ b/test/browser/inputHandlersMap.source.test.js
@@ -1,0 +1,14 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, test, expect } from '@jest/globals';
+
+const sourcePath = path.join(process.cwd(), 'src/browser/toys.js');
+
+describe('inputHandlersMap constant source', () => {
+  test('definition includes expected handler mappings', () => {
+    const src = fs.readFileSync(sourcePath, 'utf8');
+    const regex =
+      /const inputHandlersMap = \{\s*text: textHandler,\s*number: numberHandler,\s*kv: kvHandler,\s*'dendrite-story': dendriteStoryHandler,\s*default: defaultHandler,?\s*\};/s;
+    expect(src).toMatch(regex);
+  });
+});


### PR DESCRIPTION
## Summary
- add test ensuring `inputHandlersMap` maintains expected handler mappings

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684d7ddace30832e8bc3367b631a756d