### PR TITLE
Fix ESLint warning

### DIFF
--- a/test/inputHandlers/dendriteStoryHandler.test.js
+++ b/test/inputHandlers/dendriteStoryHandler.test.js
@@ -71,7 +71,10 @@ describe('dendriteStoryHandler', () => {
       hide: jest.fn(),
       disable: jest.fn(),
       querySelector: jest.fn((container, selector) => {
-        return selector === '.dendrite-form' ? existing : null;
+        if (selector === '.dendrite-form') {
+          return existing;
+        }
+        return null;
       }),
       removeChild: jest.fn(),
       createElement: jest.fn(() => ({})),


### PR DESCRIPTION
## Summary
- remove ternary from `dendriteStoryHandler.test.js` to satisfy the `no-ternary` rule

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684e71ce5948832eb3f665e168719c1b