### PR TITLE
Fix lint warning in setupAddButton

### DIFF
--- a/src/browser/toys.js
+++ b/src/browser/toys.js
@@ -692,7 +692,7 @@ export const createOnRemove = (rows, render, key) => e => {
  * @param {Function} render - The render function to update the UI
  * @param {Array} disposers - Array to store cleanup functions
  */
-export const setupAddButton = (dom, button, rows, render, disposers) => {
+export const setupAddButton = ({ dom, button, rows, render, disposers }) => {
   dom.setTextContent(button, '+');
   const onAdd = createOnAddHandler(rows, render);
   dom.addEventListener(button, 'click', onAdd);
@@ -806,7 +806,7 @@ const createButton = ({ dom, isAddButton, rows, render, key, disposers }) => {
   dom.setType(button, 'button');
 
   if (isAddButton) {
-    setupAddButton(dom, button, rows, render, disposers);
+    setupAddButton({ dom, button, rows, render, disposers });
   } else {
     setupRemoveButton(dom, button, rows, render, key, disposers);
   }

--- a/test/browser/createRemoveAddListener.direct.test.js
+++ b/test/browser/createRemoveAddListener.direct.test.js
@@ -12,7 +12,7 @@ test('createRemoveAddListener returns disposer that removes click handler', () =
   const render = jest.fn();
   const disposers = [];
 
-  setupAddButton(dom, btn, rows, render, disposers);
+  setupAddButton({ dom, button: btn, rows, render, disposers });
 
   expect(disposers).toHaveLength(1);
   const dispose = disposers[0];

--- a/test/browser/createRemoveAddListener.handlerUse.test.js
+++ b/test/browser/createRemoveAddListener.handlerUse.test.js
@@ -12,7 +12,7 @@ test('setupAddButton disposer removes the exact click handler after invocation',
   const render = jest.fn();
   const disposers = [];
 
-  setupAddButton(dom, btn, rows, render, disposers);
+  setupAddButton({ dom, button: btn, rows, render, disposers });
 
   expect(disposers).toHaveLength(1);
   const dispose = disposers[0];

--- a/test/browser/createRemoveAddListener.unique.test.js
+++ b/test/browser/createRemoveAddListener.unique.test.js
@@ -13,11 +13,11 @@ describe('createRemoveAddListener unique disposers', () => {
     const disposers = [];
 
     const btnA = {};
-    setupAddButton(dom, btnA, rows, render, disposers);
+    setupAddButton({ dom, button: btnA, rows, render, disposers });
     const disposeA = disposers.pop();
 
     const btnB = {};
-    setupAddButton(dom, btnB, rows, render, disposers);
+    setupAddButton({ dom, button: btnB, rows, render, disposers });
     const disposeB = disposers.pop();
 
     expect(typeof disposeA).toBe('function');

--- a/test/browser/setupButton.shared.test.js
+++ b/test/browser/setupButton.shared.test.js
@@ -9,7 +9,13 @@ describe.each([
     'setupAddButton',
     setupAddButton,
     (...params) =>
-      setupAddButton(params[0], params[1], params[2], params[3], params[5]),
+      setupAddButton({
+        dom: params[0],
+        button: params[1],
+        rows: params[2],
+        render: params[3],
+        disposers: params[5],
+      }),
   ],
   [
     'setupRemoveButton',

--- a/test/browser/setupButtonCleanup.test.js
+++ b/test/browser/setupButtonCleanup.test.js
@@ -12,7 +12,7 @@ describe('button cleanup helpers', () => {
     const rows = {};
     const render = jest.fn();
     const disposers = [];
-    setupAddButton(dom, button, rows, render, disposers);
+    setupAddButton({ dom, button, rows, render, disposers });
     expect(disposers).toHaveLength(1);
     const dispose = disposers[0];
     expect(typeof dispose).toBe('function');
@@ -35,7 +35,7 @@ describe('button cleanup helpers', () => {
     const render = jest.fn();
     const disposers = [];
 
-    setupAddButton(dom, button, rows, render, disposers);
+    setupAddButton({ dom, button, rows, render, disposers });
 
     const [, , onAdd] = dom.addEventListener.mock.calls[0];
     const dispose = disposers[0];
@@ -79,7 +79,7 @@ describe('button cleanup helpers', () => {
           handlers.push(handler);
         }
       }),
-      // eslint-disable-next-line complexity
+
       removeEventListener: jest.fn((_, event, handler) => {
         if (event === 'click') {
           handlers.splice(handlers.indexOf(handler) >>> 0, 1);
@@ -91,7 +91,7 @@ describe('button cleanup helpers', () => {
     const render = jest.fn();
     const disposers = [];
 
-    setupAddButton(dom, button, rows, render, disposers);
+    setupAddButton({ dom, button, rows, render, disposers });
 
     // Capture the click handler
     const clickHandler = handlers[0];
@@ -127,7 +127,7 @@ describe('button cleanup helpers', () => {
     const render = jest.fn();
     const disposers = [];
 
-    setupAddButton(dom, button, rows, render, disposers);
+    setupAddButton({ dom, button, rows, render, disposers });
 
     const dispose = disposers[0];
     dispose();

--- a/test/browser/toys.setupAddButton.test.js
+++ b/test/browser/toys.setupAddButton.test.js
@@ -23,7 +23,7 @@ describe('setupAddButton', () => {
   });
 
   it('sets the button text content to "+"', () => {
-    setupAddButton(mockDom, button, rows, render, disposers);
+    setupAddButton({ dom: mockDom, button, rows, render, disposers });
 
     expect(mockDom.setTextContent).toHaveBeenCalledWith(button, '+');
   });
@@ -37,7 +37,7 @@ describe('setupAddButton', () => {
       }
     });
 
-    setupAddButton(mockDom, button, rows, render, disposers);
+    setupAddButton({ dom: mockDom, button, rows, render, disposers });
 
     // Simulate button click
     clickHandler();
@@ -62,7 +62,7 @@ describe('setupAddButton', () => {
       }
     });
 
-    setupAddButton(mockDom, button, rows, render, disposers);
+    setupAddButton({ dom: mockDom, button, rows, render, disposers });
 
     // Simulate button click
     clickHandler();
@@ -75,10 +75,10 @@ describe('setupAddButton', () => {
   });
 
   it('returns a unique disposer for each setup call', () => {
-    setupAddButton(mockDom, button, rows, render, disposers);
+    setupAddButton({ dom: mockDom, button, rows, render, disposers });
     const firstCleanup = disposers[0];
 
-    setupAddButton(mockDom, {}, rows, render, disposers);
+    setupAddButton({ dom: mockDom, button: {}, rows, render, disposers });
     const secondCleanup = disposers[1];
 
     expect(firstCleanup).not.toBe(secondCleanup);


### PR DESCRIPTION
## Summary
- refactor `setupAddButton` to accept a single options object
- update internal usage and tests for the new signature

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686440bf2a90832e9d913a2ed2c00bc9