### PR TITLE
Fix dropdown handler complexity

### DIFF
--- a/src/browser/toys.js
+++ b/src/browser/toys.js
@@ -186,7 +186,7 @@ export function handleDropdownChange(dropdown, getData, dom) {
   const postId = getDropdownPostId(dropdown);
   const selectedValue = dropdown.value;
   const data = getData();
-  const output = data.output?.[postId];
+  const output = getOutput(data, postId);
 
   const parent = dom.querySelector(dropdown.parentNode, 'div.output');
   setTextContent(
@@ -194,6 +194,13 @@ export function handleDropdownChange(dropdown, getData, dom) {
     dom,
     parent
   );
+}
+
+function getOutput(data, postId) {
+  if (!data.output) {
+    return '';
+  }
+  return data.output[postId] || '';
 }
 
 /**

--- a/src/inputHandlers/kv.js
+++ b/src/inputHandlers/kv.js
@@ -1,15 +1,19 @@
 import { ensureKeyValueInput } from '../browser/toys.js';
 import { maybeRemoveElement } from './disposeHelpers.js';
 
-export function maybeRemoveNumber(container, dom) {
-  const numberInput = dom.querySelector(container, 'input[type="number"]');
-  maybeRemoveElement(numberInput, container, dom);
-}
+export const maybeRemoveNumber = (container, dom) =>
+  maybeRemoveElement(
+    dom.querySelector(container, 'input[type="number"]'),
+    container,
+    dom
+  );
 
-export function maybeRemoveDendrite(container, dom) {
-  const dendriteForm = dom.querySelector(container, '.dendrite-form');
-  maybeRemoveElement(dendriteForm, container, dom);
-}
+export const maybeRemoveDendrite = (container, dom) =>
+  maybeRemoveElement(
+    dom.querySelector(container, '.dendrite-form'),
+    container,
+    dom
+  );
 
 export function handleKVType(dom, container, textInput) {
   maybeRemoveNumber(container, dom);

--- a/src/utils/regexUtils.js
+++ b/src/utils/regexUtils.js
@@ -20,13 +20,10 @@ export function escapeRegex(str) {
  * @param {string} [options.flags='g'] - Regex flags
  * @returns {RegExp} The compiled regular expression
  */
-function computeActualMarker(marker, isDouble) {
+const computeActualMarker = (marker, isDouble) => {
   const escaped = escapeRegex(marker);
-  if (isDouble) {
-    return `${escaped}{2}`;
-  }
-  return escaped;
-}
+  return isDouble ? `${escaped}{2}` : escaped;
+};
 
 export function createPattern(marker, { isDouble = false, flags = 'g' } = {}) {
   const actualMarker = computeActualMarker(marker, isDouble);


### PR DESCRIPTION
## Summary
- create `getOutput` helper and simplify `handleDropdownChange`
- refactor regex helpers to expression style

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686512fc0b68832e85706da9b4148b64