### PR TITLE
Fix lint warning in test

### DIFF
--- a/test/inputHandlers/dendriteStoryHandler.test.js
+++ b/test/inputHandlers/dendriteStoryHandler.test.js
@@ -124,15 +124,13 @@ describe('dendriteStoryHandler', () => {
   test('removes number and kv inputs', () => {
     const numberInput = { _dispose: jest.fn() };
     const kvContainer = { _dispose: jest.fn() };
-    const querySelector = jest.fn((container, selector) => {
-      if (selector === 'input[type="number"]') {
-        return numberInput;
-      }
-      if (selector === '.kv-container') {
-        return kvContainer;
-      }
-      return null;
-    });
+    const selectorMap = {
+      'input[type="number"]': numberInput,
+      '.kv-container': kvContainer,
+    };
+    const querySelector = jest.fn(
+      (_, selector) => selectorMap[selector] ?? null
+    );
     const dom = {
       hide: jest.fn(),
       disable: jest.fn(),


### PR DESCRIPTION
## Summary
- simplify mocked querySelector in dendriteStoryHandler test

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684e9069acd8832ea5c4401d9e23165b