### PR TITLE
Fix lint: remove ternary operator

### DIFF
--- a/src/utils/regexUtils.js
+++ b/src/utils/regexUtils.js
@@ -6,7 +6,9 @@ const REGEX_SPECIAL_CHARS = /[.*+?^${}()|[\]\\-]/g;
  * @returns {string} The escaped string
  */
 export function escapeRegex(str) {
-  if (typeof str !== 'string') {return '';}
+  if (typeof str !== 'string') {
+    return '';
+  }
   return str.replace(REGEX_SPECIAL_CHARS, '\\$&');
 }
 
@@ -20,7 +22,10 @@ export function escapeRegex(str) {
  */
 export function createPattern(marker, { isDouble = false, flags = 'g' } = {}) {
   const escaped = escapeRegex(marker);
-  const actualMarker = isDouble ? `${escaped}{2}` : escaped;
+  let actualMarker = escaped;
+  if (isDouble) {
+    actualMarker = `${escaped}{2}`;
+  }
   return new RegExp(`${actualMarker}(.*?)${actualMarker}`, flags);
 }
 


### PR DESCRIPTION
## Summary
- remove ternary operator from `regexUtils.createPattern`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686426dcc864832eb9834fa09ce080b2