### PR TITLE
Fix lint warning

### DIFF
--- a/test/browser/toys.createDropdownInitializer.input.test.js
+++ b/test/browser/toys.createDropdownInitializer.input.test.js
@@ -8,13 +8,9 @@ describe('createDropdownInitializer input init', () => {
     const dropdown = { value: 'dendrite-story' };
 
     const SELECT_INPUT = 'article.entry .value > select.input';
+    const dropdownMap = { [SELECT_INPUT]: [dropdown] };
     const dom = {
-      querySelectorAll: jest.fn(selector => {
-        if (selector === SELECT_INPUT) {
-          return [dropdown];
-        }
-        return [];
-      }),
+      querySelectorAll: jest.fn(selector => dropdownMap[selector] || []),
       addEventListener: jest.fn(),
     };
 


### PR DESCRIPTION
## Summary
- simplify dropdown initializer test to reduce arrow function complexity

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686436281e8c832e8f0ea4f58b198914