### PR TITLE
Fix lint warning in value input handler

### DIFF
--- a/public/browser/toys.js
+++ b/public/browser/toys.js
@@ -555,13 +555,13 @@ export function createKeyInputHandler(
  * @param {Function} syncHiddenField - Function to sync the hidden field with current state
  * @returns {Function} The event handler function
  */
-export function createValueInputHandler(
+export function createValueInputHandler({
   dom,
   keyEl,
   textInput,
   rows,
-  syncHiddenField
-) {
+  syncHiddenField,
+}) {
   return e => {
     const rowKey = dom.getDataAttribute(keyEl, 'prevKey'); // may have changed via onKey
     rows[rowKey] = dom.getTargetValue(e);
@@ -634,13 +634,13 @@ export const createValueElement = (
   dom.setPlaceholder(valueEl, 'Value');
   dom.setValue(valueEl, value);
 
-  const onValue = createValueInputHandler(
+  const onValue = createValueInputHandler({
     dom,
     keyEl,
     textInput,
     rows,
-    syncHiddenField
-  );
+    syncHiddenField,
+  });
   dom.addEventListener(valueEl, 'input', onValue);
   const removeValueListener = createRemoveValueListener(dom, valueEl, onValue);
   disposers.push(removeValueListener);
@@ -754,44 +754,44 @@ export const createKeyValueRow =
     render,
     container
   ) =>
-    ([key, value], idx) => {
-      const rowEl = dom.createElement('div');
-      dom.setClassName(rowEl, 'kv-row');
+  ([key, value], idx) => {
+    const rowEl = dom.createElement('div');
+    dom.setClassName(rowEl, 'kv-row');
 
-      // Create key and value elements
-      const keyEl = createKeyElement(
-        dom,
-        key,
-        textInput,
-        rows,
-        syncHiddenField,
-        disposers
-      );
-      const valueEl = createValueElement(
-        dom,
-        value,
-        keyEl,
-        textInput,
-        rows,
-        syncHiddenField,
-        disposers
-      );
+    // Create key and value elements
+    const keyEl = createKeyElement(
+      dom,
+      key,
+      textInput,
+      rows,
+      syncHiddenField,
+      disposers
+    );
+    const valueEl = createValueElement(
+      dom,
+      value,
+      keyEl,
+      textInput,
+      rows,
+      syncHiddenField,
+      disposers
+    );
 
-      // Create and set up the appropriate button type
-      const btnEl = createButton(
-        dom,
-        idx === entries.length - 1,
-        rows,
-        render,
-        key,
-        disposers
-      );
+    // Create and set up the appropriate button type
+    const btnEl = createButton(
+      dom,
+      idx === entries.length - 1,
+      rows,
+      render,
+      key,
+      disposers
+    );
 
-      dom.appendChild(rowEl, keyEl);
-      dom.appendChild(rowEl, valueEl);
-      dom.appendChild(rowEl, btnEl);
-      dom.appendChild(container, rowEl);
-    };
+    dom.appendChild(rowEl, keyEl);
+    dom.appendChild(rowEl, valueEl);
+    dom.appendChild(rowEl, btnEl);
+    dom.appendChild(container, rowEl);
+  };
 
 const createButton = (dom, isAddButton, rows, render, key, disposers) => {
   const button = dom.createElement('button');

--- a/src/browser/toys.js
+++ b/src/browser/toys.js
@@ -65,11 +65,13 @@ export const clearDisposers = disposersArray => {
  * @param {Array} rows - The rows array to clear
  * @returns {Function} A function that cleans up resources
  */
-export const createDispose = ({ disposers, dom, container, rows }) => () => {
-  clearDisposers(disposers);
-  dom.removeAllChildren(container);
-  rows.length = 0;
-};
+export const createDispose =
+  ({ disposers, dom, container, rows }) =>
+    () => {
+      clearDisposers(disposers);
+      dom.removeAllChildren(container);
+      rows.length = 0;
+    };
 
 import { createPreElement } from '../presenters/pre.js';
 import { createTicTacToeBoardElement } from '../presenters/ticTacToeBoard.js';
@@ -559,13 +561,13 @@ export function createKeyInputHandler(
  * @param {Function} syncHiddenField - Function to sync the hidden field with current state
  * @returns {Function} The event handler function
  */
-export function createValueInputHandler(
+export function createValueInputHandler({
   dom,
   keyEl,
   textInput,
   rows,
-  syncHiddenField
-) {
+  syncHiddenField,
+}) {
   return e => {
     const rowKey = dom.getDataAttribute(keyEl, 'prevKey'); // may have changed via onKey
     rows[rowKey] = dom.getTargetValue(e);
@@ -638,13 +640,13 @@ export const createValueElement = (
   dom.setPlaceholder(valueEl, 'Value');
   dom.setValue(valueEl, value);
 
-  const onValue = createValueInputHandler(
+  const onValue = createValueInputHandler({
     dom,
     keyEl,
     textInput,
     rows,
-    syncHiddenField
-  );
+    syncHiddenField,
+  });
   dom.addEventListener(valueEl, 'input', onValue);
   const removeValueListener = createRemoveValueListener(dom, valueEl, onValue);
   disposers.push(removeValueListener);

--- a/test/browser/toys.createValueInputHandler.test.js
+++ b/test/browser/toys.createValueInputHandler.test.js
@@ -15,7 +15,7 @@ describe('createValueInputHandler', () => {
     // Mock DOM utilities
     dom = {
       getDataAttribute: jest.fn(),
-      getTargetValue: jest.fn(() => 'newValue')
+      getTargetValue: jest.fn(() => 'newValue'),
     };
 
     // Mock elements
@@ -25,14 +25,20 @@ describe('createValueInputHandler', () => {
     // Initial rows state
     rows = {
       existingKey: 'oldValue',
-      anotherKey: 'anotherValue'
+      anotherKey: 'anotherValue',
     };
 
     // Mock sync function
     syncHiddenField = jest.fn();
 
     // Create the handler
-    handler = createValueInputHandler(dom, keyEl, textInput, rows, syncHiddenField);
+    handler = createValueInputHandler({
+      dom,
+      keyEl,
+      textInput,
+      rows,
+      syncHiddenField,
+    });
 
     // Mock event
     event = { target: { value: 'newValue' } };
@@ -49,7 +55,7 @@ describe('createValueInputHandler', () => {
     // Assert
     expect(rows).toEqual({
       existingKey: 'newValue',
-      anotherKey: 'anotherValue'
+      anotherKey: 'anotherValue',
     });
     expect(syncHiddenField).toHaveBeenCalledWith(textInput, rows, dom);
   });
@@ -66,7 +72,7 @@ describe('createValueInputHandler', () => {
     // Assert
     expect(rows).toEqual({
       existingKey: 'oldValue',
-      anotherKey: 'updatedAnotherValue'
+      anotherKey: 'updatedAnotherValue',
     });
     expect(syncHiddenField).toHaveBeenCalledWith(textInput, rows, dom);
   });
@@ -83,7 +89,7 @@ describe('createValueInputHandler', () => {
     // Assert
     expect(rows).toEqual({
       existingKey: '',
-      anotherKey: 'anotherValue'
+      anotherKey: 'anotherValue',
     });
     expect(syncHiddenField).toHaveBeenCalledWith(textInput, rows, dom);
   });
@@ -111,7 +117,7 @@ describe('createValueInputHandler', () => {
     expect(rows).toEqual({
       existingKey: 'oldValue',
       anotherKey: 'anotherValue',
-      nonExistentKey: 'newValue'
+      nonExistentKey: 'newValue',
     });
     expect(syncHiddenField).toHaveBeenCalledWith(textInput, rows, dom);
   });


### PR DESCRIPTION
## Summary
- refactor `createValueInputHandler` to take a single options object
- update usage in `toys.js` and regenerate public version
- adjust unit test for new function signature

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68643bea39d0832ebdb3d51f989b5105