### PR TITLE
Fix lint warnings in test file

### DIFF
--- a/test/inputHandlers/numberHandler.test.js
+++ b/test/inputHandlers/numberHandler.test.js
@@ -9,9 +9,15 @@ describe('numberHandler', () => {
     const kvContainer = { _dispose: jest.fn() };
     const dendriteForm = { _dispose: jest.fn() };
     const querySelector = jest.fn((el, selector) => {
-      if (selector === '.kv-container') {return kvContainer;}
-      if (selector === '.dendrite-form') {return dendriteForm;}
-      if (selector === 'input[type="number"]') {return numberInput;}
+      if (selector === '.kv-container') {
+        return kvContainer;
+      }
+      if (selector === '.dendrite-form') {
+        return dendriteForm;
+      }
+      if (selector === 'input[type="number"]') {
+        return numberInput;
+      }
       return null;
     });
     const removeChild = jest.fn();
@@ -39,9 +45,12 @@ describe('numberHandler', () => {
 
   test('no elements to remove', () => {
     const numberInput = {};
-    const querySelector = jest.fn((_, selector) =>
-      selector === 'input[type="number"]' ? numberInput : null
-    );
+    const querySelector = jest.fn((_, selector) => {
+      if (selector === 'input[type="number"]') {
+        return numberInput;
+      }
+      return null;
+    });
     const dom = {
       hide: jest.fn(),
       disable: jest.fn(),
@@ -59,9 +68,15 @@ describe('numberHandler', () => {
     const kvContainer = {};
     const dendriteForm = {};
     const querySelector = jest.fn((_, selector) => {
-      if (selector === '.kv-container') {return kvContainer;}
-      if (selector === '.dendrite-form') {return dendriteForm;}
-      if (selector === 'input[type="number"]') {return {};}
+      if (selector === '.kv-container') {
+        return kvContainer;
+      }
+      if (selector === '.dendrite-form') {
+        return dendriteForm;
+      }
+      if (selector === 'input[type="number"]') {
+        return {};
+      }
       return null;
     });
     const dom = {


### PR DESCRIPTION
## Summary
- refactor numberHandler test to avoid ternary usage

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684e906a5fa4832ea7c68e212d5c0dfb