### PR TITLE
Fix lint warning

### DIFF
--- a/test/browser/initializeInteractiveComponent.missingElements.test.js
+++ b/test/browser/initializeInteractiveComponent.missingElements.test.js
@@ -43,11 +43,12 @@ describe('initializeInteractiveComponent missing elements', () => {
     const button = {};
     const dom = {
       querySelector: jest.fn((_, selector) => {
-        if (selector === 'input[type="text"]') {
-          return null;
-        }
-        if (selector === 'button[type="submit"]') {
-          return button;
+        const elements = {
+          'input[type="text"]': null,
+          'button[type="submit"]': button,
+        };
+        if (Object.prototype.hasOwnProperty.call(elements, selector)) {
+          return elements[selector];
         }
         return {};
       }),
@@ -89,11 +90,12 @@ describe('initializeInteractiveComponent missing elements', () => {
     const input = {};
     const dom = {
       querySelector: jest.fn((_, selector) => {
-        if (selector === 'input[type="text"]') {
-          return input;
-        }
-        if (selector === 'button[type="submit"]') {
-          return null;
+        const elements = {
+          'input[type="text"]': input,
+          'button[type="submit"]': null,
+        };
+        if (Object.prototype.hasOwnProperty.call(elements, selector)) {
+          return elements[selector];
         }
         return {};
       }),


### PR DESCRIPTION
## Summary
- remove complexity disable comments
- use selector maps in missing elements tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68643d2a4f24832eb19a6ab7623df57c