### PR TITLE
Fix lint warning by refactoring setupRemoveButton

### DIFF
--- a/reports/lint/lint.txt
+++ b/reports/lint/lint.txt
@@ -3,12 +3,10 @@
     15:1   warning  Function 'isKeyValuePair' has a complexity of 3. Maximum allowed is 2                  complexity
     31:34  warning  Arrow function has a complexity of 6. Maximum allowed is 2                             complexity
    187:8   warning  Function 'handleDropdownChange' has a complexity of 3. Maximum allowed is 2            complexity
-   534:10  warning  Arrow function has a complexity of 4. Maximum allowed is 2                             complexity
-   721:3   warning  Arrow function has too many parameters (6). Maximum allowed is 3                       max-params
-   766:5   warning  Arrow function has too many parameters (8). Maximum allowed is 3                       max-params
-   971:8   warning  Function 'initializeInteractiveComponent' has a complexity of 3. Maximum allowed is 2  complexity
-  1096:32  warning  Arrow function has a complexity of 4. Maximum allowed is 2                             complexity
-  1131:3   warning  Arrow function has too many parameters (6). Maximum allowed is 3                       max-params
+   529:10  warning  Arrow function has a complexity of 4. Maximum allowed is 2                             complexity
+   961:8   warning  Function 'initializeInteractiveComponent' has a complexity of 3. Maximum allowed is 2  complexity
+  1086:32  warning  Arrow function has a complexity of 4. Maximum allowed is 2                             complexity
+  1121:3   warning  Arrow function has too many parameters (6). Maximum allowed is 3                       max-params
 
 /workspace/dadeto/src/generator/generator.js
   928:1  warning  Function 'generateToyUISection' has a complexity of 4. Maximum allowed is 2  complexity
@@ -21,10 +19,6 @@
 /workspace/dadeto/src/inputHandlers/kv.js
   3:8  warning  Function 'maybeRemoveNumber' has a complexity of 3. Maximum allowed is 2    complexity
   9:8  warning  Function 'maybeRemoveDendrite' has a complexity of 3. Maximum allowed is 2  complexity
-
-/workspace/dadeto/src/inputHandlers/number.js
-  3:1  warning  Function 'maybeRemoveKV' has a complexity of 4. Maximum allowed is 2        complexity
-  9:1  warning  Function 'maybeRemoveDendrite' has a complexity of 4. Maximum allowed is 2  complexity
 
 /workspace/dadeto/src/presenters/battleshipSolitaireClues.js
   26:1  warning  Function 'validateCluesObject' has a complexity of 9. Maximum allowed is 2                complexity
@@ -74,9 +68,8 @@
   80:33  warning  Arrow function has a complexity of 3. Maximum allowed is 2  complexity
 
 /workspace/dadeto/test/browser/toys.test.js
-   823:40  warning  Arrow function has a complexity of 5. Maximum allowed is 2  complexity
-  1149:32  warning  Arrow function has a complexity of 5. Maximum allowed is 2  complexity
-  1207:32  warning  Arrow function has a complexity of 5. Maximum allowed is 2  complexity
-  1386:13  warning  Arrow function has a complexity of 3. Maximum allowed is 2  complexity
+  1150:32  warning  Arrow function has a complexity of 5. Maximum allowed is 2  complexity
+  1208:32  warning  Arrow function has a complexity of 5. Maximum allowed is 2  complexity
+  1387:13  warning  Arrow function has a complexity of 3. Maximum allowed is 2  complexity
 
-✖ 40 problems (0 errors, 40 warnings)
+✖ 35 problems (0 errors, 35 warnings)

