### PR TITLE
Fix lint warning in toys test

### DIFF
--- a/test/browser/toys.test.js
+++ b/test/browser/toys.test.js
@@ -418,7 +418,6 @@ describe('toys', () => {
       // --- THEN ---
       expect(disconnectObserver).toHaveBeenCalledWith(observer);
     });
-
   });
 
   describe('makeCreateIntersectionObserver', () => {
@@ -1412,7 +1411,12 @@ describe('createInputDropdownHandler', () => {
     };
 
     // Mock DOM functions
-    getCurrentTarget = jest.fn(arg => (arg === event ? select : null));
+    getCurrentTarget = jest.fn(arg => {
+      if (arg === event) {
+        return select;
+      }
+      return null;
+    });
     getParentElement = jest.fn(arg => (arg === select ? container : null));
 
     const selectorMap = new Map([


### PR DESCRIPTION
## Summary
- replace a ternary in `toys.test.js` to lower lint warnings

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68641ee9459c832eba1c6abed936937b