### PR TITLE
Reduce complexity in battleship clues presenter

### DIFF
--- a/src/presenters/battleshipSolitaireClues.js
+++ b/src/presenters/battleshipSolitaireClues.js
@@ -68,6 +68,24 @@ function padLeft(numStr, width) {
   return numStr.padStart(width, ' ');
 }
 
+const DEFAULT_CLUES = {
+  rowClues: Array(10).fill(0),
+  colClues: Array(10).fill(0),
+};
+
+function safeJsonParse(str) {
+  try {
+    return JSON.parse(str);
+  } catch {
+    return null;
+  }
+}
+
+const INVALID_CLUE_CHECKS = [
+  obj => obj === null,
+  obj => Boolean(findValidationError(obj)),
+];
+
 function buildColumnDigitMatrix(colClues) {
   const maxDigits = Math.max(...colClues).toString().length;
   // top lines array of length maxDigits
@@ -81,23 +99,21 @@ function buildColumnDigitMatrix(colClues) {
   return rows; // order: tens→ones (top→bottom)
 }
 
+/**
+ * Parse JSON input and return clue object or default 10×10 grid clues.
+ * @param {string} inputString
+ * @returns {{rowClues: number[], colClues: number[]}}
+ */
+function parseCluesOrDefault(inputString) {
+  const obj = safeJsonParse(inputString);
+  if (INVALID_CLUE_CHECKS.some(fn => fn(obj))) {
+    return DEFAULT_CLUES;
+  }
+  return obj;
+}
+
 export function createBattleshipCluesBoardElement(inputString, dom) {
-  let clues;
-  let invalid = false;
-  try {
-    clues = JSON.parse(inputString);
-  } catch {
-    invalid = true;
-  }
-  if (!invalid) {
-    const error = findValidationError(clues);
-    if (error) {
-      invalid = true;
-    }
-  }
-  if (invalid) {
-    clues = { rowClues: Array(10).fill(0), colClues: Array(10).fill(0) };
-  }
+  const clues = parseCluesOrDefault(inputString);
 
   const { rowClues, colClues } = clues;
   const width = colClues.length;


### PR DESCRIPTION
## Summary
- extract `parseCluesOrDefault` from `createBattleshipCluesBoardElement`
- parse and validation logic moved to helper with predicate array
- keep tests and lint passing

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6865275a934c832eadf179c0817e1f7b