### PR TITLE
Reduce complexity in getRowsJson

### DIFF
--- a/src/browser/toys.js
+++ b/src/browser/toys.js
@@ -45,9 +45,13 @@ function isBlank(value) {
  * @param {HTMLElement} inputElement - The input element
  * @returns {string} The JSON to parse
  */
+function getDefaultRowsJson(value) {
+  return isBlank(value) ? '{}' : value;
+}
+
 function getRowsJson(dom, inputElement) {
   const value = dom.getValue?.(inputElement);
-  return isBlank(value) ? '{}' : value;
+  return getDefaultRowsJson(value);
 }
 
 export const parseExistingRows = (dom, inputElement) => {


### PR DESCRIPTION
## Summary
- refactor `getRowsJson` by extracting a helper to return default JSON

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68655a450aa8832ebbe1e00d71ca1f19