### PR TITLE
Fix lint complexity warning in mapValues

### DIFF
--- a/src/utils/objectUtils.js
+++ b/src/utils/objectUtils.js
@@ -21,12 +21,15 @@ export function pick(obj, keys) {
  * @param {Function} fn - The transformation function
  * @returns {Object} A new object with transformed values
  */
-export function mapValues(obj, fn) {
-  let source = {};
-  if (Object(obj) === obj) {
-    source = obj;
-  }
+function transformEntries(source, fn) {
   return Object.fromEntries(
     Object.entries(source).map(([key, value]) => [key, fn(value, key)])
   );
+}
+
+export function mapValues(obj, fn) {
+  if (Object(obj) !== obj) {
+    return {};
+  }
+  return transformEntries(obj, fn);
 }

--- a/test/browser/setupButtonCleanup.test.js
+++ b/test/browser/setupButtonCleanup.test.js
@@ -79,7 +79,7 @@ describe('button cleanup helpers', () => {
           handlers.push(handler);
         }
       }),
-      // eslint-disable-next-line complexity
+
       removeEventListener: jest.fn((_, event, handler) => {
         if (event === 'click') {
           handlers.splice(handlers.indexOf(handler) >>> 0, 1);


### PR DESCRIPTION
## Summary
- extract `transformEntries` to streamline `mapValues`
- remove obsolete `eslint-disable` comment in tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686441dad134832e83d664127d3891a6