### PR TITLE
Reduce interactive component complexity

### DIFF
--- a/src/browser/toys.js
+++ b/src/browser/toys.js
@@ -967,6 +967,19 @@ function disableInputAndButton(inputElement, submitButton) {
   submitButton.disabled = true;
 }
 
+function getInteractiveElements(dom, article, logWarning) {
+  const inputElement = dom.querySelector(article, 'input[type="text"]');
+  const submitButton = dom.querySelector(article, 'button[type="submit"]');
+  if (!inputElement || !submitButton) {
+    logWarning(
+      'Interactive component missing input or button in article',
+      article.id
+    );
+    return null;
+  }
+  return { inputElement, submitButton };
+}
+
 /**
  * Initializes the interactive elements (input, button, output) within a toy's article element.
  * Sets up event listeners and initial state.
@@ -983,16 +996,11 @@ export function initializeInteractiveComponent(
   const { globalState, createEnvFn, errorFn, fetchFn, dom, getUuid } = config;
   const logWarning = config.loggers.logWarning;
   logInfo('Initializing interactive component for article', article.id);
-  // Get the elements within the article
-  const inputElement = dom.querySelector(article, 'input[type="text"]');
-  const submitButton = dom.querySelector(article, 'button[type="submit"]');
-  if (!inputElement || !submitButton) {
-    logWarning(
-      'Interactive component missing input or button in article',
-      article.id
-    );
+  const elements = getInteractiveElements(dom, article, logWarning);
+  if (!elements) {
     return;
   }
+  const { inputElement, submitButton } = elements;
   // Temporary debug logging for issue investigation
   logInfo('Found input element:', inputElement);
   logInfo('Found button element:', submitButton);


### PR DESCRIPTION
## Summary
- extract `getInteractiveElements` from `initializeInteractiveComponent` to simplify logic

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68653d1af9ec832eab777d9a3a6ba1c6