### PR TITLE
Add missing invalid input test for handleParsedResult

### DIFF
--- a/test/browser/handleParsedResult.additionalInvalid.test.js
+++ b/test/browser/handleParsedResult.additionalInvalid.test.js
@@ -1,0 +1,12 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { handleParsedResult } from '../../src/browser/toys.js';
+
+describe('handleParsedResult additional invalid cases', () => {
+  it('returns false for non-object values without calling fetch', () => {
+    const env = { fetchFn: jest.fn(), dom: {}, errorFn: jest.fn() };
+    const options = { parent: {}, presenterKey: 'text' };
+    expect(handleParsedResult(undefined, env, options)).toBe(false);
+    expect(handleParsedResult(123, env, options)).toBe(false);
+    expect(env.fetchFn).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add regression test covering handleParsedResult with non-object values

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684e71bd2d8c832ebd136e5dfe447bad