### PR TITLE
Refactor parseFleet to reduce complexity

### DIFF
--- a/src/toys/2025-05-11/battleshipSolitaireClues.js
+++ b/src/toys/2025-05-11/battleshipSolitaireClues.js
@@ -4,7 +4,9 @@
  * Toy signature:  generateClues(input: string): string
  *   input : JSON string of a { width, height, ships } object
  * Returns a JSON string of { rowClues: number[], colClues: number[] }  or { error }
- */
+*/
+
+import { safeParseJson } from '../../utils/jsonUtils.js';
 
 function generateClues(input) {
   const fleet = parseFleet(input);
@@ -64,17 +66,24 @@ function isValidY(y, board) {
   return y >= 0 && y < board.height;
 }
 
+
 function parseFleet(input) {
-  let fleet;
-  try {
-    fleet = JSON.parse(input);
-  } catch {
-    return { error: 'Invalid input JSON' };
-  }
-  if (!isValidFleet(fleet)) {
-    return { error: 'Invalid fleet structure' };
+  const fleet = safeParseJson(input);
+  const error = computeFleetError(fleet);
+  if (error) {
+    return { error };
   }
   return fleet;
+}
+
+const fleetChecks = [
+  [fleet => fleet === undefined, 'Invalid input JSON'],
+  [fleet => !isValidFleet(fleet), 'Invalid fleet structure'],
+];
+
+function computeFleetError(fleet) {
+  const found = fleetChecks.find(([predicate]) => predicate(fleet));
+  return found ? found[1] : '';
 }
 
 function isNumber(value) {

--- a/src/utils/jsonUtils.js
+++ b/src/utils/jsonUtils.js
@@ -4,10 +4,15 @@
  * @param {*} [fallback={}] - The value to return on failure
  * @returns {*} The parsed value or the fallback
  */
-export function parseJsonOrDefault(json, fallback = {}) {
+export function safeParseJson(json) {
   try {
     return JSON.parse(json);
   } catch {
-    return fallback;
+    return undefined;
   }
+}
+
+export function parseJsonOrDefault(json, fallback = {}) {
+  const value = safeParseJson(json);
+  return value === undefined ? fallback : value;
 }


### PR DESCRIPTION
## Summary
- add helper `safeParseJson` to utils
- refactor `parseFleet` to use `safeParseJson`
- restructure fleet validation logic

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6865308b47b8832eb162d16fd675128e