### PR TITLE
Fix lint unused imports

### DIFF
--- a/test/browser/clearDisposers.test.js
+++ b/test/browser/clearDisposers.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, jest } from '@jest/globals';
+import { describe, expect, jest } from '@jest/globals';
 import { clearDisposers } from '../../src/browser/toys.js';
 
 describe('clearDisposers', () => {
@@ -27,7 +27,6 @@ describe('clearDisposers', () => {
 
     // Act
     clearDisposers(disposers);
-
 
     // Assert
     expect(disposers).toHaveLength(0);

--- a/test/browser/parseJSONResult.realImport.test.js
+++ b/test/browser/parseJSONResult.realImport.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect } from '@jest/globals';
+import { describe, it } from '@jest/globals';
 import { processInputAndSetOutput } from '../../src/browser/toys.js';
 
 // This test indirectly covers parseJSONResult by invoking processInputAndSetOutput


### PR DESCRIPTION
## Summary
- remove unused Jest imports from test files
- format `clearDisposers.test.js`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684e71cc7644832eb97394008ec1693a