### PR TITLE
Fix lint warning

### DIFF
--- a/test/browser/createNumberInput.dispose.test.js
+++ b/test/browser/createNumberInput.dispose.test.js
@@ -11,7 +11,9 @@ describe('createNumberInput disposer', () => {
       setType: jest.fn(),
       setValue: jest.fn(),
       addEventListener: jest.fn((el, event, h) => {
-        if (event === 'input') {handler = h;}
+        if (event === 'input') {
+          handler = h;
+        }
       }),
       removeEventListener: jest.fn(),
     };
@@ -45,7 +47,7 @@ describe('createNumberInput disposer', () => {
     input._dispose();
     input._dispose();
 
-    const [[el, event, handler]] = dom.addEventListener.mock.calls;
+    const [[el, , handler]] = dom.addEventListener.mock.calls;
     expect(dom.removeEventListener).toHaveBeenCalledTimes(2);
     expect(dom.removeEventListener).toHaveBeenNthCalledWith(
       1,


### PR DESCRIPTION
## Summary
- remove unused variable in the createNumberInput dispose test

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684e906d3684832eac1262f2d05b329c