### PR TITLE
reduce dendriteStoryHandler complexity

### DIFF
--- a/src/inputHandlers/dendriteStory.js
+++ b/src/inputHandlers/dendriteStory.js
@@ -88,14 +88,20 @@ function buildForm(dom, container, textInput, data, disposers) {
   return form;
 }
 
-export function dendriteStoryHandler(dom, container, textInput) {
+function prepareTextInput(dom, textInput) {
   dom.hide(textInput);
   dom.disable(textInput);
+}
 
+function cleanContainer(dom, container) {
   maybeRemoveNumber(container, dom);
   maybeRemoveKV(container, dom);
-
   removeExistingForm(container, dom);
+}
+
+export function dendriteStoryHandler(dom, container, textInput) {
+  prepareTextInput(dom, textInput);
+  cleanContainer(dom, container);
 
   const disposers = [];
   const data = parseDendriteData(dom, textInput);


### PR DESCRIPTION
## Summary
- extract `prepareTextInput` and `cleanContainer` helpers
- use new helpers inside `dendriteStoryHandler`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68653bf2b09c832e8ef9943bc02890cf