### PR TITLE
Fix lint warning in tests

### DIFF
--- a/test/browser/toys.test.js
+++ b/test/browser/toys.test.js
@@ -820,12 +820,13 @@ describe('toys', () => {
         (el, selector) => selectorMap.get(selector) || {}
       );
       const listeners = {};
+      const listenerTargets = new Map([
+        [submitButton, 'click'],
+        [inputElement, 'keypress'],
+      ]);
       const addEventListener = jest.fn((element, event, handler) => {
-        if (element === submitButton && event === 'click') {
-          listeners.click = handler;
-        }
-        if (element === inputElement && event === 'keypress') {
-          listeners.keypress = handler;
+        if (listenerTargets.get(element) === event) {
+          listeners[event] = handler;
         }
       });
       const dom = {


### PR DESCRIPTION
## Summary
- fix complexity warning in toys.test.js by simplifying event listener logic

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6864d9131c18832e88603771a9078e39