### PR TITLE
Add test for idle status constant

### DIFF
--- a/test/browser/shouldCopyStateForFetch.idleConstant.test.js
+++ b/test/browser/shouldCopyStateForFetch.idleConstant.test.js
@@ -1,0 +1,8 @@
+import { describe, it, expect } from '@jest/globals';
+import { shouldCopyStateForFetch } from '../../src/browser/data.js';
+
+describe('shouldCopyStateForFetch idle constant usage', () => {
+  it('returns true when passed the string "idle"', () => {
+    expect(shouldCopyStateForFetch('idle')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add `shouldCopyStateForFetch.idleConstant.test.js` to validate behavior when passing the string "idle"

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684ec05bebb8832e9d76c37f05b93b3e