### PR TITLE
Add test for createOutputDropdownHandler error propagation

### DIFF
--- a/test/browser/toys.createOutputDropdownHandler.errorPropagation.test.js
+++ b/test/browser/toys.createOutputDropdownHandler.errorPropagation.test.js
@@ -1,0 +1,16 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { createOutputDropdownHandler } from '../../src/browser/toys.js';
+
+describe('createOutputDropdownHandler error propagation', () => {
+  it('throws the error from handleDropdownChange', () => {
+    const error = new Error('boom');
+    const handleDropdownChange = jest.fn(() => {
+      throw error;
+    });
+    const getData = jest.fn();
+    const dom = {};
+    const handler = createOutputDropdownHandler(handleDropdownChange, getData, dom);
+    const evt = { currentTarget: {} };
+    expect(() => handler(evt)).toThrow(error);
+  });
+});


### PR DESCRIPTION
## Summary
- add regression test ensuring createOutputDropdownHandler forwards thrown errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e71bd30a4832e91fc0e4c2204947d