### PR TITLE
Add test for undefined blogStatus

### DIFF
--- a/test/browser/shouldUseExistingFetch.undefinedStatus.test.js
+++ b/test/browser/shouldUseExistingFetch.undefinedStatus.test.js
@@ -1,0 +1,12 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { shouldUseExistingFetch } from '../../src/browser/data.js';
+
+describe('shouldUseExistingFetch with undefined status', () => {
+  it('returns false and does not log when status is undefined', () => {
+    const state = { blogStatus: undefined, blogFetchPromise: Promise.resolve() };
+    const logFn = jest.fn();
+    const result = shouldUseExistingFetch(state, logFn);
+    expect(result).toBe(false);
+    expect(logFn).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- cover `shouldUseExistingFetch` for undefined `blogStatus`

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684d7dd89d38832eb6dba703b3567606