### PR TITLE
Fix lint complexity issue

### DIFF
--- a/test/browser/initializeInteractiveComponent.keypress.test.js
+++ b/test/browser/initializeInteractiveComponent.keypress.test.js
@@ -12,20 +12,12 @@ describe('initializeInteractiveComponent keypress handling', () => {
     let keypressHandler;
 
     const dom = {
-      querySelector: jest.fn((_, selector) => {
-        switch (selector) {
-        case 'input[type="text"]':
-          return inputElement;
-        case 'button[type="submit"]':
-          return submitButton;
-        case 'div.output':
-          return outputParent;
-        case 'select.output':
-          return outputSelect;
-        default:
-          return {};
-        }
-      }),
+      querySelector: jest.fn((_, selector) => ({
+        'input[type="text"]': inputElement,
+        'button[type="submit"]': submitButton,
+        'div.output': outputParent,
+        'select.output': outputSelect,
+      }[selector] || {})),
       addEventListener: jest.fn((el, event, handler) => {
         if (el === inputElement && event === 'keypress') {
           keypressHandler = handler;


### PR DESCRIPTION
## Summary
- refactor dom lookup in keypress test to use object map

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686439becb48832eb7f83fc8e18125bb