### PR TITLE
Fix lint warning and refactor helper

### DIFF
--- a/src/generator/generator.js
+++ b/src/generator/generator.js
@@ -886,10 +886,10 @@ const INPUT_METHODS = ['text', 'number', 'kv', 'dendrite-story'];
  * @returns {string} - HTML for the dropdown and text input
  */
 function getSelectedMethod(defaultMethod) {
-  if (defaultMethod && defaultMethod !== 'text') {
-    return defaultMethod;
+  if (defaultMethod === 'text') {
+    return undefined;
   }
-  return undefined;
+  return defaultMethod;
 }
 
 function buildOption(method, selectedMethod) {
@@ -902,7 +902,9 @@ function buildOption(method, selectedMethod) {
 
 function buildToyInputDropdown(defaultMethod) {
   const selectedMethod = getSelectedMethod(defaultMethod);
-  const options = INPUT_METHODS.map(method => buildOption(method, selectedMethod)).join('');
+  const options = INPUT_METHODS.map(method =>
+    buildOption(method, selectedMethod)
+  ).join('');
   return `<select class="input">${options}</select><input type="text" disabled>`;
 }
 

--- a/src/inputHandlers/kv.js
+++ b/src/inputHandlers/kv.js
@@ -2,18 +2,14 @@ import { ensureKeyValueInput } from '../browser/toys.js';
 
 export function maybeRemoveNumber(container, dom) {
   const numberInput = dom.querySelector(container, 'input[type="number"]');
-  if (typeof numberInput?._dispose === 'function') {
-    numberInput._dispose();
-    dom.removeChild(container, numberInput);
-  }
+  typeof numberInput?._dispose === 'function' &&
+    (numberInput._dispose(), dom.removeChild(container, numberInput));
 }
 
 export function maybeRemoveDendrite(container, dom) {
   const dendriteForm = dom.querySelector(container, '.dendrite-form');
-  if (dendriteForm && typeof dendriteForm._dispose === 'function') {
-    dendriteForm._dispose();
-    dom.removeChild(container, dendriteForm);
-  }
+  typeof dendriteForm?._dispose === 'function' &&
+    (dendriteForm._dispose(), dom.removeChild(container, dendriteForm));
 }
 
 export function handleKVType(dom, container, textInput) {


### PR DESCRIPTION
## Summary
- reduce complexity in `getSelectedMethod`
- update input handler cleanup helpers to use short circuiting

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686444cb60ec832e8d3d7058fb009737