### PR TITLE
Fix lint warning

### DIFF
--- a/src/generator/generator.js
+++ b/src/generator/generator.js
@@ -885,18 +885,24 @@ const INPUT_METHODS = ['text', 'number', 'kv', 'dendrite-story'];
  * @param {string} defaultMethod - The configured default input method
  * @returns {string} - HTML for the dropdown and text input
  */
-function buildToyInputDropdown(defaultMethod) {
-  let selectedMethod;
+function getSelectedMethod(defaultMethod) {
   if (defaultMethod && defaultMethod !== 'text') {
-    selectedMethod = defaultMethod;
+    return defaultMethod;
   }
-  const options = INPUT_METHODS.map(method => {
-    let selected = '';
-    if (method === selectedMethod) {
-      selected = ' selected';
-    }
-    return `<option value="${method}"${selected}>${method}</option>`;
-  }).join('');
+  return undefined;
+}
+
+function buildOption(method, selectedMethod) {
+  let selected = '';
+  if (method === selectedMethod) {
+    selected = ' selected';
+  }
+  return `<option value="${method}"${selected}>${method}</option>`;
+}
+
+function buildToyInputDropdown(defaultMethod) {
+  const selectedMethod = getSelectedMethod(defaultMethod);
+  const options = INPUT_METHODS.map(method => buildOption(method, selectedMethod)).join('');
   return `<select class="input">${options}</select><input type="text" disabled>`;
 }
 

--- a/test/browser/createDispose.export.test.js
+++ b/test/browser/createDispose.export.test.js
@@ -3,9 +3,9 @@ import { describe, it, expect } from '@jest/globals';
 // Import the module within the test to ensure coverage of the export line
 
 describe('createDispose export', () => {
-  it('is a function that expects four parameters', async () => {
+  it('is a function that expects one parameter', async () => {
     const { createDispose } = await import('../../src/browser/toys.js');
     expect(typeof createDispose).toBe('function');
-    expect(createDispose.length).toBe(4);
+    expect(createDispose.length).toBe(1);
   });
 });

--- a/test/browser/createDispose.instance.test.js
+++ b/test/browser/createDispose.instance.test.js
@@ -9,8 +9,8 @@ describe('createDispose instances', () => {
     const rows1 = ['a'];
     const rows2 = ['b'];
 
-    const first = createDispose([], dom, container1, rows1);
-    const second = createDispose([], dom, container2, rows2);
+    const first = createDispose({ disposers: [], dom, container: container1, rows: rows1 });
+    const second = createDispose({ disposers: [], dom, container: container2, rows: rows2 });
 
     expect(typeof first).toBe('function');
     expect(typeof second).toBe('function');

--- a/test/browser/toys.createDispose.test.js
+++ b/test/browser/toys.createDispose.test.js
@@ -3,8 +3,8 @@ import { createDispose } from '../../src/browser/toys.js';
 
 describe('createDispose', () => {
   it('can be called and disposed', () => {
-    // Verify the factory function expects four parameters
-    expect(createDispose.length).toBe(4);
+    // Verify the factory function expects one parameter
+    expect(createDispose.length).toBe(1);
     // Mock the required parameters
     const disposer = jest.fn();
     const disposers = [disposer];
@@ -15,7 +15,7 @@ describe('createDispose', () => {
     const rows = ['row'];
 
     // Create and call dispose
-    const dispose = createDispose(disposers, dom, container, rows);
+    const dispose = createDispose({ disposers, dom, container, rows });
 
     // Ensure a function was returned
     expect(typeof dispose).toBe('function');
@@ -30,7 +30,7 @@ describe('createDispose', () => {
   });
 
   it('clears all registered disposers', () => {
-    expect(createDispose.length).toBe(4);
+    expect(createDispose.length).toBe(1);
     const disposer1 = jest.fn();
     const disposer2 = jest.fn();
     const disposers = [disposer1, disposer2];
@@ -40,7 +40,7 @@ describe('createDispose', () => {
     const container = {};
     const rows = ['a', 'b'];
 
-    const dispose = createDispose(disposers, dom, container, rows);
+    const dispose = createDispose({ disposers, dom, container, rows });
     expect(typeof dispose).toBe('function');
 
     dispose();
@@ -61,7 +61,7 @@ describe('createDispose', () => {
     const container = {};
     const rows = ['x'];
 
-    const dispose = createDispose(disposers, dom, container, rows);
+    const dispose = createDispose({ disposers, dom, container, rows });
 
     expect(() => dispose()).not.toThrow();
     expect(() => dispose()).not.toThrow();
@@ -79,7 +79,7 @@ describe('createDispose', () => {
     const container = {};
     const rows = [];
 
-    const dispose = createDispose(disposers, dom, container, rows);
+    const dispose = createDispose({ disposers, dom, container, rows });
     expect(typeof dispose).toBe('function');
     expect(dispose.length).toBe(0);
 
@@ -94,7 +94,7 @@ describe('createDispose', () => {
     // scenario: array has an existing row
     const dom1 = { removeAllChildren: jest.fn() };
     const rows1 = ['x'];
-    const dispose1 = createDispose([], dom1, container, rows1);
+    const dispose1 = createDispose({ disposers: [], dom: dom1, container, rows: rows1 });
     expect(() => dispose1()).not.toThrow();
     expect(dom1.removeAllChildren).toHaveBeenCalledWith(container);
     expect(rows1).toHaveLength(0);
@@ -102,7 +102,7 @@ describe('createDispose', () => {
     // scenario: array already empty
     const dom2 = { removeAllChildren: jest.fn() };
     const rows2 = [];
-    const dispose2 = createDispose([], dom2, container, rows2);
+    const dispose2 = createDispose({ disposers: [], dom: dom2, container, rows: rows2 });
     expect(typeof dispose2).toBe('function');
     expect(() => dispose2()).not.toThrow();
     expect(dom2.removeAllChildren).toHaveBeenCalledWith(container);


### PR DESCRIPTION
## Summary
- refactor `createDispose` to use an options object
- simplify input dropdown building helpers
- split key-value array parsing into small helpers
- update tests for the new dispose API

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686439a7d594832ea894a7c046260711