### PR TITLE
Add failing cases for isValidParsedRequest

### DIFF
--- a/test/browser/toys.isValidParsedRequest.additional.test.js
+++ b/test/browser/toys.isValidParsedRequest.additional.test.js
@@ -1,0 +1,14 @@
+import { describe, it, expect } from '@jest/globals';
+import { isValidParsedRequest } from '../../src/browser/toys.js';
+
+describe('isValidParsedRequest additional scenarios', () => {
+  it('returns false for object with numeric url', () => {
+    const parsed = { request: { url: 123 } };
+    expect(isValidParsedRequest(parsed)).toBe(false);
+  });
+
+  it('returns false when request field missing url property', () => {
+    const parsed = { request: { notUrl: 'x' } };
+    expect(isValidParsedRequest(parsed)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add coverage for invalid parsed request shapes to help kill surviving mutants

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684e71bd8bf0832ebe7a1d88c078560f