### PR TITLE
Fix lint complexity warning

### DIFF
--- a/test/browser/createInputDropdownHandler.cleanupDefault.test.js
+++ b/test/browser/createInputDropdownHandler.cleanupDefault.test.js
@@ -14,16 +14,12 @@ describe('createInputDropdownHandler cleanup default', () => {
       getCurrentTarget: jest.fn(() => select),
       getParentElement: jest.fn(() => container),
       querySelector: jest.fn((parent, selector) => {
-        if (selector === 'input[type="text"]') {
-          return textInput;
-        }
-        if (selector === 'input[type="number"]') {
-          return numberInput;
-        }
-        if (selector === '.kv-container') {
-          return kvContainer;
-        }
-        return null;
+        const map = {
+          'input[type="text"]': textInput,
+          'input[type="number"]': numberInput,
+          '.kv-container': kvContainer,
+        };
+        return map[selector] ?? null;
       }),
       createElement: jest.fn(() => ({})),
       setType: jest.fn(),


### PR DESCRIPTION
## Summary
- simplify DOM selector stubs in cleanup default test

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686440bec710832ead6cc5caa127270b