### PR TITLE
Remove deprecated unescape usage

### DIFF
--- a/public/browser/data.js
+++ b/public/browser/data.js
@@ -36,14 +36,19 @@ export function shouldUseExistingFetch(globalState, logFn) {
 }
 
 /**
- * Returns a Base64 encoding function using the provided btoa, unescape, and encodeURIComponent.
+ * Returns a Base64 encoding function using the provided btoa and
+ * encodeURIComponent. It converts percent-encoded bytes back to a
+ * binary string to avoid relying on the deprecated unescape.
  * @param {function} btoa - The btoa function
- * @param {function} unescape - The unescape function
  * @param {function} encodeURIComponentFn - The encodeURIComponent function
  * @returns {function} encodeBase64 - Function that encodes a string to Base64
  */
-export function getEncodeBase64(btoa, unescape, encodeURIComponentFn) {
-  return str => btoa(unescape(encodeURIComponentFn(str)));
+export function getEncodeBase64(btoa, encodeURIComponentFn) {
+  const toBinary = str =>
+    encodeURIComponentFn(str).replace(/%([0-9A-F]{2})/g, (_, hex) =>
+      String.fromCharCode(parseInt(hex, 16))
+    );
+  return str => btoa(toBinary(str));
 }
 
 /**

--- a/public/browser/main.js
+++ b/public/browser/main.js
@@ -60,7 +60,7 @@ function createEnv() {
       'setData',
       newData => setData({ desired: newData, current: globalState }, loggers),
     ],
-    ['encodeBase64', getEncodeBase64(btoa, unescape, encodeURIComponent)],
+    ['encodeBase64', getEncodeBase64(btoa, encodeURIComponent)],
   ]);
 }
 

--- a/src/browser/data.js
+++ b/src/browser/data.js
@@ -36,14 +36,19 @@ export function shouldUseExistingFetch(globalState, logFn) {
 }
 
 /**
- * Returns a Base64 encoding function using the provided btoa, unescape, and encodeURIComponent.
+ * Returns a Base64 encoding function using the provided btoa and
+ * encodeURIComponent. This avoids the deprecated unescape by manually
+ * converting percent-encoded bytes back to a binary string.
  * @param {function} btoa - The btoa function
- * @param {function} unescape - The unescape function
  * @param {function} encodeURIComponentFn - The encodeURIComponent function
  * @returns {function} encodeBase64 - Function that encodes a string to Base64
  */
-export function getEncodeBase64(btoa, unescape, encodeURIComponentFn) {
-  return str => btoa(unescape(encodeURIComponentFn(str)));
+export function getEncodeBase64(btoa, encodeURIComponentFn) {
+  const toBinary = str =>
+    encodeURIComponentFn(str).replace(/%([0-9A-F]{2})/g, (_, hex) =>
+      String.fromCharCode(parseInt(hex, 16))
+    );
+  return str => btoa(toBinary(str));
 }
 
 /**

--- a/src/browser/main.js
+++ b/src/browser/main.js
@@ -60,7 +60,7 @@ function createEnv() {
       'setData',
       newData => setData({ desired: newData, current: globalState }, loggers),
     ],
-    ['encodeBase64', getEncodeBase64(btoa, unescape, encodeURIComponent)],
+    ['encodeBase64', getEncodeBase64(btoa, encodeURIComponent)],
   ]);
 }
 

--- a/test/browser/data.test.js
+++ b/test/browser/data.test.js
@@ -526,16 +526,11 @@ describe('getData, setData, and getDeepStateCopy', () => {
       typeof btoa !== 'undefined'
         ? btoa
         : str => Buffer.from(str, 'binary').toString('base64');
-    const unescapeFn = typeof unescape !== 'undefined' ? unescape : str => str;
     const encodeURIComponentFn =
       typeof encodeURIComponent !== 'undefined'
         ? encodeURIComponent
         : encodeURIComponent;
-    const encodeBase64 = getEncodeBase64(
-      btoaFn,
-      unescapeFn,
-      encodeURIComponentFn
-    );
+    const encodeBase64 = getEncodeBase64(btoaFn, encodeURIComponentFn);
     const input = 'hello world!';
     expect(encodeBase64(input)).toBe('aGVsbG8gd29ybGQh');
   });


### PR DESCRIPTION
## Summary
- switch getEncodeBase64 to avoid deprecated `unescape`
- update public browser files and tests accordingly

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684e7186d138832e9e5807c6e7f0c9f6