### PR TITLE
Fix lint warning in test helper

### DIFF
--- a/test/browser/createInputDropdownHandler.allTypes.mutantKill.test.js
+++ b/test/browser/createInputDropdownHandler.allTypes.mutantKill.test.js
@@ -11,16 +11,18 @@ describe('createInputDropdownHandler all types', () => {
     const event = {};
     let numberQueryCount = 0;
 
+    function handleNumberQuery() {
+      numberQueryCount += 1;
+      if (numberQueryCount > 1) {
+        return numberInput;
+      }
+      return null;
+    }
+
     const queryHandlers = {
       'input[type="text"]': () => textInput,
       '.kv-container': () => kvContainer,
-      'input[type="number"]': () => {
-        numberQueryCount += 1;
-        if (numberQueryCount === 1) {
-          return null;
-        }
-        return numberInput;
-      },
+      'input[type="number"]': handleNumberQuery,
     };
 
     function mockQuerySelector(_, selector) {


### PR DESCRIPTION
## Summary
- extract handler for number queries in `createInputDropdownHandler.allTypes` test

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686505799c48832e83a18682d99597d0