### PR TITLE
Fix lint warning

### DIFF
--- a/test/browser/tags.test.js
+++ b/test/browser/tags.test.js
@@ -130,7 +130,12 @@ describe('makeHandleHideSpan', () => {
       }),
       addClass: jest.fn(),
       appendChild: jest.fn(),
-      createTextNode: jest.fn(txt => (txt === ' (' ? textNode1 : textNode2)),
+      createTextNode: jest.fn(txt => {
+        if (txt === ' (') {
+          return textNode1;
+        }
+        return textNode2;
+      }),
       setTextContent: jest.fn(),
       addEventListener: jest.fn(),
       insertBefore: jest.fn(),


### PR DESCRIPTION
## Summary
- refactor hide span test to remove ternary usage

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686429ef5268832eb911ff155a4c62a6