### PR TITLE
Fix lint warning in dropdown handler test

### DIFF
--- a/reports/lint/lint.txt
+++ b/reports/lint/lint.txt
@@ -1,24 +1,23 @@
 
 /workspace/dadeto/src/browser/toys.js
-    15:1   warning  Function 'isKeyValuePair' has a complexity of 3. Maximum allowed is 2                  complexity
-    31:34  warning  Arrow function has a complexity of 6. Maximum allowed is 2                             complexity
-   187:8   warning  Function 'handleDropdownChange' has a complexity of 3. Maximum allowed is 2            complexity
-   529:10  warning  Arrow function has a complexity of 4. Maximum allowed is 2                             complexity
-   961:8   warning  Function 'initializeInteractiveComponent' has a complexity of 3. Maximum allowed is 2  complexity
-  1086:32  warning  Arrow function has a complexity of 4. Maximum allowed is 2                             complexity
-  1121:3   warning  Arrow function has too many parameters (6). Maximum allowed is 3                       max-params
+    28:34  warning  Arrow function has a complexity of 6. Maximum allowed is 2                             complexity
+   185:8   warning  Function 'handleDropdownChange' has a complexity of 3. Maximum allowed is 2            complexity
+   527:10  warning  Arrow function has a complexity of 4. Maximum allowed is 2                             complexity
+   959:8   warning  Function 'initializeInteractiveComponent' has a complexity of 3. Maximum allowed is 2  complexity
+  1084:32  warning  Arrow function has a complexity of 4. Maximum allowed is 2                             complexity
+  1119:3   warning  Arrow function has too many parameters (6). Maximum allowed is 3                       max-params
 
 /workspace/dadeto/src/generator/generator.js
   928:1  warning  Function 'generateToyUISection' has a complexity of 4. Maximum allowed is 2  complexity
 
 /workspace/dadeto/src/inputHandlers/dendriteStory.js
   17:1   warning  Function 'maybeRemoveKV' has a complexity of 3. Maximum allowed is 2         complexity
-  25:8   warning  Function 'dendriteStoryHandler' has a complexity of 5. Maximum allowed is 2  complexity
-  61:18  warning  Arrow function has a complexity of 4. Maximum allowed is 2                   complexity
+  27:8   warning  Function 'dendriteStoryHandler' has a complexity of 5. Maximum allowed is 2  complexity
+  63:18  warning  Arrow function has a complexity of 4. Maximum allowed is 2                   complexity
 
 /workspace/dadeto/src/inputHandlers/kv.js
-  3:8  warning  Function 'maybeRemoveNumber' has a complexity of 3. Maximum allowed is 2    complexity
-  9:8  warning  Function 'maybeRemoveDendrite' has a complexity of 3. Maximum allowed is 2  complexity
+   3:8  warning  Function 'maybeRemoveNumber' has a complexity of 3. Maximum allowed is 2    complexity
+  13:8  warning  Function 'maybeRemoveDendrite' has a complexity of 3. Maximum allowed is 2  complexity
 
 /workspace/dadeto/src/presenters/battleshipSolitaireClues.js
   26:1  warning  Function 'validateCluesObject' has a complexity of 9. Maximum allowed is 2                complexity
@@ -40,7 +39,8 @@
   1:8  warning  Function 'startLocalDendriteStory' has a complexity of 9. Maximum allowed is 2  complexity
 
 /workspace/dadeto/src/utils/regexUtils.js
-  23:8  warning  Function 'createPattern' has a complexity of 5. Maximum allowed is 2  complexity
+  23:8   warning  Function 'createPattern' has a complexity of 4. Maximum allowed is 2  complexity
+  30:10  warning  Ternary operator used                                                 no-ternary
 
 /workspace/dadeto/test/browser/createInputDropdownHandler.allTypes.mutantKill.test.js
   17:30  warning  Arrow function has a complexity of 5. Maximum allowed is 2  complexity
@@ -50,12 +50,6 @@
 
 /workspace/dadeto/test/browser/createInputDropdownHandler.dendriteStory.test.js
   19:30  warning  Arrow function has a complexity of 9. Maximum allowed is 2  complexity
-
-/workspace/dadeto/test/browser/createInputDropdownHandler.kv.test.js
-  15:30  warning  Arrow function has a complexity of 3. Maximum allowed is 2  complexity
-
-/workspace/dadeto/test/browser/createInputDropdownHandler.numberThenKv.mutantKill.test.js
-  15:28  warning  Arrow function has a complexity of 4. Maximum allowed is 2  complexity
 
 /workspace/dadeto/test/browser/createInputDropdownHandler.unknownMutantKill.test.js
   13:28  warning  Arrow function has a complexity of 4. Maximum allowed is 2  complexity
@@ -72,4 +66,4 @@
   1208:32  warning  Arrow function has a complexity of 5. Maximum allowed is 2  complexity
   1387:13  warning  Arrow function has a complexity of 3. Maximum allowed is 2  complexity
 
-✖ 35 problems (0 errors, 35 warnings)
+✖ 33 problems (0 errors, 33 warnings)

--- a/test/browser/createInputDropdownHandler.kv.test.js
+++ b/test/browser/createInputDropdownHandler.kv.test.js
@@ -12,11 +12,13 @@ describe('createInputDropdownHandler kv type', () => {
     const dom = {
       getCurrentTarget: jest.fn(() => select),
       getParentElement: jest.fn(() => container),
-      querySelector: jest.fn((el, selector) => {
-        if (selector === 'input[type="text"]') {return textInput;}
-        if (selector === 'input[type="number"]') {return numberInput;}
-        return null;
-      }),
+      querySelector: jest.fn(
+        (el, selector) =>
+          ({
+            'input[type="text"]': textInput,
+            'input[type="number"]': numberInput,
+          })[selector] ?? null
+      ),
       createElement: jest.fn(() => ({})),
       setClassName: jest.fn(),
       getNextSibling: jest.fn(() => null),


### PR DESCRIPTION
## Summary
- use object lookup to simplify `querySelector` in the KV dropdown handler test
- update lint report

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6864e6c31914832e91fd845787d75f2e