### PR TITLE
Reduce getOutput complexity

### DIFF
--- a/public/browser/toys.js
+++ b/public/browser/toys.js
@@ -186,7 +186,7 @@ export function handleDropdownChange(dropdown, getData, dom) {
   const postId = getDropdownPostId(dropdown);
   const selectedValue = dropdown.value;
   const data = getData();
-  const output = getOutput(data, postId);
+  const output = outputForPostId(data.output, postId);
 
   const parent = dom.querySelector(dropdown.parentNode, 'div.output');
   setTextContent(
@@ -196,11 +196,11 @@ export function handleDropdownChange(dropdown, getData, dom) {
   );
 }
 
-function getOutput(data, postId) {
-  if (!data.output) {
-    return '';
+function outputForPostId(output, postId) {
+  if (output && output[postId]) {
+    return output[postId];
   }
-  return data.output[postId] || '';
+  return '';
 }
 
 /**

--- a/src/browser/toys.js
+++ b/src/browser/toys.js
@@ -189,7 +189,7 @@ export function handleDropdownChange(dropdown, getData, dom) {
   const postId = getDropdownPostId(dropdown);
   const selectedValue = dropdown.value;
   const data = getData();
-  const output = getOutput(data, postId);
+  const output = outputForPostId(data.output, postId);
 
   const parent = dom.querySelector(dropdown.parentNode, 'div.output');
   setTextContent(
@@ -199,11 +199,11 @@ export function handleDropdownChange(dropdown, getData, dom) {
   );
 }
 
-function getOutput(data, postId) {
-  if (!data.output) {
-    return '';
+function outputForPostId(output, postId) {
+  if (output && output[postId]) {
+    return output[postId];
   }
-  return data.output[postId] || '';
+  return '';
 }
 
 /**


### PR DESCRIPTION
## Summary
- inline `getOutput` wrapper to simplify logic

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68653e884134832ea5c3c73e64963844