### PR TITLE
Fix lint warning in setupButton tests

### DIFF
--- a/test/browser/setupButton.shared.test.js
+++ b/test/browser/setupButton.shared.test.js
@@ -8,14 +8,13 @@ describe.each([
   [
     'setupAddButton',
     setupAddButton,
-    (dom, button, rows, render, key, disposers) =>
-      setupAddButton(dom, button, rows, render, disposers),
+    (...params) =>
+      setupAddButton(params[0], params[1], params[2], params[3], params[5]),
   ],
   [
     'setupRemoveButton',
     setupRemoveButton,
-    (dom, button, rows, render, key, disposers) =>
-      setupRemoveButton(dom, button, rows, render, key, disposers),
+    (...params) => setupRemoveButton(...params),
   ],
 ])('%s common behaviour', (_name, _setup, invoke) => {
   let dom;


### PR DESCRIPTION
## Summary
- replace long parameter lists in setupButton.shared.test.js
- use rest params when invoking setup functions

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6864362ac3e0832e9334c2540a7b173f