### PR TITLE
Fix lint warning in key-value row

### DIFF
--- a/src/browser/toys.js
+++ b/src/browser/toys.js
@@ -754,7 +754,7 @@ export const setupRemoveButton = (
  * @returns {Function} A function that takes [key, value] and index and creates a row
  */
 export const createKeyValueRow =
-  (
+  ({
     dom,
     entries,
     textInput,
@@ -762,8 +762,8 @@ export const createKeyValueRow =
     syncHiddenField,
     disposers,
     render,
-    container
-  ) =>
+    container,
+  }) =>
     ([key, value], idx) => {
       const rowEl = dom.createElement('div');
       dom.setClassName(rowEl, 'kv-row');
@@ -1143,16 +1143,16 @@ export const createRenderer = (
 
     const entries = Object.entries(rows);
     entries.forEach(
-      createKeyValueRow(
+      createKeyValueRow({
         dom,
         entries,
         textInput,
         rows,
         syncHiddenField,
-        disposersArray,
+        disposers: disposersArray,
         render,
-        container
-      )
+        container,
+      })
     );
 
     syncHiddenField(textInput, rows, dom);

--- a/test/browser/createKeyValueRow.appendChild.test.js
+++ b/test/browser/createKeyValueRow.appendChild.test.js
@@ -26,16 +26,16 @@ describe('createKeyValueRow DOM appends', () => {
       addEventListener: jest.fn(),
     };
 
-    const rowCreator = createKeyValueRow(
+    const rowCreator = createKeyValueRow({
       dom,
-      [],
-      {},
-      {},
-      () => {},
-      [],
-      () => {},
-      container
-    );
+      entries: [],
+      textInput: {},
+      rows: {},
+      syncHiddenField: () => {},
+      disposers: [],
+      render: () => {},
+      container,
+    });
 
     rowCreator(['a', 'b'], 0);
 

--- a/test/browser/createKeyValueRow.args.test.js
+++ b/test/browser/createKeyValueRow.args.test.js
@@ -32,7 +32,7 @@ describe('createKeyValueRow argument handling', () => {
     const render = jest.fn();
     const container = {};
 
-    const rowCreator = createKeyValueRow(
+    const rowCreator = createKeyValueRow({
       dom,
       entries,
       textInput,
@@ -40,8 +40,8 @@ describe('createKeyValueRow argument handling', () => {
       syncHiddenField,
       disposers,
       render,
-      container
-    );
+      container,
+    });
 
     rowCreator(['alpha', 'beta'], 0);
 

--- a/test/browser/createKeyValueRow.return.test.js
+++ b/test/browser/createKeyValueRow.return.test.js
@@ -11,7 +11,7 @@ describe('createKeyValueRow return value', () => {
     const disposers = [];
     const render = () => {};
     const container = {};
-    const rowHandler = createKeyValueRow(
+    const rowHandler = createKeyValueRow({
       dom,
       entries,
       textInput,
@@ -19,13 +19,13 @@ describe('createKeyValueRow return value', () => {
       syncHiddenField,
       disposers,
       render,
-      container
-    );
+      container,
+    });
     expect(typeof rowHandler).toBe('function');
     expect(rowHandler.length).toBe(2);
   });
 
-  it('has an arity of 8 and each call returns a new unary function', () => {
+  it('has an arity of 1 and each call returns a new unary function', () => {
     const dom = {};
     const entries = [];
     const textInput = {};
@@ -35,9 +35,9 @@ describe('createKeyValueRow return value', () => {
     const render = () => {};
     const container = {};
 
-    expect(createKeyValueRow.length).toBe(8);
+    expect(createKeyValueRow.length).toBe(1);
 
-    const first = createKeyValueRow(
+    const first = createKeyValueRow({
       dom,
       entries,
       textInput,
@@ -45,10 +45,10 @@ describe('createKeyValueRow return value', () => {
       syncHiddenField,
       disposers,
       render,
-      container
-    );
+      container,
+    });
 
-    const second = createKeyValueRow(
+    const second = createKeyValueRow({
       dom,
       entries,
       textInput,
@@ -56,8 +56,8 @@ describe('createKeyValueRow return value', () => {
       syncHiddenField,
       disposers,
       render,
-      container
-    );
+      container,
+    });
 
     expect(typeof first).toBe('function');
     expect(typeof second).toBe('function');

--- a/test/browser/toys.createKeyValueRow.test.js
+++ b/test/browser/toys.createKeyValueRow.test.js
@@ -58,16 +58,16 @@ describe('createKeyValueRow', () => {
     mockContainer = {};
 
     // Create the row creator function
-    rowCreator = createKeyValueRow(
-      mockDom,
-      mockEntries,
-      mockTextInput,
-      mockRows,
-      mockSyncHiddenField,
-      mockDisposers,
-      mockRender,
-      mockContainer
-    );
+    rowCreator = createKeyValueRow({
+      dom: mockDom,
+      entries: mockEntries,
+      textInput: mockTextInput,
+      rows: mockRows,
+      syncHiddenField: mockSyncHiddenField,
+      disposers: mockDisposers,
+      render: mockRender,
+      container: mockContainer,
+    });
   });
 
   it('creates a row with key and value inputs', () => {
@@ -83,7 +83,7 @@ describe('createKeyValueRow', () => {
       .mockReturnValue({}); // Any other calls
 
     // Call the row creator function
-    rowCreator('key1', 'value1', false);
+    rowCreator(['key1', 'value1'], 0);
 
     // Verify the row element was created with the correct class
     expect(mockDom.createElement).toHaveBeenCalledWith('div');
@@ -99,7 +99,7 @@ describe('createKeyValueRow', () => {
     expect(mockDom.setDataAttribute).toHaveBeenCalledWith(
       mockInputElement,
       'prevKey',
-      'k'
+      'key1'
     );
 
     // Verify elements were appended to the row and the row was appended to the container
@@ -128,7 +128,7 @@ describe('createKeyValueRow', () => {
       .mockReturnValue(mockButton); // remove button
 
     // Call the row creator function with isLast = false
-    rowCreator('key1', 'value1', false);
+    rowCreator(['key1', 'value1'], 0);
 
     // Should set up a remove button (×)
     expect(mockDom.setTextContent).toHaveBeenCalledWith(mockButton, '×');
@@ -144,10 +144,10 @@ describe('createKeyValueRow', () => {
       .mockReturnValue(mockButton); // add button
 
     // Call the row creator function with isLast = true
-    rowCreator('key1', 'value1', true);
+    rowCreator(['key1', 'value1'], 1);
 
-    // Should set up an add button (×)
-    expect(mockDom.setTextContent).toHaveBeenCalledWith(mockButton, '×');
+    // Should set up an add button (+)
+    expect(mockDom.setTextContent).toHaveBeenCalledWith(mockButton, '+');
   });
 
   it('uses the index to set up a remove button when not last', () => {
@@ -196,7 +196,6 @@ describe('createKeyValueRow', () => {
     const mockValueInput = {};
     const mockButton = {};
 
-
     mockDom.createElement
       .mockReturnValueOnce({}) // row div
       .mockReturnValueOnce(mockKeyInput) // key input
@@ -204,7 +203,7 @@ describe('createKeyValueRow', () => {
       .mockReturnValue(mockButton); // button
 
     // Call the row creator function
-    rowCreator('key1', 'value1', false);
+    rowCreator(['key1', 'value1'], 0);
 
     // Verify event listeners were added
     expect(mockDom.addEventListener.mock.calls).toEqual([


### PR DESCRIPTION
## Summary
- refactor `createKeyValueRow` to accept an options object
- adjust renderer to call `createKeyValueRow` with the new API
- update tests to match the refactored function

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6864d9119a6c832e99dac2743ccc1af0