### PR TITLE
Fix lint warning

### DIFF
--- a/test/browser/createInputDropdownHandler.sequentialValues.test.js
+++ b/test/browser/createInputDropdownHandler.sequentialValues.test.js
@@ -10,7 +10,12 @@ test('createInputDropdownHandler handles text, unknown, then text', () => {
   const dom = {
     getCurrentTarget: jest.fn(() => select),
     getParentElement: jest.fn(() => container),
-    querySelector: jest.fn((_, selector) => (selector === 'input[type="text"]' ? textInput : null)),
+    querySelector: jest.fn((_, selector) => {
+      if (selector === 'input[type="text"]') {
+        return textInput;
+      }
+      return null;
+    }),
     getValue: jest
       .fn()
       .mockReturnValueOnce('text')


### PR DESCRIPTION
## Summary
- remove a ternary expression from `createInputDropdownHandler.sequentialValues.test.js`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68643c707df0832e8c08b70953dafe5d