### PR TITLE
Fix lint warning and update tests

### DIFF
--- a/test/browser/createInputDropdownHandler.defaultOrder.test.js
+++ b/test/browser/createInputDropdownHandler.defaultOrder.test.js
@@ -10,9 +10,12 @@ test('createInputDropdownHandler hides before disabling text input', () => {
   const dom = {
     getCurrentTarget: jest.fn(() => select),
     getParentElement: jest.fn(() => container),
-    querySelector: jest.fn((_, selector) =>
-      selector === 'input[type="text"]' ? textInput : null
-    ),
+    querySelector: jest.fn((_, selector) => {
+      if (selector === 'input[type="text"]') {
+        return textInput;
+      }
+      return null;
+    }),
     getValue: jest.fn(() => 'unknown'),
     reveal: jest.fn(),
     enable: jest.fn(),

--- a/test/browser/tags.test.js
+++ b/test/browser/tags.test.js
@@ -130,7 +130,12 @@ describe('makeHandleHideSpan', () => {
       }),
       addClass: jest.fn(),
       appendChild: jest.fn(),
-      createTextNode: jest.fn(txt => (txt === ' (' ? textNode1 : textNode2)),
+      createTextNode: jest.fn(txt => {
+        if (txt === ' (') {
+          return textNode1;
+        }
+        return textNode2;
+      }),
       setTextContent: jest.fn(),
       addEventListener: jest.fn(),
       insertBefore: jest.fn(),

--- a/test/browser/toys.createDropdownInitializer.input.test.js
+++ b/test/browser/toys.createDropdownInitializer.input.test.js
@@ -10,10 +10,10 @@ describe('createDropdownInitializer input init', () => {
     const SELECT_INPUT = 'article.entry .value > select.input';
     const dom = {
       querySelectorAll: jest.fn(selector => {
-        const mapping = {
-          [SELECT_INPUT]: [dropdown],
-        };
-        return mapping[selector] || [];
+        if (selector === SELECT_INPUT) {
+          return [dropdown];
+        }
+        return [];
       }),
       addEventListener: jest.fn(),
     };


### PR DESCRIPTION
## Summary
- simplify querySelector mocks in dropdown handler tests
- remove ternary from tags tests
- adjust dropdown initializer test logic

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686429f03ad4832e9b8dd03463371c5e