### PR TITLE
Fix lint warning

### DIFF
--- a/src/browser/document.js
+++ b/src/browser/document.js
@@ -70,8 +70,12 @@ export const logError = (...args) => console.error(...args);
  * @param {string} prefix - The prefix string to prepend
  * @returns {Function} The prefixed logger function
  */
-export const createPrefixedLogger = (logger, prefix) =>
-  logger ? (...args) => logger(prefix, ...args) : () => {};
+export const createPrefixedLogger = (logger, prefix) => {
+  if (logger) {
+    return (...args) => logger(prefix, ...args);
+  }
+  return () => {};
+};
 
 /**
  * Creates a loggers object with each logger prefixed using the given prefix.


### PR DESCRIPTION
## Summary
- remove ternary use in `createPrefixedLogger`

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e6e208a58832e86967f5063026f1c