### PR TITLE
Fix lint warning

### DIFF
--- a/test/browser/createInputDropdownHandler.textOnly.mutant.test.js
+++ b/test/browser/createInputDropdownHandler.textOnly.mutant.test.js
@@ -10,9 +10,12 @@ test('createInputDropdownHandler shows text input when value is "text"', () => {
   const dom = {
     getCurrentTarget: jest.fn(() => select),
     getParentElement: jest.fn(() => container),
-    querySelector: jest.fn((_, selector) =>
-      selector === 'input[type="text"]' ? textInput : null
-    ),
+    querySelector: jest.fn((_, selector) => {
+      if (selector === 'input[type="text"]') {
+        return textInput;
+      }
+      return null;
+    }),
     getValue: jest.fn(() => 'text'),
     reveal: jest.fn(),
     enable: jest.fn(),


### PR DESCRIPTION
## Summary
- remove ternary operator from `createInputDropdownHandler.textOnly.mutant.test.js`

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68643b181748832e92bac8636f5a9d5b