### PR TITLE
Fix lint warning

### DIFF
--- a/src/inputHandlers/kv.js
+++ b/src/inputHandlers/kv.js
@@ -2,14 +2,20 @@ import { ensureKeyValueInput } from '../browser/toys.js';
 
 export function maybeRemoveNumber(container, dom) {
   const numberInput = dom.querySelector(container, 'input[type="number"]');
-  typeof numberInput?._dispose === 'function' &&
-    (numberInput._dispose(), dom.removeChild(container, numberInput));
+  const canDispose = typeof numberInput?._dispose === 'function';
+  if (canDispose) {
+    numberInput._dispose();
+    dom.removeChild(container, numberInput);
+  }
 }
 
 export function maybeRemoveDendrite(container, dom) {
   const dendriteForm = dom.querySelector(container, '.dendrite-form');
-  typeof dendriteForm?._dispose === 'function' &&
-    (dendriteForm._dispose(), dom.removeChild(container, dendriteForm));
+  const canDispose = typeof dendriteForm?._dispose === 'function';
+  if (canDispose) {
+    dendriteForm._dispose();
+    dom.removeChild(container, dendriteForm);
+  }
 }
 
 export function handleKVType(dom, container, textInput) {

--- a/test/browser/createInputDropdownHandler.numberThenKv.mutantKill.test.js
+++ b/test/browser/createInputDropdownHandler.numberThenKv.mutantKill.test.js
@@ -12,12 +12,15 @@ test("createInputDropdownHandler handles number then kv sequentially", () => {
   const dom = {
     getCurrentTarget: jest.fn(() => select),
     getParentElement: jest.fn(() => container),
-    querySelector: jest.fn((_, selector) => {
-      if (selector === "input[type=\"text\"]") {return textInput;}
-      if (selector === "input[type=\"number\"]") {return numberInput;}
-      if (selector === ".kv-container") {return kvContainer;}
-      return null;
-    }),
+    querySelector: jest.fn((_, selector) =>
+      (
+        {
+          'input[type="text"]': textInput,
+          'input[type="number"]': numberInput,
+          '.kv-container': kvContainer,
+        }[selector] || null
+      )
+    ),
     createElement: jest.fn(() => ({})),
     getNextSibling: jest.fn(() => null),
     insertBefore: jest.fn(),


### PR DESCRIPTION
## Summary
- refactor kv input cleanup helpers to simplify checks
- reduce complexity in a dropdown handler test

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6864de822644832eb9da8a127dfaf865