### PR TITLE
Fix ESLint complexity warning

### DIFF
--- a/test/browser/initializeInteractiveComponent.logInfo.test.js
+++ b/test/browser/initializeInteractiveComponent.logInfo.test.js
@@ -14,20 +14,13 @@ describe('initializeInteractiveComponent logging', () => {
     const outputSelect = {};
     const logInfo = jest.fn();
 
-    const querySelector = jest.fn((_, selector) => {
-      switch (selector) {
-      case 'input[type="text"]':
-        return inputElement;
-      case 'button[type="submit"]':
-        return submitButton;
-      case 'div.output':
-        return outputParent;
-      case 'select.output':
-        return outputSelect;
-      default:
-        return {};
-      }
-    });
+    const elements = {
+      'input[type="text"]': inputElement,
+      'button[type="submit"]': submitButton,
+      'div.output': outputParent,
+      'select.output': outputSelect,
+    };
+    const querySelector = jest.fn((_, selector) => elements[selector] || {});
 
     const dom = {
       removeAllChildren: jest.fn(),


### PR DESCRIPTION
## Summary
- simplify test `querySelector` helper using a lookup map

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864382feb10832eaf811be9e201ad67