### PR TITLE
Fix lint warning in clue generator

### DIFF
--- a/public/2025-05-11/battleshipSolitaireClues.js
+++ b/public/2025-05-11/battleshipSolitaireClues.js
@@ -14,7 +14,7 @@ function generateClues(input) {
   const board = { width, height };
   ships.forEach(ship => {
     getShipCells(ship).forEach(([x, y]) => {
-      incrementClues(x, y, board, clues);
+      incrementClues({ x, y }, board, clues);
     });
   });
   return JSON.stringify({ rowClues: clues.row, colClues: clues.col });
@@ -42,11 +42,16 @@ function getVerticalCells(ship) {
 }
 
 
-function incrementClues(x, y, board, clues) {
-  if (isValidX(x, board) && isValidY(y, board)) {
+function incrementClues(position, board, clues) {
+  if (isValidCell(position, board)) {
+    const { x, y } = position;
     clues.row[y] += 1;
     clues.col[x] += 1;
   }
+}
+
+function isValidCell({ x, y }, board) {
+  return isValidX(x, board) && isValidY(y, board);
 }
 
 function isValidX(x, board) {

--- a/reports/lint/lint.txt
+++ b/reports/lint/lint.txt
@@ -20,21 +20,12 @@
 /workspace/dadeto/src/toys/2025-03-29/get.js
   40:1  warning  Function 'traverseSegment' has a complexity of 3. Maximum allowed is 2  complexity
 
-/workspace/dadeto/src/toys/2025-05-08/battleshipSolitaireFleet.js
-  281:1  warning  Function 'parseConfig' has a complexity of 5. Maximum allowed is 2  complexity
-
 /workspace/dadeto/src/toys/2025-05-11/battleshipSolitaireClues.js
   67:1  warning  Function 'parseFleet' has a complexity of 3. Maximum allowed is 2    complexity
   80:1  warning  Function 'isValidFleet' has a complexity of 6. Maximum allowed is 2  complexity
 
-/workspace/dadeto/src/toys/2025-06-09/startLocalDendriteStory.js
-  1:8  warning  Function 'startLocalDendriteStory' has a complexity of 9. Maximum allowed is 2  complexity
-
 /workspace/dadeto/src/utils/regexUtils.js
-  31:8  warning  Function 'createPattern' has a complexity of 3. Maximum allowed is 2  complexity
-
-/workspace/dadeto/test/browser/initializeInteractiveComponent.keypress.test.js
-  21:33  warning  Arrow function has a complexity of 3. Maximum allowed is 2  complexity
+  31:8  warning  Function 'createPattern' has a complexity of 4. Maximum allowed is 2  complexity
 
 /workspace/dadeto/test/browser/toys.getModuleInitializer.invoke.test.js
   23:33  warning  Arrow function has a complexity of 3. Maximum allowed is 2  complexity
@@ -45,4 +36,4 @@
   1208:32  warning  Arrow function has a complexity of 5. Maximum allowed is 2  complexity
   1387:13  warning  Arrow function has a complexity of 3. Maximum allowed is 2  complexity
 
-✖ 22 problems (0 errors, 22 warnings)
+✖ 19 problems (0 errors, 19 warnings)


### PR DESCRIPTION
## Summary
- reduce function parameters and add helper for validity check in public clue generator file
- update lint report

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686510bbcc3c832ebb122d7a4b11aacd