### PR TITLE
Add unit test for label creation

### DIFF
--- a/test/inputHandlers/dendriteStoryHandler.test.js
+++ b/test/inputHandlers/dendriteStoryHandler.test.js
@@ -245,6 +245,34 @@ test('sets expected placeholders and label text', () => {
   expect(labels).toEqual(expected);
 });
 
+test('creates a label element for each field', () => {
+  const dom = {
+    hide: jest.fn(),
+    disable: jest.fn(),
+    querySelector: jest.fn(() => null),
+    removeChild: jest.fn(),
+    createElement: jest.fn(() => ({})),
+    setClassName: jest.fn(),
+    getNextSibling: jest.fn(() => ({})),
+    insertBefore: jest.fn(),
+    setType: jest.fn(),
+    setPlaceholder: jest.fn(),
+    setTextContent: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    appendChild: jest.fn(),
+    getValue: jest.fn(() => '{}'),
+    setValue: jest.fn(),
+  };
+
+  dendriteStoryHandler(dom, {}, { value: '{}' });
+
+  const labelCalls = dom.createElement.mock.calls.filter(
+    ([tag]) => tag === 'label'
+  );
+  expect(labelCalls).toHaveLength(6);
+});
+
 test('does not set input values when data is missing', () => {
   const container = {};
   const textInput = { value: '{}' };


### PR DESCRIPTION
## Summary
- ensure dendriteStoryHandler creates `<label>` elements for each field

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684d7dd7fa5c832ea4ab189533135090