### PR TITLE
Fix lint warning

### DIFF
--- a/test/browser/data.test.js
+++ b/test/browser/data.test.js
@@ -526,10 +526,7 @@ describe('getData, setData, and getDeepStateCopy', () => {
       typeof btoa !== 'undefined'
         ? btoa
         : str => Buffer.from(str, 'binary').toString('base64');
-    const encodeURIComponentFn =
-      typeof encodeURIComponent !== 'undefined'
-        ? encodeURIComponent
-        : encodeURIComponent;
+    const encodeURIComponentFn = encodeURIComponent;
     const encodeBase64 = getEncodeBase64(btoaFn, encodeURIComponentFn);
     const input = 'hello world!';
     expect(encodeBase64(input)).toBe('aGVsbG8gd29ybGQh');


### PR DESCRIPTION
## Summary
- remove ternary from `data.test.js` to satisfy no-ternary rule

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68643ac9c918832eb57d0ee1a286c307