### PR TITLE
Fix lint warning

### DIFF
--- a/src/utils/objectUtils.js
+++ b/src/utils/objectUtils.js
@@ -22,12 +22,8 @@ export function pick(obj, keys) {
  * @returns {Object} A new object with transformed values
  */
 export function mapValues(obj, fn) {
-  if (!obj || typeof obj !== 'object') {
-    return {};
-  }
-
-  return Object.entries(obj).reduce((result, [key, value]) => {
-    result[key] = fn(value, key);
-    return result;
-  }, {});
+  const source = Object(obj) === obj ? obj : {};
+  return Object.fromEntries(
+    Object.entries(source).map(([key, value]) => [key, fn(value, key)])
+  );
 }

--- a/test/browser/createInputDropdownHandler.mutant.test.js
+++ b/test/browser/createInputDropdownHandler.mutant.test.js
@@ -10,9 +10,12 @@ test('createInputDropdownHandler invokes visibility handlers', () => {
   const dom = {
     getCurrentTarget: jest.fn(() => select),
     getParentElement: jest.fn(() => container),
-    querySelector: jest.fn((_, selector) =>
-      selector === 'input[type="text"]' ? textInput : null
-    ),
+    querySelector: jest.fn((_, selector) => {
+      if (selector === 'input[type="text"]') {
+        return textInput;
+      }
+      return null;
+    }),
     getValue: jest.fn(() => 'text'),
     reveal: jest.fn(),
     enable: jest.fn(),


### PR DESCRIPTION
## Summary
- update mapValues to reduce cyclomatic complexity
- expand querySelector callback to avoid ternary

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6864382e8cf0832e965c65424b0cebd5