### PR TITLE
Remove duplicate dendriteStoryHandler test

### DIFF
--- a/test/inputHandlers/dendriteStoryHandler.formElement.test.js
+++ b/test/inputHandlers/dendriteStoryHandler.formElement.test.js
@@ -60,34 +60,4 @@ describe('dendriteStoryHandler form element', () => {
     );
     expect(divCalls).toHaveLength(7);
   });
-
-  test('creates a label element for each form field', () => {
-    const dom = {
-      hide: jest.fn(),
-      disable: jest.fn(),
-      querySelector: jest.fn(() => null),
-      removeChild: jest.fn(),
-      createElement: jest.fn(() => ({})),
-      setClassName: jest.fn(),
-      getNextSibling: jest.fn(() => ({})),
-      insertBefore: jest.fn(),
-      setType: jest.fn(),
-      setPlaceholder: jest.fn(),
-      setTextContent: jest.fn(),
-      addEventListener: jest.fn(),
-      removeEventListener: jest.fn(),
-      appendChild: jest.fn(),
-      getValue: jest.fn(() => '{}'),
-      setValue: jest.fn(),
-    };
-    const container = {};
-    const textInput = { value: '{}' };
-
-    dendriteStoryHandler(dom, container, textInput);
-
-    const labelCalls = dom.createElement.mock.calls.filter(
-      ([tag]) => tag === 'label'
-    );
-    expect(labelCalls).toHaveLength(6);
-  });
 });


### PR DESCRIPTION
## Summary
- delete redundant label creation test from `dendriteStoryHandler.formElement.test.js`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684e905a3614832e8c71dd2d1bf6a0b0