### PR TITLE
Remove duplicate getDeepStateCopy tests

### DIFF
--- a/test/browser/getDeepStateCopy.toys.array.test.js
+++ b/test/browser/getDeepStateCopy.toys.array.test.js
@@ -2,15 +2,6 @@ import { describe, it, expect } from '@jest/globals';
 import { getDeepStateCopy } from '../../src/browser/toys.js';
 
 describe('getDeepStateCopy arrays from toys.js', () => {
-  it('creates a deep copy of objects containing arrays', () => {
-    const original = { arr: [1, 2, { x: 3 }] };
-    const copy = getDeepStateCopy(original);
-    expect(copy).toEqual(original);
-    expect(copy).not.toBe(original);
-    expect(copy.arr).not.toBe(original.arr);
-    expect(copy.arr[2]).not.toBe(original.arr[2]);
-  });
-
   it('changing the copy does not mutate the original', () => {
     const original = { arr: [1, { a: 'b' }] };
     const copy = getDeepStateCopy(original);

--- a/test/browser/toys.test.js
+++ b/test/browser/toys.test.js
@@ -976,26 +976,7 @@ describe('toys', () => {
     });
   });
 
-  describe('getDeepStateCopy', () => {
-    it('returns a deep copy of the global state object', () => {
-      const globalState = {
-        level1: {
-          level2: {
-            value: 'original',
-          },
-        },
-      };
-      const copy = getDeepStateCopy(globalState);
-      // Expectations at end
-      expect(copy).toEqual(globalState);
-      expect(copy).not.toBe(globalState);
-      expect(copy.level1).not.toBe(globalState.level1);
-      expect(copy.level1.level2).not.toBe(globalState.level1.level2);
-      // Modify copy to ensure it's a deep copy
-      copy.level1.level2.value = 'modified';
-      expect(globalState.level1.level2.value).toBe('original');
-    });
-  });
+
 
   describe('initializeInteractiveComponent', () => {
     let querySelector;


### PR DESCRIPTION
## Summary
- eliminate duplicated deep copy tests
- keep single array mutation test

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684e71c51544832e821c9159c984d929