### PR TITLE
Reduce complexity of validate function

### DIFF
--- a/public/presenters/battleshipSolitaireClues.js
+++ b/public/presenters/battleshipSolitaireClues.js
@@ -23,23 +23,27 @@
  *    (ones) is closest to the grid
  */
 
-function validateCluesObject(obj) {
-  if (!obj || typeof obj !== 'object') {
-    return 'Invalid JSON object';
-  }
-  if (!Array.isArray(obj.rowClues) || !Array.isArray(obj.colClues)) {
-    return 'Missing rowClues or colClues array';
-  }
-  if (
-    obj.rowClues.some(n => typeof n !== 'number') ||
-    obj.colClues.some(n => typeof n !== 'number')
-  ) {
-    return 'Clue values must be numbers';
-  }
-  if (obj.rowClues.length === 0 || obj.colClues.length === 0) {
-    return 'rowClues and colClues must be non-empty';
-  }
-  return '';
+const VALIDATION_CHECKS = [
+  [o => !o || typeof o !== 'object', 'Invalid JSON object'],
+  [
+    o => !Array.isArray(o.rowClues) || !Array.isArray(o.colClues),
+    'Missing rowClues or colClues array',
+  ],
+  [
+    o =>
+      o.rowClues.some(n => typeof n !== 'number') ||
+      o.colClues.some(n => typeof n !== 'number'),
+    'Clue values must be numbers',
+  ],
+  [
+    o => o.rowClues.length === 0 || o.colClues.length === 0,
+    'rowClues and colClues must be non-empty',
+  ],
+];
+
+function findValidationError(obj) {
+  const found = VALIDATION_CHECKS.find(([pred]) => pred(obj));
+  return found ? found[1] : '';
 }
 
 function padLeft(numStr, width) {
@@ -68,7 +72,7 @@ export function createBattleshipCluesBoardElement(inputString, dom) {
     invalid = true;
   }
   if (!invalid) {
-    const error = validateCluesObject(clues);
+    const error = findValidationError(clues);
     if (error) {
       invalid = true;
     }

--- a/src/presenters/battleshipSolitaireClues.js
+++ b/src/presenters/battleshipSolitaireClues.js
@@ -43,20 +43,21 @@ function getClueArrays(obj) {
   return [obj.rowClues, obj.colClues];
 }
 
-function validateCluesObject(obj) {
-  const checks = [
-    [o => !isObject(o), 'Invalid JSON object'],
-    [o => !hasValidClueArrays(o), 'Missing rowClues or colClues array'],
-    [
-      o => getClueArrays(o).some(hasNonNumberValues),
-      'Clue values must be numbers',
-    ],
-    [
-      o => getClueArrays(o).some(isEmpty),
-      'rowClues and colClues must be non-empty',
-    ],
-  ];
-  const found = checks.find(([predicate]) => predicate(obj));
+const VALIDATION_CHECKS = [
+  [o => !isObject(o), 'Invalid JSON object'],
+  [o => !hasValidClueArrays(o), 'Missing rowClues or colClues array'],
+  [
+    o => getClueArrays(o).some(hasNonNumberValues),
+    'Clue values must be numbers',
+  ],
+  [
+    o => getClueArrays(o).some(isEmpty),
+    'rowClues and colClues must be non-empty',
+  ],
+];
+
+function findValidationError(obj) {
+  const found = VALIDATION_CHECKS.find(([predicate]) => predicate(obj));
   if (found) {
     return found[1];
   }
@@ -89,7 +90,7 @@ export function createBattleshipCluesBoardElement(inputString, dom) {
     invalid = true;
   }
   if (!invalid) {
-    const error = validateCluesObject(clues);
+    const error = findValidationError(clues);
     if (error) {
       invalid = true;
     }


### PR DESCRIPTION
## Summary
- extract validator helper for battleship clues presenter
- refactor `validateCluesObject` to delegate to new helper
- inline `validateCluesObject`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6865234c1058832eadb0225daaf7aed2