### PR TITLE
Remove unused variable to fix lint warning

### DIFF
--- a/test/browser/toys.createKeyValueRow.test.js
+++ b/test/browser/toys.createKeyValueRow.test.js
@@ -196,8 +196,6 @@ describe('createKeyValueRow', () => {
     const mockValueInput = {};
     const mockButton = {};
 
-    let inputHandler;
-
     mockDom.createElement
       .mockReturnValueOnce({}) // row div
       .mockReturnValueOnce(mockKeyInput) // key input


### PR DESCRIPTION
## Summary
- remove an unused `inputHandler` variable from `toys.createKeyValueRow.test.js`

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68641d0ce3b0832e829ef5022a80c579