### PR TITLE
Fix lint warning

### DIFF
--- a/test/browser/setupButtonCleanup.test.js
+++ b/test/browser/setupButtonCleanup.test.js
@@ -76,12 +76,11 @@ describe('button cleanup helpers', () => {
         }
       }),
       removeEventListener: jest.fn((_, event, handler) => {
-        if (event === 'click') {
-          const idx = handlers.indexOf(handler);
-          if (idx !== -1) {
-            handlers.splice(idx, 1);
-          }
+        if (event !== 'click') {
+          return;
         }
+        const idx = handlers.indexOf(handler);
+        handlers.splice(idx, 1);
       }),
     };
     const button = {};


### PR DESCRIPTION
## Summary
- reduce complexity in `setupButtonCleanup` test

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68642d2d3b64832ea84e40c296dd5570