### PR TITLE
Fix lint warning and update tests

### DIFF
--- a/src/browser/toys.js
+++ b/src/browser/toys.js
@@ -12,16 +12,19 @@ import { createPrefixedLoggers } from './document.js';
  * @param {Array<{key: string, value: any}>} array - The array to convert
  * @returns {Object} An object with keys and values from the array
  */
+const toKeyValueEntry = pair => {
+  if (pair && typeof pair === 'object' && 'key' in pair) {
+    return [pair.key, pair.value ?? ''];
+  }
+  return null;
+};
+
 export const convertArrayToKeyValueObject = array => {
   if (!Array.isArray(array)) {
     return {};
   }
-  return array.reduce((obj, pair) => {
-    if (pair && typeof pair === 'object' && 'key' in pair) {
-      obj[pair.key] = pair.value ?? '';
-    }
-    return obj;
-  }, {});
+  const entries = array.map(toKeyValueEntry).filter(Boolean);
+  return Object.fromEntries(entries);
 };
 
 export const parseExistingRows = (dom, inputElement) => {

--- a/test/browser/data.test.js
+++ b/test/browser/data.test.js
@@ -364,7 +364,7 @@ describe('getData, setData, and getDeepStateCopy', () => {
 
     setData(
       { desired: incomingState, current: state },
-      { logInfo: logFn, logError: errorFn },
+      { logInfo: logFn, logError: errorFn }
     );
 
     expect(state.blogStatus).toBe('loaded');
@@ -379,20 +379,24 @@ describe('getData, setData, and getDeepStateCopy', () => {
         { desired: {}, current: state },
         { logInfo: logFn, logError: errorFn }
       )
-    ).toThrow("setData requires an object with at least a 'temporary' property.");
+    ).toThrow(
+      "setData requires an object with at least a 'temporary' property."
+    );
     expect(errorFn).toHaveBeenCalledWith(
       'setData received invalid data structure:',
       {}
     );
   });
 
-  it("setData throws a descriptive error when blog data is missing", () => {
+  it('setData throws a descriptive error when blog data is missing', () => {
     expect(() =>
       setData(
         { desired: {}, current: state },
         { logInfo: logFn, logError: errorFn }
       )
-    ).toThrow("setData requires an object with at least a 'temporary' property.");
+    ).toThrow(
+      "setData requires an object with at least a 'temporary' property."
+    );
   });
 
   it('setData throws and logs error if incoming state is object but lacks temporary property', () => {
@@ -522,14 +526,18 @@ describe('getData, setData, and getDeepStateCopy', () => {
   });
 
   it('getEncodeBase64 returns a function that encodes to base64 using provided helpers', () => {
-    const btoaFn =
-      typeof btoa !== 'undefined'
-        ? btoa
-        : str => Buffer.from(str, 'binary').toString('base64');
-    const encodeURIComponentFn =
-      typeof encodeURIComponent !== 'undefined'
-        ? encodeURIComponent
-        : encodeURIComponent;
+    let btoaFn;
+    if (typeof btoa !== 'undefined') {
+      btoaFn = btoa;
+    } else {
+      btoaFn = str => Buffer.from(str, 'binary').toString('base64');
+    }
+    let encodeURIComponentFn;
+    if (typeof encodeURIComponent !== 'undefined') {
+      encodeURIComponentFn = encodeURIComponent;
+    } else {
+      encodeURIComponentFn = encodeURIComponent;
+    }
     const encodeBase64 = getEncodeBase64(btoaFn, encodeURIComponentFn);
     const input = 'hello world!';
     expect(encodeBase64(input)).toBe('aGVsbG8gd29ybGQh');


### PR DESCRIPTION
## Summary
- refactor `convertArrayToKeyValueObject` to reduce complexity
- avoid ternary operators in `data.test.js`

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68643b185764832e8ed50ffae7ef7a6d