### PR TITLE
Fix one ESLint complexity warning

### DIFF
--- a/test/browser/createInputDropdownHandler.unknownMutantKill.test.js
+++ b/test/browser/createInputDropdownHandler.unknownMutantKill.test.js
@@ -7,15 +7,16 @@ test('createInputDropdownHandler handles unknown select values without throwing'
   const textInput = {};
   const event = {};
 
+  const queryMap = {
+    'input[type="text"]': textInput,
+    'input[type="number"]': { _dispose: jest.fn() },
+    '.kv-container': { _dispose: jest.fn() },
+  };
+
   const dom = {
     getCurrentTarget: jest.fn(() => select),
     getParentElement: jest.fn(() => container),
-    querySelector: jest.fn((_, selector) => {
-      if (selector === 'input[type="text"]') {return textInput;}
-      if (selector === 'input[type="number"]') {return { _dispose: jest.fn() };}
-      if (selector === '.kv-container') {return { _dispose: jest.fn() };}
-      return null;
-    }),
+    querySelector: jest.fn((_, selector) => queryMap[selector] || null),
     getValue: jest.fn(() => 'mystery'),
     reveal: jest.fn(),
     enable: jest.fn(),


### PR DESCRIPTION
## Summary
- simplify mock selector logic in `createInputDropdownHandler.unknownMutantKill.test.js`

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6864ed9bb404832e9650015c12a8b6fb