### PR TITLE
Add runtime check for BLOG_STATUS

### DIFF
--- a/src/browser/data.js
+++ b/src/browser/data.js
@@ -1,6 +1,6 @@
 const INTERNAL_STATE_KEYS = ['blogStatus', 'blogError', 'blogFetchPromise'];
 
-const BLOG_STATUS = {
+export const BLOG_STATUS = {
   IDLE: 'idle',
   LOADING: 'loading',
   LOADED: 'loaded',

--- a/test/browser/data.blogStatusSource.test.js
+++ b/test/browser/data.blogStatusSource.test.js
@@ -1,17 +1,16 @@
-import fs from 'fs';
-import path from 'path';
 import { describe, test, expect } from '@jest/globals';
-
-const sourcePath = path.join(process.cwd(), 'src/browser/data.js');
+import { BLOG_STATUS } from '../../src/browser/data.js';
 
 // Ensure BLOG_STATUS constant contains expected keys and values
 // This guards against mutations that change the object structure
 // or the string values used for each status.
 describe('BLOG_STATUS constant source', () => {
   test('definition includes all expected status values', () => {
-    const src = fs.readFileSync(sourcePath, 'utf8');
-    const regex =
-      /const BLOG_STATUS = \{\s*IDLE: 'idle',\s*LOADING: 'loading',\s*LOADED: 'loaded',\s*ERROR: 'error',?\s*\};/s;
-    expect(src).toMatch(regex);
+    expect(BLOG_STATUS).toEqual({
+      IDLE: 'idle',
+      LOADING: 'loading',
+      LOADED: 'loaded',
+      ERROR: 'error',
+    });
   });
 });

--- a/test/generator/dateFormatOptions.runtime.test.js
+++ b/test/generator/dateFormatOptions.runtime.test.js
@@ -20,6 +20,7 @@ describe('DATE_FORMAT_OPTIONS runtime', () => {
 
     const html = generateBlog({ blog, header, footer }, wrapHtml);
     expect(html).toContain('<p class="value metadata">4 May 2024</p>');
+    expect(html).not.toContain('May 4, 2024');
     expect(html).not.toContain('04/05/2024');
   });
 });


### PR DESCRIPTION
## Summary
- export `BLOG_STATUS` so tests can verify it directly
- check the `BLOG_STATUS` object via runtime import instead of reading source

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ec05bc81c832eae1e46bf403ae1b7