### PR TITLE
Fix lint warning in KV helpers

### DIFF
--- a/src/inputHandlers/kv.js
+++ b/src/inputHandlers/kv.js
@@ -1,15 +1,14 @@
 import { ensureKeyValueInput } from '../browser/toys.js';
+import { dispose } from './default.js';
 
 export function maybeRemoveNumber(container, dom) {
   const numberInput = dom.querySelector(container, 'input[type="number"]');
-  typeof numberInput?._dispose === 'function' &&
-    (numberInput._dispose(), dom.removeChild(container, numberInput));
+  dispose(numberInput, dom, container);
 }
 
 export function maybeRemoveDendrite(container, dom) {
   const dendriteForm = dom.querySelector(container, '.dendrite-form');
-  typeof dendriteForm?._dispose === 'function' &&
-    (dendriteForm._dispose(), dom.removeChild(container, dendriteForm));
+  dispose(dendriteForm, dom, container);
 }
 
 export function handleKVType(dom, container, textInput) {

--- a/src/inputHandlers/number.js
+++ b/src/inputHandlers/number.js
@@ -1,7 +1,7 @@
 import { ensureNumberInput } from '../browser/toys.js';
 
 function isDisposable(element) {
-  return !!element && typeof element._dispose === 'function';
+  return Boolean(element) && typeof element._dispose === 'function';
 }
 
 function maybeRemoveKV(container, dom) {


### PR DESCRIPTION
## Summary
- refactor helper functions in `kv.js` to use the shared `dispose` util
- replace implicit boolean coercion in `number.js`

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864de812ea8832ea3ab47da2211bbfe