### PR TITLE
Reduce complexity of isValidFleet

### DIFF
--- a/src/toys/2025-05-11/battleshipSolitaireClues.js
+++ b/src/toys/2025-05-11/battleshipSolitaireClues.js
@@ -77,12 +77,13 @@ function parseFleet(input) {
   return fleet;
 }
 
+function isNumber(value) {
+  return typeof value === 'number';
+}
+
 function isValidFleet(fleet) {
-  return (
-    typeof fleet?.width === 'number' &&
-    typeof fleet?.height === 'number' &&
-    Array.isArray(fleet?.ships)
-  );
+  const { width, height, ships } = Object(fleet);
+  return [width, height].every(isNumber) && Array.isArray(ships);
 }
 
 export { generateClues };


### PR DESCRIPTION
## Summary
- simplify `isValidFleet` by extracting `isNumber`
- update fleet validation to avoid optional chaining

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install --no-save @eslint/js`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686521c538b0832ebda3a753b4ae6670