### PR TITLE
Fix lint warning

### DIFF
--- a/reports/lint/lint.txt
+++ b/reports/lint/lint.txt
@@ -1,24 +1,17 @@
 
 /workspace/dadeto/src/browser/toys.js
-    15:1   warning  Function 'isKeyValuePair' has a complexity of 3. Maximum allowed is 2                  complexity
-    31:34  warning  Arrow function has a complexity of 6. Maximum allowed is 2                             complexity
-   187:8   warning  Function 'handleDropdownChange' has a complexity of 3. Maximum allowed is 2            complexity
-   529:10  warning  Arrow function has a complexity of 4. Maximum allowed is 2                             complexity
-   961:8   warning  Function 'initializeInteractiveComponent' has a complexity of 3. Maximum allowed is 2  complexity
-  1086:32  warning  Arrow function has a complexity of 4. Maximum allowed is 2                             complexity
-  1121:3   warning  Arrow function has too many parameters (6). Maximum allowed is 3                       max-params
+    28:34  warning  Arrow function has a complexity of 6. Maximum allowed is 2                             complexity
+   185:8   warning  Function 'handleDropdownChange' has a complexity of 3. Maximum allowed is 2            complexity
+   527:10  warning  Arrow function has a complexity of 4. Maximum allowed is 2                             complexity
+   959:8   warning  Function 'initializeInteractiveComponent' has a complexity of 3. Maximum allowed is 2  complexity
+  1084:32  warning  Arrow function has a complexity of 4. Maximum allowed is 2                             complexity
 
 /workspace/dadeto/src/generator/generator.js
   928:1  warning  Function 'generateToyUISection' has a complexity of 4. Maximum allowed is 2  complexity
 
 /workspace/dadeto/src/inputHandlers/dendriteStory.js
-  17:1   warning  Function 'maybeRemoveKV' has a complexity of 3. Maximum allowed is 2         complexity
-  25:8   warning  Function 'dendriteStoryHandler' has a complexity of 5. Maximum allowed is 2  complexity
-  61:18  warning  Arrow function has a complexity of 4. Maximum allowed is 2                   complexity
-
-/workspace/dadeto/src/inputHandlers/kv.js
-  3:8  warning  Function 'maybeRemoveNumber' has a complexity of 3. Maximum allowed is 2    complexity
-  9:8  warning  Function 'maybeRemoveDendrite' has a complexity of 3. Maximum allowed is 2  complexity
+  13:8   warning  Function 'dendriteStoryHandler' has a complexity of 5. Maximum allowed is 2  complexity
+  49:18  warning  Arrow function has a complexity of 4. Maximum allowed is 2                   complexity
 
 /workspace/dadeto/src/presenters/battleshipSolitaireClues.js
   26:1  warning  Function 'validateCluesObject' has a complexity of 9. Maximum allowed is 2                complexity
@@ -31,34 +24,14 @@
   281:1  warning  Function 'parseConfig' has a complexity of 5. Maximum allowed is 2  complexity
 
 /workspace/dadeto/src/toys/2025-05-11/battleshipSolitaireClues.js
-  45:1  warning  Function 'incrementClues' has too many parameters (4). Maximum allowed is 3  max-params
-  45:1  warning  Function 'incrementClues' has a complexity of 3. Maximum allowed is 2        complexity
-  60:1  warning  Function 'parseFleet' has a complexity of 3. Maximum allowed is 2            complexity
-  73:1  warning  Function 'isValidFleet' has a complexity of 6. Maximum allowed is 2          complexity
+  67:1  warning  Function 'parseFleet' has a complexity of 3. Maximum allowed is 2    complexity
+  80:1  warning  Function 'isValidFleet' has a complexity of 6. Maximum allowed is 2  complexity
 
 /workspace/dadeto/src/toys/2025-06-09/startLocalDendriteStory.js
   1:8  warning  Function 'startLocalDendriteStory' has a complexity of 9. Maximum allowed is 2  complexity
 
 /workspace/dadeto/src/utils/regexUtils.js
-  23:8  warning  Function 'createPattern' has a complexity of 5. Maximum allowed is 2  complexity
-
-/workspace/dadeto/test/browser/createInputDropdownHandler.allTypes.mutantKill.test.js
-  17:30  warning  Arrow function has a complexity of 5. Maximum allowed is 2  complexity
-
-/workspace/dadeto/test/browser/createInputDropdownHandler.dendriteStory.mutantKill.additional.test.js
-  16:28  warning  Arrow function has a complexity of 5. Maximum allowed is 2  complexity
-
-/workspace/dadeto/test/browser/createInputDropdownHandler.dendriteStory.test.js
-  19:30  warning  Arrow function has a complexity of 9. Maximum allowed is 2  complexity
-
-/workspace/dadeto/test/browser/createInputDropdownHandler.kv.test.js
-  15:30  warning  Arrow function has a complexity of 3. Maximum allowed is 2  complexity
-
-/workspace/dadeto/test/browser/createInputDropdownHandler.numberThenKv.mutantKill.test.js
-  15:28  warning  Arrow function has a complexity of 4. Maximum allowed is 2  complexity
-
-/workspace/dadeto/test/browser/createInputDropdownHandler.unknownMutantKill.test.js
-  13:28  warning  Arrow function has a complexity of 4. Maximum allowed is 2  complexity
+  31:8  warning  Function 'createPattern' has a complexity of 3. Maximum allowed is 2  complexity
 
 /workspace/dadeto/test/browser/initializeInteractiveComponent.keypress.test.js
   21:33  warning  Arrow function has a complexity of 3. Maximum allowed is 2  complexity
@@ -72,4 +45,4 @@
   1208:32  warning  Arrow function has a complexity of 5. Maximum allowed is 2  complexity
   1387:13  warning  Arrow function has a complexity of 3. Maximum allowed is 2  complexity
 
-✖ 35 problems (0 errors, 35 warnings)
+✖ 22 problems (0 errors, 22 warnings)

--- a/src/utils/regexUtils.js
+++ b/src/utils/regexUtils.js
@@ -20,13 +20,17 @@ export function escapeRegex(str) {
  * @param {string} [options.flags='g'] - Regex flags
  * @returns {RegExp} The compiled regular expression
  */
-export function createPattern(marker, options) {
-  const { isDouble = false, flags = 'g' } = options ?? {};
+function computeActualMarker(marker, isDouble) {
   const escaped = escapeRegex(marker);
-  let actualMarker = escaped;
   if (isDouble) {
-    actualMarker = `${escaped}{2}`;
+    return `${escaped}{2}`;
   }
+  return escaped;
+}
+
+export function createPattern(marker, options = {}) {
+  const actualMarker = computeActualMarker(marker, options.isDouble);
+  const flags = options.flags || 'g';
   return new RegExp(`${actualMarker}(.*?)${actualMarker}`, flags);
 }
 


### PR DESCRIPTION
## Summary
- refactor regex utils to compute markers in a helper
- update lint report

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686507f20638832e8afd4e1e2b0055e5