### PR TITLE
Fix lint warning in syncHiddenField tests

### DIFF
--- a/test/browser/toys.syncHiddenField.test.js
+++ b/test/browser/toys.syncHiddenField.test.js
@@ -11,30 +11,30 @@ describe('syncHiddenField', () => {
 
     // Setup mock DOM utilities
     mockDom = {
-      setValue: jest.fn()
+      setValue: jest.fn(),
     };
   });
 
   it('includes entries where either key or value is truthy', () => {
     const rows = {
-      'key1': 'value1', // Included (both key and value are truthy)
+      key1: 'value1', // Included (both key and value are truthy)
       '': 'emptyKey', // Excluded (key is falsy, but value is truthy - but implementation only checks key)
-      'emptyValue': '', // Included (key is truthy, even though value is falsy)
-      'key2': 'value2', // Included (both key and value are truthy)
-      '': '' // Excluded (both key and value are falsy)
+      emptyValue: '', // Included (key is truthy, even though value is falsy)
+      key2: 'value2', // Included (both key and value are truthy)
+      '': '', // Excluded (both key and value are falsy)
     };
 
     syncHiddenField(mockTextInput, rows, mockDom);
 
     // Get the actual result
-    const [actualTextInput, actualJson] = mockDom.setValue.mock.calls[0];
+    const [, actualJson] = mockDom.setValue.mock.calls[0];
     const actual = JSON.parse(actualJson);
 
     // Check that all expected entries are present, regardless of order
     expect(actual).toMatchObject({
-      'key1': 'value1',
-      'emptyValue': '',
-      'key2': 'value2'
+      key1: 'value1',
+      emptyValue: '',
+      key2: 'value2',
       // Note: '' (empty key) is not included because the implementation only checks the key
     });
 
@@ -58,27 +58,27 @@ describe('syncHiddenField', () => {
   it('excludes entries where both key and value are falsy', () => {
     const rows = {
       '': '', // Excluded (both key and value are falsy)
-      'key1': 'value1',
+      key1: 'value1',
       '': 'value2', // Included (value is truthy)
-      'key2': '', // Included (key is truthy)
-      'key3': 'value3',
-      '0': 0, // Included (key is truthy, even though value is falsy)
-      'false': false // Included (key is truthy, even though value is falsy)
+      key2: '', // Included (key is truthy)
+      key3: 'value3',
+      0: 0, // Included (key is truthy, even though value is falsy)
+      false: false, // Included (key is truthy, even though value is falsy)
     };
 
     syncHiddenField(mockTextInput, rows, mockDom);
 
-    const [actualTextInput, actualJson] = mockDom.setValue.mock.calls[0];
+    const [, actualJson] = mockDom.setValue.mock.calls[0];
     const actual = JSON.parse(actualJson);
 
     // Check that all expected entries are present, regardless of order
     expect(actual).toMatchObject({
-      'key1': 'value1',
+      key1: 'value1',
       '': 'value2',
-      'key2': '',
-      'key3': 'value3',
-      '0': 0,
-      'false': false
+      key2: '',
+      key3: 'value3',
+      0: 0,
+      false: false,
     });
 
     // Verify no unexpected entries
@@ -93,7 +93,7 @@ describe('syncHiddenField', () => {
       boolean: true,
       nullValue: null,
       object: { a: 1 },
-      array: [1, 2, 3]
+      array: [1, 2, 3],
     };
 
     syncHiddenField(mockTextInput, rows, mockDom);
@@ -105,7 +105,7 @@ describe('syncHiddenField', () => {
         boolean: true,
         nullValue: null,
         object: { a: 1 },
-        array: [1, 2, 3]
+        array: [1, 2, 3],
       })
     );
   });
@@ -113,23 +113,23 @@ describe('syncHiddenField', () => {
   it('preserves whitespace in keys and values', () => {
     const rows = {
       '  key  ': '  value  ', // Both key and value have whitespace
-      'key2': '  ', // Value is whitespace-only
+      key2: '  ', // Value is whitespace-only
       '  ': '  ', // Key is whitespace-only, value is whitespace
       '  key3  ': '  value with spaces  ',
-      '': '' // Excluded (both key and value are empty)
+      '': '', // Excluded (both key and value are empty)
     };
 
     syncHiddenField(mockTextInput, rows, mockDom);
 
-    const [actualTextInput, actualJson] = mockDom.setValue.mock.calls[0];
+    const [, actualJson] = mockDom.setValue.mock.calls[0];
     const actual = JSON.parse(actualJson);
 
     // Check that all expected entries are present, regardless of order
     expect(actual).toMatchObject({
       '  key  ': '  value  ',
-      'key2': '  ',
+      key2: '  ',
       '  ': '  ', // Included because value is non-empty (whitespace is truthy)
-      '  key3  ': '  value with spaces  '
+      '  key3  ': '  value with spaces  ',
     });
 
     // Verify no unexpected entries


### PR DESCRIPTION
## Summary
- run prettier on `toys.syncHiddenField.test.js`
- remove unused variables via array destructuring

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684ea32b922c832e90a7afaf13aff74b