### PR TITLE
Fix lint warning

### DIFF
--- a/test/browser/toys.createDropdownInitializer.output.test.js
+++ b/test/browser/toys.createDropdownInitializer.output.test.js
@@ -9,9 +9,6 @@ describe('createDropdownInitializer output init', () => {
         if (selector === 'article.entry .value > select.output') {
           return [dropdown];
         }
-        if (selector === 'article.entry .value > select.input') {
-          return [];
-        }
         return [];
       }),
       addEventListener: jest.fn(),


### PR DESCRIPTION
## Summary
- simplify querySelectorAll logic in dropdown initializer test

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68642d2bf16c832eaa36794852239605