### PR TITLE
Add test to kill dropdown handler mutant

### DIFF
--- a/test/browser/toys.createOutputDropdownHandler.test.js
+++ b/test/browser/toys.createOutputDropdownHandler.test.js
@@ -259,4 +259,11 @@ describe('createOutputDropdownHandler', () => {
     expect(fnString).toContain('handleDropdownChange(event.currentTarget, getData, dom)');
     expect(handler.length).toBe(1);
   });
+
+  test('factory function source includes inner arrow', () => {
+    const fnString = createOutputDropdownHandler.toString();
+    expect(fnString).toContain('event =>');
+    expect(fnString).toContain('handleDropdownChange');
+    expect(createOutputDropdownHandler.length).toBe(3);
+  });
 });


### PR DESCRIPTION
## Summary
- ensure `createOutputDropdownHandler` source code includes the inner arrow

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684d7dd92fc4832ea76b15752ae4754b