### PR TITLE
Add test for CLASS.KEY constant

### DIFF
--- a/test/generator/classConstants.key.only.test.js
+++ b/test/generator/classConstants.key.only.test.js
@@ -1,0 +1,21 @@
+import { describe, test, expect } from '@jest/globals';
+import { generateBlogOuter } from '../../src/generator/generator.js';
+
+describe('CLASS.KEY constant usage', () => {
+  test('generateBlogOuter uses "key" CSS class for labels', () => {
+    const blog = {
+      posts: [
+        {
+          key: 'CK',
+          title: 'Key Const',
+          publicationDate: '2024-01-01',
+          content: [],
+        },
+      ],
+    };
+    const html = generateBlogOuter(blog);
+    const regex = /<div class="key[^"]*">/g;
+    const matches = html.match(regex) || [];
+    expect(matches.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add a regression test to ensure the `key` CSS class is emitted in generated HTML

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684e71be0e20832e8245dd2bfb3663d8