### PR TITLE
Fix lint warning in createKeyElement

### DIFF
--- a/src/browser/toys.js
+++ b/src/browser/toys.js
@@ -577,22 +577,23 @@ export function createValueInputHandler({
 
 /**
  * Creates a key input element with event listeners
- * @param {Object} dom - The DOM utilities object
- * @param {string} key - The initial key value
- * @param {HTMLElement} textInput - The hidden text input element
- * @param {Object} rows - The rows object containing key-value pairs
- * @param {Function} syncHiddenField - Function to sync the hidden field with current state
- * @param {Array<Function>} disposers - Array to store cleanup functions
+ * @param {Object} options - Function options
+ * @param {Object} options.dom - The DOM utilities object
+ * @param {string} options.key - The initial key value
+ * @param {HTMLElement} options.textInput - The hidden text input element
+ * @param {Object} options.rows - The rows object containing key-value pairs
+ * @param {Function} options.syncHiddenField - Function to sync the hidden field with current state
+ * @param {Array<Function>} options.disposers - Array to store cleanup functions
  * @returns {HTMLInputElement} The created key input element
  */
-export const createKeyElement = (
+export const createKeyElement = ({
   dom,
   key,
   textInput,
   rows,
   syncHiddenField,
-  disposers
-) => {
+  disposers,
+}) => {
   const keyEl = dom.createElement('input');
   dom.setType(keyEl, 'text');
   dom.setPlaceholder(keyEl, 'Key');
@@ -765,14 +766,14 @@ export const createKeyValueRow =
       dom.setClassName(rowEl, 'kv-row');
 
       // Create key and value elements
-      const keyEl = createKeyElement(
+      const keyEl = createKeyElement({
         dom,
         key,
         textInput,
         rows,
         syncHiddenField,
-        disposers
-      );
+        disposers,
+      });
       const valueEl = createValueElement(
         dom,
         value,

--- a/test/browser/toys.createKeyElement.test.js
+++ b/test/browser/toys.createKeyElement.test.js
@@ -28,14 +28,14 @@ describe('createKeyElement', () => {
   it('creates a key input element with the correct initial properties', () => {
     const key = 'testKey';
 
-    keyEl = createKeyElement(
-      mockDom,
+    keyEl = createKeyElement({
+      dom: mockDom,
       key,
       textInput,
       rows,
       syncHiddenField,
-      disposers
-    );
+      disposers,
+    });
 
     expect(mockDom.createElement).toHaveBeenCalledWith('input');
     expect(mockDom.setType).toHaveBeenCalledWith(keyEl, 'text');
@@ -67,14 +67,14 @@ describe('createKeyElement', () => {
   it('removes the same listener that was added', () => {
     const key = 'testKey';
 
-    keyEl = createKeyElement(
-      mockDom,
+    keyEl = createKeyElement({
+      dom: mockDom,
       key,
       textInput,
       rows,
       syncHiddenField,
-      disposers
-    );
+      disposers,
+    });
 
     const handler = mockDom.addEventListener.mock.calls[0][2];
     const disposer = disposers[0];
@@ -91,14 +91,14 @@ describe('createKeyElement', () => {
   it('calls removeEventListener each time the disposer runs', () => {
     const key = 'testKey';
 
-    keyEl = createKeyElement(
-      mockDom,
+    keyEl = createKeyElement({
+      dom: mockDom,
       key,
       textInput,
       rows,
       syncHiddenField,
-      disposers
-    );
+      disposers,
+    });
 
     const disposer = disposers[0];
 


### PR DESCRIPTION
## Summary
- reduce parameter count for `createKeyElement`
- update tests for new API

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68643d86fa94832ea8de0f2ee1abc028