### PR TITLE
Fix lint warning in dropdown handler test

### DIFF
--- a/src/inputHandlers/dendriteStory.js
+++ b/src/inputHandlers/dendriteStory.js
@@ -16,11 +16,10 @@ function maybeRemoveNumber(container, dom) {
 
 function maybeRemoveKV(container, dom) {
   const kvContainer = dom.querySelector(container, '.kv-container');
-  const dispose = kvContainer?._dispose;
-  if (typeof dispose !== 'function') {
+  if (!kvContainer?._dispose) {
     return;
   }
-  dispose.call(kvContainer);
+  kvContainer._dispose();
   dom.removeChild(container, kvContainer);
 }
 

--- a/src/utils/regexUtils.js
+++ b/src/utils/regexUtils.js
@@ -23,15 +23,11 @@ export function escapeRegex(str) {
 export function createPattern(marker, options) {
   const { isDouble = false, flags = 'g' } = options ?? {};
   const escaped = escapeRegex(marker);
-  const actualMarker = computeActualMarker(escaped, isDouble);
-  return new RegExp(`${actualMarker}(.*?)${actualMarker}`, flags);
-}
-
-function computeActualMarker(escaped, isDouble) {
+  let actualMarker = escaped;
   if (isDouble) {
-    return `${escaped}{2}`;
+    actualMarker = `${escaped}{2}`;
   }
-  return escaped;
+  return new RegExp(`${actualMarker}(.*?)${actualMarker}`, flags);
 }
 
 /**

--- a/test/browser/createInputDropdownHandler.dendriteStory.test.js
+++ b/test/browser/createInputDropdownHandler.dendriteStory.test.js
@@ -17,19 +17,13 @@ describe('createInputDropdownHandler dendrite-story', () => {
       getCurrentTarget: jest.fn(() => select),
       getParentElement: jest.fn(() => container),
       querySelector: jest.fn((el, selector) => {
-        if (el === container && selector === 'input[type="text"]') {
-          return textInput;
-        }
-        if (el === container && selector === 'input[type="number"]') {
-          return numberInput;
-        }
-        if (el === container && selector === '.kv-container') {
-          return kvContainer;
-        }
-        if (el === container && selector === '.dendrite-form') {
-          return null;
-        }
-        return null;
+        const map = {
+          [`${container}|input[type="text"]`]: textInput,
+          [`${container}|input[type="number"]`]: numberInput,
+          [`${container}|.kv-container`]: kvContainer,
+          [`${container}|.dendrite-form`]: null,
+        };
+        return map[`${el}|${selector}`] ?? null;
       }),
       getValue: jest.fn(target => {
         if (target === select) {


### PR DESCRIPTION
## Summary
- simplify `createPattern` to avoid extra function
- refactor `maybeRemoveKV` to return early
- reduce complexity in dropdown handler test

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6864feb9af58832e9fbbb708bef006d6