### PR TITLE
Reduce parseJsonOrDefault complexity

### DIFF
--- a/src/utils/jsonUtils.js
+++ b/src/utils/jsonUtils.js
@@ -12,7 +12,10 @@ export function safeParseJson(json) {
   }
 }
 
-export function parseJsonOrDefault(json, fallback = {}) {
-  const value = safeParseJson(json);
+export function valueOr(value, fallback) {
   return value === undefined ? fallback : value;
+}
+
+export function parseJsonOrDefault(json, fallback = {}) {
+  return valueOr(safeParseJson(json), fallback);
 }


### PR DESCRIPTION
## Summary
- extract `valueOr` helper
- use helper in `parseJsonOrDefault`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68653585a504832eba904423ae4eb60d