### PR TITLE
Fix lint complexity in utilities

### DIFF
--- a/src/browser/toys.js
+++ b/src/browser/toys.js
@@ -13,10 +13,7 @@ import { createPrefixedLoggers } from './document.js';
  * @returns {Object} An object with keys and values from the array
  */
 function isKeyValuePair(pair) {
-  if (!pair || typeof pair !== 'object') {
-    return false;
-  }
-  return 'key' in pair;
+  return 'key' in Object(pair);
 }
 
 export const convertArrayToKeyValueObject = array => {

--- a/src/utils/regexUtils.js
+++ b/src/utils/regexUtils.js
@@ -22,11 +22,12 @@ export function escapeRegex(str) {
  */
 export function createPattern(marker, { isDouble = false, flags = 'g' } = {}) {
   const escaped = escapeRegex(marker);
-  let actualMarker = escaped;
-  if (isDouble) {
-    actualMarker = `${escaped}{2}`;
-  }
+  const actualMarker = getActualMarker(escaped, isDouble);
   return new RegExp(`${actualMarker}(.*?)${actualMarker}`, flags);
+}
+
+function getActualMarker(escaped, isDouble) {
+  return isDouble ? `${escaped}{2}` : escaped;
 }
 
 /**


### PR DESCRIPTION
## Summary
- streamline `isKeyValuePair` in `toys.js`
- simplify `createPattern` in `regexUtils.js`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6864de8538e4832e9d798810a7762aa7