### PR TITLE
Fix lint complexity warning

### DIFF
--- a/public/utils/validation.js
+++ b/public/utils/validation.js
@@ -22,11 +22,13 @@ export function isValidString(str) {
  * @param {*} value - The value to check
  * @returns {boolean} True if the value is a valid boolean or boolean string
  */
+export function isBooleanString(value) {
+  return /^(?:true|false)$/i.test(String(value));
+}
+
 export function isValidBoolean(value) {
-  if (typeof value === 'boolean') {return true;}
-  if (typeof value === 'string') {
-    const lower = value.toLowerCase();
-    return lower === 'true' || lower === 'false';
+  if (typeof value === 'boolean') {
+    return true;
   }
-  return false;
+  return isBooleanString(value);
 }

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -22,6 +22,13 @@ export function isValidString(str) {
  * @param {*} value - The value to check
  * @returns {boolean} True if the value is a valid boolean or boolean string
  */
+export function isBooleanString(value) {
+  return /^(?:true|false)$/i.test(String(value));
+}
+
 export function isValidBoolean(value) {
-  return typeof value === 'boolean' || /^(?:true|false)$/i.test(String(value));
+  if (typeof value === 'boolean') {
+    return true;
+  }
+  return isBooleanString(value);
 }

--- a/test/utils/validation.test.js
+++ b/test/utils/validation.test.js
@@ -1,5 +1,9 @@
 import { describe, test, expect } from '@jest/globals';
-import { isType, isValidBoolean } from '../../src/utils/validation.js';
+import {
+  isType,
+  isValidBoolean,
+  isBooleanString,
+} from '../../src/utils/validation.js';
 
 describe('isType', () => {
   test('returns true for matching types', () => {
@@ -21,6 +25,18 @@ describe('isType', () => {
     expect(isType(true, 'number')).toBe(false);
     expect(isType(null, 'undefined')).toBe(false);
     expect(isType(undefined, 'null')).toBe(false);
+  });
+});
+
+describe('isBooleanString', () => {
+  test('returns true for boolean strings', () => {
+    expect(isBooleanString('true')).toBe(true);
+    expect(isBooleanString('False')).toBe(true);
+  });
+
+  test('returns false for non-boolean strings', () => {
+    expect(isBooleanString('yes')).toBe(false);
+    expect(isBooleanString('')).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- extract `isBooleanString` helper
- remove explanatory comments
- test the new helper

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686440becc18832eb2f1aaf26d94cc7a