### PR TITLE
Reduce regexUtils complexity

### DIFF
--- a/src/utils/regexUtils.js
+++ b/src/utils/regexUtils.js
@@ -28,7 +28,12 @@ const computeActualMarker = (marker, isDouble) => {
   return escaped;
 };
 
-export function createPattern(marker, { isDouble = false, flags = 'g' } = {}) {
+function normalizePatternOptions(options = {}) {
+  return { isDouble: false, flags: 'g', ...options };
+}
+
+export function createPattern(marker, options) {
+  const { isDouble, flags } = normalizePatternOptions(options);
   const actualMarker = computeActualMarker(marker, isDouble);
   return new RegExp(`${actualMarker}(.*?)${actualMarker}`, flags);
 }


### PR DESCRIPTION
## Summary
- extract `normalizePatternOptions` helper from `createPattern`
- default options using object spread to avoid branching

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686551fdac4c832e96b0c2a5f11eb0ab