### PR TITLE
Fix lint warning

### DIFF
--- a/src/inputHandlers/default.js
+++ b/src/inputHandlers/default.js
@@ -1,11 +1,8 @@
-/* eslint-disable complexity */
+import { maybeRemoveElement } from './disposeHelpers.js';
+
 export function dispose(element, dom, container) {
-  if (typeof element?._dispose === 'function') {
-    element._dispose();
-    dom.removeChild(container, element);
-  }
+  maybeRemoveElement(element, container, dom);
 }
-/* eslint-enable complexity */
 
 export function defaultHandler(dom, container, textInput) {
   dom.hide(textInput);

--- a/src/inputHandlers/dendriteStory.js
+++ b/src/inputHandlers/dendriteStory.js
@@ -1,26 +1,13 @@
-function isDisposable(element) {
-  if (!element) {
-    return false;
-  }
-  return typeof element._dispose === 'function';
-}
+import { maybeRemoveElement } from './disposeHelpers.js';
 
 function maybeRemoveNumber(container, dom) {
   const numberInput = dom.querySelector(container, 'input[type="number"]');
-  if (!isDisposable(numberInput)) {
-    return;
-  }
-  numberInput._dispose();
-  dom.removeChild(container, numberInput);
+  maybeRemoveElement(numberInput, container, dom);
 }
 
 function maybeRemoveKV(container, dom) {
   const kvContainer = dom.querySelector(container, '.kv-container');
-  if (!kvContainer?._dispose) {
-    return;
-  }
-  kvContainer._dispose();
-  dom.removeChild(container, kvContainer);
+  maybeRemoveElement(kvContainer, container, dom);
 }
 
 export function dendriteStoryHandler(dom, container, textInput) {

--- a/src/inputHandlers/disposeHelpers.js
+++ b/src/inputHandlers/disposeHelpers.js
@@ -1,0 +1,14 @@
+export function isDisposable(element) {
+  return Boolean(element) && typeof element._dispose === 'function';
+}
+
+export function disposeAndRemove(element, container, dom) {
+  element._dispose();
+  dom.removeChild(container, element);
+}
+
+export function maybeRemoveElement(element, container, dom) {
+  if (isDisposable(element)) {
+    disposeAndRemove(element, container, dom);
+  }
+}

--- a/src/inputHandlers/kv.js
+++ b/src/inputHandlers/kv.js
@@ -1,19 +1,5 @@
 import { ensureKeyValueInput } from '../browser/toys.js';
-
-function isDisposable(element) {
-  return Boolean(element) && typeof element._dispose === 'function';
-}
-
-function disposeAndRemove(element, container, dom) {
-  element._dispose();
-  dom.removeChild(container, element);
-}
-
-function maybeRemoveElement(element, container, dom) {
-  if (isDisposable(element)) {
-    disposeAndRemove(element, container, dom);
-  }
-}
+import { maybeRemoveElement } from './disposeHelpers.js';
 
 export function maybeRemoveNumber(container, dom) {
   const numberInput = dom.querySelector(container, 'input[type="number"]');

--- a/src/inputHandlers/number.js
+++ b/src/inputHandlers/number.js
@@ -1,25 +1,14 @@
 import { ensureNumberInput } from '../browser/toys.js';
-
-function isDisposable(element) {
-  return Boolean(element) && typeof element._dispose === 'function';
-}
+import { maybeRemoveElement } from './disposeHelpers.js';
 
 function maybeRemoveKV(container, dom) {
   const kvContainer = dom.querySelector(container, '.kv-container');
-  if (!isDisposable(kvContainer)) {
-    return;
-  }
-  kvContainer._dispose();
-  dom.removeChild(container, kvContainer);
+  maybeRemoveElement(kvContainer, container, dom);
 }
 
 function maybeRemoveDendrite(container, dom) {
   const dendriteForm = dom.querySelector(container, '.dendrite-form');
-  if (!isDisposable(dendriteForm)) {
-    return;
-  }
-  dendriteForm._dispose();
-  dom.removeChild(container, dendriteForm);
+  maybeRemoveElement(dendriteForm, container, dom);
 }
 
 export function numberHandler(dom, container, textInput) {

--- a/test/inputHandlers/disposeHelpers.test.js
+++ b/test/inputHandlers/disposeHelpers.test.js
@@ -1,0 +1,33 @@
+import { describe, test, expect, jest } from "@jest/globals";
+import {
+  isDisposable,
+  disposeAndRemove,
+  maybeRemoveElement,
+} from "../../src/inputHandlers/disposeHelpers.js";
+
+describe("disposeHelpers", () => {
+  test("isDisposable detects element with dispose", () => {
+    expect(isDisposable({ _dispose: () => {} })).toBe(true);
+    expect(isDisposable(null)).toBe(false);
+    expect(isDisposable({})).toBe(false);
+  });
+
+  test("disposeAndRemove disposes and removes", () => {
+    const element = { _dispose: jest.fn() };
+    const dom = { removeChild: jest.fn() };
+    disposeAndRemove(element, {}, dom);
+    expect(element._dispose).toHaveBeenCalled();
+    expect(dom.removeChild).toHaveBeenCalledWith({}, element);
+  });
+
+  test("maybeRemoveElement acts only on disposables", () => {
+    const element = { _dispose: jest.fn() };
+    const dom = { removeChild: jest.fn() };
+    maybeRemoveElement(element, {}, dom);
+    expect(dom.removeChild).toHaveBeenCalledWith({}, element);
+
+    const otherDom = { removeChild: jest.fn() };
+    maybeRemoveElement({}, {}, otherDom);
+    expect(otherDom.removeChild).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- share common dispose helpers among input handlers
- use helper in dendrite story handler and other handlers
- add disposeHelpers tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68650257f2d0832e93423d61ac5e287f