### PR TITLE
Fix lint complexity warnings

### DIFF
--- a/src/inputHandlers/dendriteStory.js
+++ b/src/inputHandlers/dendriteStory.js
@@ -7,16 +7,15 @@ function isDisposable(element) {
 
 function maybeRemoveNumber(container, dom) {
   const numberInput = dom.querySelector(container, 'input[type="number"]');
-  if (!isDisposable(numberInput)) {
-    return;
+  if (isDisposable(numberInput)) {
+    numberInput._dispose();
+    dom.removeChild(container, numberInput);
   }
-  numberInput._dispose();
-  dom.removeChild(container, numberInput);
 }
 
 function maybeRemoveKV(container, dom) {
   const kvContainer = dom.querySelector(container, '.kv-container');
-  if (kvContainer && typeof kvContainer._dispose === 'function') {
+  if (isDisposable(kvContainer)) {
     kvContainer._dispose();
     dom.removeChild(container, kvContainer);
   }

--- a/src/inputHandlers/kv.js
+++ b/src/inputHandlers/kv.js
@@ -1,15 +1,23 @@
 import { ensureKeyValueInput } from '../browser/toys.js';
 
+function isDisposable(element) {
+  return Boolean(element) && typeof element._dispose === 'function';
+}
+
 export function maybeRemoveNumber(container, dom) {
   const numberInput = dom.querySelector(container, 'input[type="number"]');
-  typeof numberInput?._dispose === 'function' &&
-    (numberInput._dispose(), dom.removeChild(container, numberInput));
+  if (isDisposable(numberInput)) {
+    numberInput._dispose();
+    dom.removeChild(container, numberInput);
+  }
 }
 
 export function maybeRemoveDendrite(container, dom) {
   const dendriteForm = dom.querySelector(container, '.dendrite-form');
-  typeof dendriteForm?._dispose === 'function' &&
-    (dendriteForm._dispose(), dom.removeChild(container, dendriteForm));
+  if (isDisposable(dendriteForm)) {
+    dendriteForm._dispose();
+    dom.removeChild(container, dendriteForm);
+  }
 }
 
 export function handleKVType(dom, container, textInput) {

--- a/src/inputHandlers/number.js
+++ b/src/inputHandlers/number.js
@@ -1,7 +1,7 @@
 import { ensureNumberInput } from '../browser/toys.js';
 
 function isDisposable(element) {
-  return !!element && typeof element._dispose === 'function';
+  return Boolean(element) && typeof element._dispose === 'function';
 }
 
 function maybeRemoveKV(container, dom) {


### PR DESCRIPTION
## Summary
- reduce complexity in `kv` cleanup helpers
- update disposable checks in number handler
- adjust dendrite story helpers accordingly

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6864de7ff704832ea54f1606f1a32e60