### PR TITLE
Fix lint complexity warning

### DIFF
--- a/src/utils/objectUtils.js
+++ b/src/utils/objectUtils.js
@@ -22,11 +22,11 @@ export function pick(obj, keys) {
  * @returns {Object} A new object with transformed values
  */
 export function mapValues(obj, fn) {
-  if (Object(obj) !== obj) {
-    return {};
+  let source = {};
+  if (Object(obj) === obj) {
+    source = obj;
   }
-
   return Object.fromEntries(
-    Object.entries(obj).map(([key, value]) => [key, fn(value, key)])
+    Object.entries(source).map(([key, value]) => [key, fn(value, key)])
   );
 }


### PR DESCRIPTION
## Summary
- refactor `mapValues` in `objectUtils.js` to reduce complexity

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686440be9ef8832e921596dbf2910f8e