### PR TITLE
Fix lint max-params warning

### DIFF
--- a/src/browser/toys.js
+++ b/src/browser/toys.js
@@ -619,24 +619,25 @@ export const createKeyElement = ({
 
 /**
  * Creates a value input element with event listeners
- * @param {Object} dom - The DOM utilities object
- * @param {string} value - The initial value
- * @param {HTMLElement} keyEl - The corresponding key input element
- * @param {HTMLElement} textInput - The hidden text input element
- * @param {Object} rows - The rows object containing key-value pairs
- * @param {Function} syncHiddenField - Function to sync the hidden field with current state
- * @param {Array<Function>} disposers - Array to store cleanup functions
+ * @param {Object} options - Function options
+ * @param {Object} options.dom - The DOM utilities object
+ * @param {string} options.value - The initial value
+ * @param {HTMLElement} options.keyEl - The corresponding key input element
+ * @param {HTMLElement} options.textInput - The hidden text input element
+ * @param {Object} options.rows - The rows object containing key-value pairs
+ * @param {Function} options.syncHiddenField - Function to sync the hidden field with current state
+ * @param {Array<Function>} options.disposers - Array to store cleanup functions
  * @returns {HTMLInputElement} The created value input element
  */
-export const createValueElement = (
+export const createValueElement = ({
   dom,
   value,
   keyEl,
   textInput,
   rows,
   syncHiddenField,
-  disposers
-) => {
+  disposers,
+}) => {
   const valueEl = dom.createElement('input');
   dom.setType(valueEl, 'text');
   dom.setPlaceholder(valueEl, 'Value');
@@ -776,15 +777,15 @@ export const createKeyValueRow =
         syncHiddenField,
         disposers,
       });
-      const valueEl = createValueElement(
+      const valueEl = createValueElement({
         dom,
         value,
         keyEl,
         textInput,
         rows,
         syncHiddenField,
-        disposers
-      );
+        disposers,
+      });
 
       // Create and set up the appropriate button type
       const btnEl = createButton({

--- a/test/browser/createRemoveValueListener.doubleRemoval.test.js
+++ b/test/browser/createRemoveValueListener.doubleRemoval.test.js
@@ -20,24 +20,24 @@ describe('createRemoveValueListener multiple removals', () => {
     const sync = jest.fn();
     const disposers = [];
 
-    const valueEl1 = createValueElement(
+    const valueEl1 = createValueElement({
       dom,
-      '',
+      value: '',
       keyEl,
       textInput,
       rows,
-      sync,
-      disposers
-    );
-    const valueEl2 = createValueElement(
+      syncHiddenField: sync,
+      disposers,
+    });
+    const valueEl2 = createValueElement({
       dom,
-      '',
+      value: '',
       keyEl,
       textInput,
       rows,
-      sync,
-      disposers
-    );
+      syncHiddenField: sync,
+      disposers,
+    });
 
     const handler1 = dom.addEventListener.mock.calls[0][2];
     const handler2 = dom.addEventListener.mock.calls[1][2];

--- a/test/browser/createRemoveValueListener.multipleCalls.new.test.js
+++ b/test/browser/createRemoveValueListener.multipleCalls.new.test.js
@@ -15,7 +15,15 @@ describe('createRemoveValueListener repeated calls', () => {
       setDataAttribute: jest.fn(),
     };
     const disposers = [];
-    const el = createValueElement(dom, '', {}, {}, {}, jest.fn(), disposers);
+    const el = createValueElement({
+      dom,
+      value: '',
+      keyEl: {},
+      textInput: {},
+      rows: {},
+      syncHiddenField: jest.fn(),
+      disposers,
+    });
     const dispose = disposers[0];
     const handler = dom.addEventListener.mock.calls[0][2];
 

--- a/test/browser/createRemoveValueListener.mutantKill.test.js
+++ b/test/browser/createRemoveValueListener.mutantKill.test.js
@@ -20,27 +20,27 @@ describe('createRemoveValueListener unique disposers', () => {
     const sync = jest.fn();
 
     const disposers1 = [];
-    const valueEl1 = createValueElement(
+    const valueEl1 = createValueElement({
       dom,
-      '',
+      value: '',
       keyEl,
       textInput,
       rows,
-      sync,
-      disposers1
-    );
+      syncHiddenField: sync,
+      disposers: disposers1,
+    });
     const disposer1 = disposers1[0];
 
     const disposers2 = [];
-    const valueEl2 = createValueElement(
+    const valueEl2 = createValueElement({
       dom,
-      '',
+      value: '',
       keyEl,
       textInput,
       rows,
-      sync,
-      disposers2
-    );
+      syncHiddenField: sync,
+      disposers: disposers2,
+    });
     const disposer2 = disposers2[0];
 
     expect(typeof disposer1).toBe('function');

--- a/test/browser/toys.createValueElement.test.js
+++ b/test/browser/toys.createValueElement.test.js
@@ -35,7 +35,15 @@ describe('createValueElement', () => {
   it('creates a value input element with the correct initial properties', () => {
     const initialValue = 'testValue';
 
-    valueEl = createValueElement(mockDom, initialValue, keyEl, textInput, rows, syncHiddenField, disposers);
+    valueEl = createValueElement({
+      dom: mockDom,
+      value: initialValue,
+      keyEl,
+      textInput,
+      rows,
+      syncHiddenField,
+      disposers,
+    });
 
     // Verify element creation
     expect(mockDom.createElement).toHaveBeenCalledWith('input');
@@ -66,7 +74,15 @@ describe('createValueElement', () => {
     rows[key] = initialValue;
 
     // Create the value element
-    valueEl = createValueElement(mockDom, initialValue, keyEl, textInput, rows, syncHiddenField, disposers);
+    valueEl = createValueElement({
+      dom: mockDom,
+      value: initialValue,
+      keyEl,
+      textInput,
+      rows,
+      syncHiddenField,
+      disposers,
+    });
 
     // Get the input event handler
     const inputHandler = mockDom.addEventListener.mock.calls[0][2];
@@ -86,7 +102,15 @@ describe('createValueElement', () => {
   });
 
   it('cleans up event listeners when disposer is called', () => {
-    valueEl = createValueElement(mockDom, 'testValue', keyEl, textInput, rows, syncHiddenField, disposers);
+    valueEl = createValueElement({
+      dom: mockDom,
+      value: 'testValue',
+      keyEl,
+      textInput,
+      rows,
+      syncHiddenField,
+      disposers,
+    });
 
     // Get the disposer function
     const disposer = disposers[0];
@@ -103,15 +127,15 @@ describe('createValueElement', () => {
   });
 
   it('uses the same handler for add and remove listener', () => {
-    valueEl = createValueElement(
-      mockDom,
-      'testValue',
+    valueEl = createValueElement({
+      dom: mockDom,
+      value: 'testValue',
       keyEl,
       textInput,
       rows,
       syncHiddenField,
-      disposers
-    );
+      disposers,
+    });
 
     // Capture the handler passed to addEventListener
     const [el, eventName, handler] = mockDom.addEventListener.mock.calls[0];
@@ -125,15 +149,15 @@ describe('createValueElement', () => {
   });
 
   it('cleanup can be called multiple times', () => {
-    valueEl = createValueElement(
-      mockDom,
-      'multi',
+    valueEl = createValueElement({
+      dom: mockDom,
+      value: 'multi',
       keyEl,
       textInput,
       rows,
       syncHiddenField,
-      disposers
-    );
+      disposers,
+    });
 
     const disposer = disposers[0];
     disposer();


### PR DESCRIPTION
## Summary
- refactor `createValueElement` to take an options object
- update usage in `createKeyValueRow`
- adjust tests for new signature

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686443486370832ea9fef0e9766aba6c