### PR TITLE
Fix lint warning in traverseSegment

### DIFF
--- a/src/toys/2025-03-29/get.js
+++ b/src/toys/2025-03-29/get.js
@@ -43,12 +43,7 @@ function traverseSegment(currentValue, segment, currentPath) {
   if (nonObjectError !== null) {
     return { error: nonObjectError };
   }
-
-  const result = getSegmentValueOrError(currentValue, segment, nextPath);
-  if (result.error) {
-    return { error: result.error };
-  }
-  return { value: result.value, path: result.path, error: null };
+  return getSegmentValueOrError(currentValue, segment, nextPath);
 }
 
 function getNextPath(currentPath, segment) {


### PR DESCRIPTION
## Summary
- simplify `traverseSegment` to reduce cyclomatic complexity

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686511d8f3bc832e9d84cec5eef74fee