--- a/src/browser/toys.js
+++ b/src/browser/toys.js
@@ -701,14 +701,14 @@ export const setupAddButton = ({ dom, button, rows, render, disposers }) => {
  * @param {string} key - The key of the row to remove
  * @param {Array} disposers - Array to store cleanup functions
  */
-export const setupRemoveButton = (
+export const setupRemoveButton = ({
   dom,
   button,
   rows,
   render,
   key,
-  disposers
-) => {
+  disposers,
+}) => {
   dom.setTextContent(button, '×');
   const onRemove = createOnRemove(rows, render, key);
   dom.addEventListener(button, 'click', onRemove);
@@ -800,7 +800,7 @@ const createButton = ({ dom, isAddButton, rows, render, key, disposers }) => {
   if (isAddButton) {
     setupAddButton({ dom, button, rows, render, disposers });
   } else {
-    setupRemoveButton(dom, button, rows, render, key, disposers);
+    setupRemoveButton({ dom, button, rows, render, key, disposers });
   }
 
   return button;

--- a/src/inputHandlers/number.js
+++ b/src/inputHandlers/number.js
@@ -1,7 +1,7 @@
 import { ensureNumberInput } from '../browser/toys.js';
 
 function isDisposable(element) {
-  return !!element && typeof element._dispose === 'function';
+  return Boolean(element) && typeof element._dispose === 'function';
 }
 
 function maybeRemoveKV(container, dom) {

--- a/test/browser/createRemoveRemoveListener.count.test.js
+++ b/test/browser/createRemoveRemoveListener.count.test.js
@@ -13,7 +13,14 @@ describe('createRemoveRemoveListener call count', () => {
     const render = jest.fn();
     const disposers = [];
 
-    setupRemoveButton(dom, button, rows, render, 'k', disposers);
+    setupRemoveButton({
+      dom,
+      button,
+      rows,
+      render,
+      key: 'k',
+      disposers,
+    });
 
     expect(disposers).toHaveLength(1);
     const dispose = disposers[0];

--- a/test/browser/createRemoveRemoveListener.doubleRemoval.test.js
+++ b/test/browser/createRemoveRemoveListener.doubleRemoval.test.js
@@ -13,7 +13,14 @@ describe('createRemoveRemoveListener multiple disposals', () => {
     const render = jest.fn();
     const disposers = [];
 
-    setupRemoveButton(dom, button, rows, render, 'k', disposers);
+    setupRemoveButton({
+      dom,
+      button,
+      rows,
+      render,
+      key: 'k',
+      disposers,
+    });
 
     expect(disposers).toHaveLength(1);
     const dispose = disposers[0];

--- a/test/browser/createRemoveRemoveListener.order.test.js
+++ b/test/browser/createRemoveRemoveListener.order.test.js
@@ -14,9 +14,23 @@ describe('createRemoveRemoveListener order of disposal', () => {
     const render = jest.fn();
     const disposers = [];
 
-    setupRemoveButton(dom, buttonA, rows, render, 'a', disposers);
+    setupRemoveButton({
+      dom,
+      button: buttonA,
+      rows,
+      render,
+      key: 'a',
+      disposers,
+    });
     const disposeA = disposers.pop();
-    setupRemoveButton(dom, buttonB, rows, render, 'b', disposers);
+    setupRemoveButton({
+      dom,
+      button: buttonB,
+      rows,
+      render,
+      key: 'b',
+      disposers,
+    });
     const disposeB = disposers.pop();
 
     const handlerA = dom.addEventListener.mock.calls[0][2];

--- a/test/browser/createRemoveRemoveListener.tripleCalls.test.js
+++ b/test/browser/createRemoveRemoveListener.tripleCalls.test.js
@@ -14,7 +14,14 @@ describe('createRemoveRemoveListener triple calls', () => {
     const buttons = [{}, {}, {}];
 
     buttons.forEach((btn, idx) => {
-      setupRemoveButton(dom, btn, rows, render, 'k' + idx, disposers);
+      setupRemoveButton({
+        dom,
+        button: btn,
+        rows,
+        render,
+        key: 'k' + idx,
+        disposers,
+      });
       const disposer = disposers[idx];
       expect(typeof disposer).toBe('function');
       const handler = dom.addEventListener.mock.calls[idx][2];

--- a/test/browser/createRemoveRemoveListener.unique.test.js
+++ b/test/browser/createRemoveRemoveListener.unique.test.js
@@ -18,11 +18,25 @@ describe('setupRemoveButton multiple disposers', () => {
     const disposers = [];
 
     // First setup
-    setupRemoveButton(dom, buttonA, rows, render, 'a', disposers);
+    setupRemoveButton({
+      dom,
+      button: buttonA,
+      rows,
+      render,
+      key: 'a',
+      disposers,
+    });
     const disposerA = disposers.pop();
 
     // Second setup
-    setupRemoveButton(dom, buttonB, rows, render, 'b', disposers);
+    setupRemoveButton({
+      dom,
+      button: buttonB,
+      rows,
+      render,
+      key: 'b',
+      disposers,
+    });
     const disposerB = disposers.pop();
 
     expect(typeof disposerA).toBe('function');

--- a/test/browser/setupButton.shared.test.js
+++ b/test/browser/setupButton.shared.test.js
@@ -20,7 +20,15 @@ describe.each([
   [
     'setupRemoveButton',
     setupRemoveButton,
-    (...params) => setupRemoveButton(...params),
+    (...params) =>
+      setupRemoveButton({
+        dom: params[0],
+        button: params[1],
+        rows: params[2],
+        render: params[3],
+        key: params[4],
+        disposers: params[5],
+      }),
   ],
 ])('%s common behaviour', (_name, _setup, invoke) => {
   let dom;

--- a/test/browser/setupButtonCleanup.test.js
+++ b/test/browser/setupButtonCleanup.test.js
@@ -58,7 +58,14 @@ describe('button cleanup helpers', () => {
     const rows = { k: 'v' };
     const render = jest.fn();
     const disposers = [];
-    setupRemoveButton(dom, button, rows, render, 'k', disposers);
+    setupRemoveButton({
+      dom,
+      button,
+      rows,
+      render,
+      key: 'k',
+      disposers,
+    });
     expect(disposers).toHaveLength(1);
     const dispose = disposers[0];
     expect(typeof dispose).toBe('function');

--- a/test/browser/toys.setupRemoveButton.test.js
+++ b/test/browser/toys.setupRemoveButton.test.js
@@ -25,7 +25,14 @@ describe('setupRemoveButton', () => {
   });
 
   it('sets the button text content to "×"', () => {
-    setupRemoveButton(mockDom, button, rows, render, rowKey, disposers);
+    setupRemoveButton({
+      dom: mockDom,
+      button,
+      rows,
+      render,
+      key: rowKey,
+      disposers,
+    });
 
     expect(mockDom.setTextContent).toHaveBeenCalledWith(button, '×');
   });
@@ -39,7 +46,14 @@ describe('setupRemoveButton', () => {
       }
     });
 
-    setupRemoveButton(mockDom, button, rows, render, rowKey, disposers);
+    setupRemoveButton({
+      dom: mockDom,
+      button,
+      rows,
+      render,
+      key: rowKey,
+      disposers,
+    });
 
     // Simulate button click
     clickHandler(mockEvent);
@@ -66,7 +80,14 @@ describe('setupRemoveButton', () => {
       }
     });
 
-    setupRemoveButton(mockDom, button, rows, render, nonExistentKey, disposers);
+    setupRemoveButton({
+      dom: mockDom,
+      button,
+      rows,
+      render,
+      key: nonExistentKey,
+      disposers,
+    });
 
     // Simulate button click
     clickHandler(mockEvent);


### PR DESCRIPTION
## Summary
- refactor `setupRemoveButton` to accept an options object
- update all usages and tests
- adjust lint fixes for number handler

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6864de7f8df8832ea8a5e10ed9b6fa03