### PR TITLE
Fix lint warning

### DIFF
--- a/test/browser/createInputDropdownHandler.randomMutantKill.test.js
+++ b/test/browser/createInputDropdownHandler.randomMutantKill.test.js
@@ -10,9 +10,12 @@ test('createInputDropdownHandler handles sequential text then unknown values', (
   const dom = {
     getCurrentTarget: jest.fn(() => select),
     getParentElement: jest.fn(() => container),
-    querySelector: jest.fn((_, selector) =>
-      selector === 'input[type="text"]' ? textInput : null
-    ),
+    querySelector: jest.fn((_, selector) => {
+      if (selector === 'input[type="text"]') {
+        return textInput;
+      }
+      return null;
+    }),
     getValue: jest
       .fn()
       .mockReturnValueOnce('text')


### PR DESCRIPTION
## Summary
- replace ternary in `createInputDropdownHandler.randomMutantKill.test.js`

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686429f002ac832e89b55b2a38538b06