### PR TITLE
Add locale assertion for date formatting

### DIFF
--- a/test/generator/generateBlogOuter.dateFormat.test.js
+++ b/test/generator/generateBlogOuter.dateFormat.test.js
@@ -1,15 +1,23 @@
-import { describe, it, expect } from '@jest/globals';
+import { describe, it, expect, jest } from '@jest/globals';
 import { generateBlogOuter } from '../../src/generator/generator.js';
 
 describe('generateBlogOuter date formatting', () => {
   it('formats publication dates with short month names', () => {
     const blog = {
       posts: [
-        { key: 'DF1', title: 'Date Test', publicationDate: '2024-06-01', content: [] },
+        {
+          key: 'DF1',
+          title: 'Date Test',
+          publicationDate: '2024-06-01',
+          content: [],
+        },
       ],
     };
 
+    const spy = jest.spyOn(Date.prototype, 'toLocaleDateString');
     const html = generateBlogOuter(blog);
     expect(html).toContain('<p class="value metadata">1 Jun 2024</p>');
+    expect(spy).toHaveBeenCalledWith('en-GB', expect.any(Object));
+    spy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- improve `generateBlogOuter.dateFormat` test by asserting `toLocaleDateString` is called with `'en-GB'`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ec05c55b0832e814931b824fef84b