### PR TITLE
Fix lint warning

### DIFF
--- a/test/browser/toys.test.js
+++ b/test/browser/toys.test.js
@@ -976,8 +976,6 @@ describe('toys', () => {
     });
   });
 
-
-
   describe('initializeInteractiveComponent', () => {
     let querySelector;
     let selectorMap;
@@ -1495,9 +1493,12 @@ describe('createInputDropdownHandler', () => {
 
   // Helper function to create a querySelector mock
   const createQuerySelector = selectorMap =>
-    jest.fn((parent, selector) =>
-      parent === container ? selectorMap.get(selector) || null : null
-    );
+    jest.fn((parent, selector) => {
+      if (parent !== container) {
+        return null;
+      }
+      return selectorMap.get(selector) || null;
+    });
 
   beforeEach(() => {
     // Given


### PR DESCRIPTION
## Summary
- refactor query selector helper in `toys.test.js` to reduce complexity

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684e906c1a60832eb16e1333a9df359a