### PR TITLE
Fix lint warning

### DIFF
--- a/test/inputHandlers/numberHandler.test.js
+++ b/test/inputHandlers/numberHandler.test.js
@@ -39,9 +39,12 @@ describe('numberHandler', () => {
 
   test('no elements to remove', () => {
     const numberInput = {};
-    const querySelector = jest.fn((_, selector) =>
-      selector === 'input[type="number"]' ? numberInput : null
-    );
+    const querySelector = jest.fn((_, selector) => {
+      if (selector === 'input[type="number"]') {
+        return numberInput;
+      }
+      return null;
+    });
     const dom = {
       hide: jest.fn(),
       disable: jest.fn(),


### PR DESCRIPTION
## Summary
- fix lint warning about ternary usage in numberHandler tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684e906a75c8832eb02bc5faa5c736a7