### PR TITLE
Fix lint max-params warning

### DIFF
--- a/src/browser/toys.js
+++ b/src/browser/toys.js
@@ -1101,22 +1101,23 @@ export const syncHiddenField = (textInput, rows, dom) => {
  */
 /**
  * Creates a render function with access to the given disposers array and rows
- * @param {Object} dom - The DOM utilities object
- * @param {Array} disposersArray - Array to store cleanup functions
- * @param {HTMLElement} container - The container element for the key-value pairs
- * @param {Object} rows - The rows object containing key-value pairs
- * @param {HTMLInputElement} textInput - The hidden input element
- * @param {Function} syncHiddenField - Function to sync the hidden field
+ * @param {Object} options - Configuration options
+ * @param {Object} options.dom - The DOM utilities object
+ * @param {Array} options.disposersArray - Array to store cleanup functions
+ * @param {HTMLElement} options.container - The container element for the key-value pairs
+ * @param {Object} options.rows - The rows object containing key-value pairs
+ * @param {HTMLInputElement} options.textInput - The hidden input element
+ * @param {Function} options.syncHiddenField - Function to sync the hidden field
  * @returns {Function} The render function
  */
-export const createRenderer = (
+export const createRenderer = ({
   dom,
   disposersArray,
   container,
   rows,
   textInput,
-  syncHiddenField
-) => {
+  syncHiddenField,
+}) => {
   /**
    * Renders the key-value input UI
    */
@@ -1165,14 +1166,14 @@ export const ensureKeyValueInput = (container, textInput, dom) => {
   const disposers = [];
 
   // Create the render function with the required dependencies
-  const render = createRenderer(
+  const render = createRenderer({
     dom,
-    disposers,
-    kvContainer,
+    disposersArray: disposers,
+    container: kvContainer,
     rows,
     textInput,
-    syncHiddenField
-  );
+    syncHiddenField,
+  });
 
   // Initial render
   render();

--- a/src/generator/generator.js
+++ b/src/generator/generator.js
@@ -929,13 +929,11 @@ function generateToyUISection(post) {
   if (!hasToy(post)) {
     return '';
   }
-  let defaultMethod = 'text';
-  if (post.toy && post.toy.defaultInputMethod) {
-    defaultMethod = post.toy.defaultInputMethod;
-  }
-  const sections = getToyUISections(defaultMethod);
+  const defaultMethod = post.toy?.defaultInputMethod ?? 'text';
   return join(
-    sections.map(([label, buildHTML]) => buildToySection(label, buildHTML))
+    getToyUISections(defaultMethod).map(([label, buildHTML]) =>
+      buildToySection(label, buildHTML)
+    )
   );
 }
 

--- a/test/browser/toys.createRenderer.test.js
+++ b/test/browser/toys.createRenderer.test.js
@@ -32,14 +32,14 @@ describe('createRenderer', () => {
     const rows = { foo: 'bar' };
     const textInput = undefined;
     const syncHiddenField = jest.fn();
-    const render = createRenderer(
+    const render = createRenderer({
       dom,
-      disposers,
+      disposersArray: disposers,
       container,
       rows,
       textInput,
-      syncHiddenField
-    );
+      syncHiddenField,
+    });
     render();
     expect(syncHiddenField).toHaveBeenCalled();
   });
@@ -62,14 +62,14 @@ describe('createRenderer', () => {
     const rows = {};
     const textInput = {};
     const syncHiddenField = jest.fn();
-    const render = createRenderer(
+    const render = createRenderer({
       dom,
-      disposers,
+      disposersArray: disposers,
       container,
       rows,
       textInput,
-      syncHiddenField
-    );
+      syncHiddenField,
+    });
     render();
     expect(rows).toEqual({ '': '' });
   });
@@ -92,14 +92,14 @@ describe('createRenderer', () => {
     const rows = { existing: 'val' };
     const textInput = {};
     const syncHiddenField = jest.fn();
-    const render = createRenderer(
+    const render = createRenderer({
       dom,
-      disposers,
+      disposersArray: disposers,
       container,
       rows,
       textInput,
-      syncHiddenField
-    );
+      syncHiddenField,
+    });
     render();
     expect(rows).toEqual({ existing: 'val' });
   });


### PR DESCRIPTION
## Summary
- refactor `createRenderer` to accept a single options object
- update calls and tests to use the new signature
- simplify `generateToyUISection` default method handling

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6864eb03163c832e8f963affc3e7945f