### PR TITLE
Refactor kv handler to remove lint warning

### DIFF
--- a/src/inputHandlers/kv.js
+++ b/src/inputHandlers/kv.js
@@ -1,22 +1,24 @@
 import { ensureKeyValueInput } from '../browser/toys.js';
 
+function isDisposable(element) {
+  return Boolean(element) && typeof element._dispose === 'function';
+}
+
 export function maybeRemoveNumber(container, dom) {
   const numberInput = dom.querySelector(container, 'input[type="number"]');
-  const dispose = numberInput?._dispose;
-  if (typeof dispose !== 'function') {
+  if (!isDisposable(numberInput)) {
     return;
   }
-  dispose.call(numberInput);
+  numberInput._dispose();
   dom.removeChild(container, numberInput);
 }
 
 export function maybeRemoveDendrite(container, dom) {
   const dendriteForm = dom.querySelector(container, '.dendrite-form');
-  const dispose = dendriteForm?._dispose;
-  if (typeof dispose !== 'function') {
+  if (!isDisposable(dendriteForm)) {
     return;
   }
-  dispose.call(dendriteForm);
+  dendriteForm._dispose();
   dom.removeChild(container, dendriteForm);
 }
 


### PR DESCRIPTION
## Summary
- refactor `maybeRemoveNumber` and `maybeRemoveDendrite` to use a shared `isDisposable` helper
- remove cyclomatic complexity lint warnings for `src/inputHandlers/kv.js`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6864f6cc2fec832eb6ed528a0f4cace4