### PR TITLE
Assume logInfo is always provided

### DIFF
--- a/src/browser/toys.js
+++ b/src/browser/toys.js
@@ -356,8 +356,7 @@ export function makeObserverCallback(moduleInfo, env, dom) {
     `[${moduleInfo.article.id}]`
   );
   const handleEntryFactory = getEntryHandler(moduleInfo, moduleConfig);
-  const logInfo =
-    (moduleConfig.loggers && moduleConfig.loggers.logInfo) || (() => {});
+  const logInfo = moduleConfig.loggers.logInfo;
   return (entries, observer) => {
     const handleEntry = handleEntryFactory(observer);
     entries.forEach(entry => {

--- a/test/browser/makeObserverCallback.logInfo.test.js
+++ b/test/browser/makeObserverCallback.logInfo.test.js
@@ -69,7 +69,7 @@ describe('makeObserverCallback logging', () => {
     );
   });
 
-  it('handles missing loggers without throwing', () => {
+  it('handles provided loggers without error', () => {
     const dom = {
       removeAllChildren: jest.fn(),
       importModule: jest.fn(),
@@ -78,7 +78,7 @@ describe('makeObserverCallback logging', () => {
       error: jest.fn(),
       contains: () => true,
     };
-    const env = { loggers: {} }; // loggers without logInfo
+    const env = { loggers: { logInfo: jest.fn() } }; // loggers with logInfo
     const moduleInfo = {
       modulePath: 'mod.js',
       article: { id: 'art' },

--- a/test/browser/makeObserverCallback.logInfo.undefined.test.js
+++ b/test/browser/makeObserverCallback.logInfo.undefined.test.js
@@ -1,8 +1,8 @@
 import { describe, it, expect, jest } from '@jest/globals';
 import { makeObserverCallback } from '../../src/browser/toys.js';
 
-describe('makeObserverCallback missing logInfo', () => {
-  it('handles absence of logInfo without throwing', () => {
+describe('makeObserverCallback with logInfo defined', () => {
+  it('calls logInfo when defined', () => {
     const dom = {
       removeAllChildren: jest.fn(),
       importModule: jest.fn(),
@@ -11,7 +11,7 @@ describe('makeObserverCallback missing logInfo', () => {
       error: jest.fn(),
       contains: () => true,
     };
-    const env = { loggers: {} };
+    const env = { loggers: { logInfo: jest.fn() } };
     const moduleInfo = {
       modulePath: 'mod.js',
       article: { id: 'art' },
@@ -21,5 +21,6 @@ describe('makeObserverCallback missing logInfo', () => {
     const observer = {};
     const entry = {};
     expect(() => observerCallback([entry], observer)).not.toThrow();
+    expect(env.loggers.logInfo).toHaveBeenCalled();
   });
 });

--- a/test/browser/makeObserverCallback.loggersMissing.test.js
+++ b/test/browser/makeObserverCallback.loggersMissing.test.js
@@ -1,8 +1,8 @@
 import { describe, it, expect, jest } from '@jest/globals';
 import { makeObserverCallback } from '../../src/browser/toys.js';
 
-describe('makeObserverCallback without loggers', () => {
-  it('handles loggers object without logInfo', () => {
+describe('makeObserverCallback with complete loggers', () => {
+  it('imports module when loggers include logInfo', () => {
     const dom = {
       removeAllChildren: jest.fn(),
       importModule: jest.fn(),
@@ -11,7 +11,7 @@ describe('makeObserverCallback without loggers', () => {
       error: jest.fn(),
       contains: () => true,
     };
-    const env = { loggers: {} };
+    const env = { loggers: { logInfo: jest.fn() } };
     const moduleInfo = {
       modulePath: 'mod.js',
       article: { id: 'art' },
@@ -21,6 +21,7 @@ describe('makeObserverCallback without loggers', () => {
     const observer = {};
     const entry = {};
     expect(() => cb([entry], observer)).not.toThrow();
+    expect(env.loggers.logInfo).toHaveBeenCalled();
     expect(dom.importModule).toHaveBeenCalledWith(
       moduleInfo.modulePath,
       expect.any(Function),

--- a/test/browser/makeObserverCallback.noLogInfo.test.js
+++ b/test/browser/makeObserverCallback.noLogInfo.test.js
@@ -1,8 +1,8 @@
 import { describe, it, expect, jest } from '@jest/globals';
 import { makeObserverCallback } from '../../src/browser/toys.js';
 
-describe('makeObserverCallback without logInfo', () => {
-  it('handles missing logInfo without throwing', () => {
+describe('makeObserverCallback with logInfo provided', () => {
+  it('imports the module when logInfo exists', () => {
     const dom = {
       removeAllChildren: jest.fn(),
       importModule: jest.fn(),
@@ -11,12 +11,13 @@ describe('makeObserverCallback without logInfo', () => {
       error: jest.fn(),
       contains: () => true,
     };
-    const env = { loggers: { logError: jest.fn() } };
+    const env = { loggers: { logError: jest.fn(), logInfo: jest.fn() } };
     const moduleInfo = { modulePath: 'mod.js', article: { id: 'art' }, functionName: 'fn' };
     const callback = makeObserverCallback(moduleInfo, env, dom);
     const observer = {};
     const entry = {};
     expect(() => callback([entry], observer)).not.toThrow();
+    expect(env.loggers.logInfo).toHaveBeenCalled();
     expect(dom.importModule).toHaveBeenCalledWith('mod.js', expect.any(Function), expect.any(Function));
     expect(dom.disconnectObserver).toHaveBeenCalledWith(observer);
   });

--- a/test/browser/makeObserverCallback.noLogger.test.js
+++ b/test/browser/makeObserverCallback.noLogger.test.js
@@ -1,8 +1,8 @@
 import { describe, it, expect, jest } from '@jest/globals';
 import { makeObserverCallback } from '../../src/browser/toys.js';
 
-describe('makeObserverCallback logInfo fallback', () => {
-  it('uses noop when logInfo is missing', () => {
+describe('makeObserverCallback logInfo required', () => {
+  it('calls logInfo when provided', () => {
     const dom = {
       removeAllChildren: jest.fn(),
       importModule: jest.fn(),
@@ -11,7 +11,7 @@ describe('makeObserverCallback logInfo fallback', () => {
       error: jest.fn(),
       contains: () => true,
     };
-    const env = { loggers: { logError: jest.fn(), logWarning: jest.fn() } };
+    const env = { loggers: { logError: jest.fn(), logWarning: jest.fn(), logInfo: jest.fn() } };
     const moduleInfo = {
       modulePath: 'mod.js',
       article: { id: 'art2' },
@@ -21,6 +21,7 @@ describe('makeObserverCallback logInfo fallback', () => {
     const observer = {};
     const entry = {};
     expect(() => observerCallback([entry], observer)).not.toThrow();
+    expect(env.loggers.logInfo).toHaveBeenCalled();
     expect(dom.importModule).toHaveBeenCalledWith(
       moduleInfo.modulePath,
       expect.any(Function),

--- a/test/browser/makeObserverCallback.noLoggersObject.test.js
+++ b/test/browser/makeObserverCallback.noLoggersObject.test.js
@@ -1,8 +1,8 @@
 import { describe, it, expect, jest } from '@jest/globals';
 import { makeObserverCallback } from '../../src/browser/toys.js';
 
-describe('makeObserverCallback missing loggers.logInfo', () => {
-  it('falls back to a noop logger and still imports the module', () => {
+describe('makeObserverCallback with logInfo present', () => {
+  it('imports the module when logInfo is provided', () => {
     const dom = {
       removeAllChildren: jest.fn(),
       importModule: jest.fn(),
@@ -11,13 +11,14 @@ describe('makeObserverCallback missing loggers.logInfo', () => {
       error: jest.fn(),
       contains: () => true,
     };
-    const env = { loggers: { logError: jest.fn() } };
+    const env = { loggers: { logError: jest.fn(), logInfo: jest.fn() } };
     const moduleInfo = { modulePath: 'mod.js', article: { id: 'art' }, functionName: 'fn' };
     const callback = makeObserverCallback(moduleInfo, env, dom);
     const observer = {};
     const entry = {};
 
     expect(() => callback([entry], observer)).not.toThrow();
+    expect(env.loggers.logInfo).toHaveBeenCalled();
     expect(dom.importModule).toHaveBeenCalledWith('mod.js', expect.any(Function), expect.any(Function));
     expect(dom.disconnectObserver).toHaveBeenCalledWith(observer);
   });


### PR DESCRIPTION
## Summary
- remove logInfo fallback in `makeObserverCallback`
- adjust tests to include a `logInfo` logger

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68640dc9b504832eaa2355f2c6fe74ea