### PR TITLE
Fix lint complexity warning

### DIFF
--- a/test/browser/initializeInteractiveComponent.keypress.test.js
+++ b/test/browser/initializeInteractiveComponent.keypress.test.js
@@ -12,24 +12,20 @@ describe('initializeInteractiveComponent keypress handling', () => {
     let keypressHandler;
 
     const dom = {
-      querySelector: jest.fn((_, selector) => {
-        switch (selector) {
-        case 'input[type="text"]':
-          return inputElement;
-        case 'button[type="submit"]':
-          return submitButton;
-        case 'div.output':
-          return outputParent;
-        case 'select.output':
-          return outputSelect;
-        default:
-          return {};
-        }
-      }),
+      querySelector: jest.fn((_, selector) => ({
+        'input[type="text"]': inputElement,
+        'button[type="submit"]': submitButton,
+        'div.output': outputParent,
+        'select.output': outputSelect,
+      }[selector] || {})),
       addEventListener: jest.fn((el, event, handler) => {
-        if (el === inputElement && event === 'keypress') {
-          keypressHandler = handler;
+        if (el !== inputElement) {
+          return;
         }
+        if (event !== 'keypress') {
+          return;
+        }
+        keypressHandler = handler;
       }),
       removeAllChildren: jest.fn(),
       createElement: jest.fn(() => ({ textContent: '' })),


### PR DESCRIPTION
## Summary
- simplify DOM stubs in the keypress handler test
- adjust event listener stub logic

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686439a722d0832e99e8f2f01397d0ba