### PR TITLE
Fix lint warning in text handler

### DIFF
--- a/src/inputHandlers/default.js
+++ b/src/inputHandlers/default.js
@@ -1,5 +1,5 @@
 /* eslint-disable complexity */
-function dispose(element, dom, container) {
+export function dispose(element, dom, container) {
   if (typeof element?._dispose === 'function') {
     element._dispose();
     dom.removeChild(container, element);

--- a/src/inputHandlers/text.js
+++ b/src/inputHandlers/text.js
@@ -1,19 +1,9 @@
+import { dispose } from './default.js';
+
 export function textHandler(dom, container, textInput) {
   dom.reveal(textInput);
   dom.enable(textInput);
-  const numberInput = dom.querySelector(container, 'input[type="number"]');
-  if (numberInput && typeof numberInput._dispose === 'function') {
-    numberInput._dispose();
-    dom.removeChild(container, numberInput);
-  }
-  const kvContainer = dom.querySelector(container, '.kv-container');
-  if (kvContainer && typeof kvContainer._dispose === 'function') {
-    kvContainer._dispose();
-    dom.removeChild(container, kvContainer);
-  }
-  const dendriteForm = dom.querySelector(container, '.dendrite-form');
-  if (dendriteForm && typeof dendriteForm._dispose === 'function') {
-    dendriteForm._dispose();
-    dom.removeChild(container, dendriteForm);
-  }
+  dispose(dom.querySelector(container, 'input[type="number"]'), dom, container);
+  dispose(dom.querySelector(container, '.kv-container'), dom, container);
+  dispose(dom.querySelector(container, '.dendrite-form'), dom, container);
 }


### PR DESCRIPTION
## Summary
- reduce lint complexity by reusing the existing `dispose` helper
- export helper from `default.js`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6864434e8020832e88e035ba40fdadd2