### PR TITLE
Fix lint warning

### DIFF
--- a/test/browser/toys.test.js
+++ b/test/browser/toys.test.js
@@ -5,17 +5,13 @@ import {
   enableInteractiveControls,
   getModuleInitializer,
   initializeVisibleComponents,
-  getDeepStateCopy,
-  createHandleSubmit,
   initializeInteractiveComponent,
   handleModuleError,
   handleDropdownChange,
   createAddDropdownListener,
   createInputDropdownHandler,
-  createUpdateTextInputValue,
   getText,
 } from '../../src/browser/toys.js';
-import * as toys from '../../src/browser/toys.js';
 
 describe('createAddDropdownListener', () => {
   it('adds a change event listener to the dropdown', () => {


### PR DESCRIPTION
## Summary
- remove unused imports in `toys.test.js`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684e906901f4832ea751de59e0ca25f4