### PR TITLE
Fix lint warning

### DIFF
--- a/test/browser/toys.createDropdownInitializer.input.test.js
+++ b/test/browser/toys.createDropdownInitializer.input.test.js
@@ -7,15 +7,13 @@ describe('createDropdownInitializer input init', () => {
   it('calls onInputChange for existing dropdown selection', () => {
     const dropdown = { value: 'dendrite-story' };
 
+    const SELECT_INPUT = 'article.entry .value > select.input';
     const dom = {
       querySelectorAll: jest.fn(selector => {
-        if (selector === 'article.entry .value > select.output') {
-          return [];
-        }
-        if (selector === 'article.entry .value > select.input') {
-          return [dropdown];
-        }
-        return [];
+        const mapping = {
+          [SELECT_INPUT]: [dropdown],
+        };
+        return mapping[selector] || [];
       }),
       addEventListener: jest.fn(),
     };


### PR DESCRIPTION
## Summary
- reduce complexity in dropdown initializer test

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686426de5274832e86255d31c54306bd