### PR TITLE
Fix lint warning

### DIFF
--- a/test/browser/setupButtonCleanup.test.js
+++ b/test/browser/setupButtonCleanup.test.js
@@ -41,7 +41,11 @@ describe('button cleanup helpers', () => {
     const dispose = disposers[0];
     dispose();
 
-    expect(dom.removeEventListener).toHaveBeenCalledWith(button, 'click', onAdd);
+    expect(dom.removeEventListener).toHaveBeenCalledWith(
+      button,
+      'click',
+      onAdd
+    );
   });
 
   it('setupRemoveButton disposer removes event listener', () => {
@@ -77,10 +81,7 @@ describe('button cleanup helpers', () => {
       }),
       removeEventListener: jest.fn((_, event, handler) => {
         if (event === 'click') {
-          const idx = handlers.indexOf(handler);
-          if (idx !== -1) {
-            handlers.splice(idx, 1);
-          }
+          handlers.splice(handlers.indexOf(handler) >>> 0, 1);
         }
       }),
     };

--- a/test/browser/toys.createDropdownInitializer.output.test.js
+++ b/test/browser/toys.createDropdownInitializer.output.test.js
@@ -5,15 +5,13 @@ describe('createDropdownInitializer output init', () => {
   it('handles existing output dropdowns', () => {
     const dropdown = { value: 'text' };
     const dom = {
-      querySelectorAll: jest.fn(selector => {
-        if (selector === 'article.entry .value > select.output') {
-          return [dropdown];
-        }
-        if (selector === 'article.entry .value > select.input') {
-          return [];
-        }
-        return [];
-      }),
+      querySelectorAll: jest.fn(
+        selector =>
+          ({
+            'article.entry .value > select.output': [dropdown],
+            'article.entry .value > select.input': [],
+          })[selector] || []
+      ),
       addEventListener: jest.fn(),
     };
     const onOutputChange = jest.fn();


### PR DESCRIPTION
## Summary
- reduce complexity in `setupButtonCleanup.test.js`
- simplify selector handling in `toys.createDropdownInitializer.output.test.js`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68642d45d368832eafba4ed8bf5d7e5f