### PR TITLE
Fix lint warning

### DIFF
--- a/test/toys/2025-06-09/uuid.test.js
+++ b/test/toys/2025-06-09/uuid.test.js
@@ -5,7 +5,13 @@ describe('uuidToy', () => {
   it('returns the uuid from the environment', () => {
     const mockUuid = '84f8e1f2-3e9d-4fd1-b1a2-d9c2bd34fdba';
     const getUuid = jest.fn(() => mockUuid);
-    const env = { get: key => (key === 'getUuid' ? getUuid : undefined) };
+    const get = key => {
+      if (key === 'getUuid') {
+        return getUuid;
+      }
+      return undefined;
+    };
+    const env = { get };
     expect(uuidToy(undefined, env)).toBe(mockUuid);
   });
 });


### PR DESCRIPTION
## Summary
- remove ternary usage in `uuid.test.js`
- extract `get` arrow from env object

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684e71cd66c0832ea8829989f340619e