### PR TITLE
Fix lint warning in regexUtils

### DIFF
--- a/src/utils/regexUtils.js
+++ b/src/utils/regexUtils.js
@@ -22,7 +22,10 @@ export function escapeRegex(str) {
  */
 const computeActualMarker = (marker, isDouble) => {
   const escaped = escapeRegex(marker);
-  return isDouble ? `${escaped}{2}` : escaped;
+  if (isDouble) {
+    return `${escaped}{2}`;
+  }
+  return escaped;
 };
 
 export function createPattern(marker, { isDouble = false, flags = 'g' } = {}) {


### PR DESCRIPTION
## Summary
- replace ternary in `computeActualMarker` with `if`/`return` logic

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68651766ad98832e900d337cec2321fd