### PR TITLE
Fix lint warning in missing elements test

### DIFF
--- a/test/browser/initializeInteractiveComponent.missingElements.test.js
+++ b/test/browser/initializeInteractiveComponent.missingElements.test.js
@@ -47,10 +47,10 @@ describe('initializeInteractiveComponent missing elements', () => {
           'input[type="text"]': null,
           'button[type="submit"]': button,
         };
-        if (Object.prototype.hasOwnProperty.call(mapping, selector)) {
-          return mapping[selector];
+        if (!Object.prototype.hasOwnProperty.call(mapping, selector)) {
+          return {};
         }
-        return {};
+        return mapping[selector];
       }),
       removeAllChildren: jest.fn(),
       createElement: jest.fn(() => ({ textContent: '' })),
@@ -94,10 +94,10 @@ describe('initializeInteractiveComponent missing elements', () => {
           'input[type="text"]': input,
           'button[type="submit"]': null,
         };
-        if (Object.prototype.hasOwnProperty.call(mapping, selector)) {
-          return mapping[selector];
+        if (!Object.prototype.hasOwnProperty.call(mapping, selector)) {
+          return {};
         }
-        return {};
+        return mapping[selector];
       }),
       removeAllChildren: jest.fn(),
       createElement: jest.fn(() => ({ textContent: '' })),


### PR DESCRIPTION
## Summary
- refactor `initializeInteractiveComponent.missingElements.test.js` to simplify `querySelector` helpers

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686444cbb2b4832e8184496e12ae5b2c