### PR TITLE
Fix lint no-ternary warning

### DIFF
--- a/test/browser/createInputDropdownHandler.sequenceAdditional.test.js
+++ b/test/browser/createInputDropdownHandler.sequenceAdditional.test.js
@@ -11,9 +11,12 @@ describe('createInputDropdownHandler sequential values', () => {
     const dom = {
       getCurrentTarget: jest.fn(() => select),
       getParentElement: jest.fn(() => container),
-      querySelector: jest.fn((_, selector) =>
-        selector === 'input[type="text"]' ? textInput : null
-      ),
+      querySelector: jest.fn((_, selector) => {
+        if (selector === 'input[type="text"]') {
+          return textInput;
+        }
+        return null;
+      }),
       getValue: jest
         .fn()
         .mockReturnValueOnce('text')


### PR DESCRIPTION
## Summary
- remove a ternary in `createInputDropdownHandler.sequenceAdditional.test.js`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686439a79b88832eb7f3dd3ad6dca937