### PR TITLE
Reduce event handler complexity

### DIFF
--- a/test/browser/toys.getModuleInitializer.invoke.test.js
+++ b/test/browser/toys.getModuleInitializer.invoke.test.js
@@ -18,10 +18,11 @@ describe('getModuleInitializer minimal invoke', () => {
       ['div.output > p', paragraph],
       ['select.output', outputSelect],
     ]);
+    const isSubmitClick = (el, event) => el === submitButton && event === 'click';
     const dom = {
       querySelector: jest.fn((el, selector) => selectorMap.get(selector)),
       addEventListener: jest.fn((el, event, handler) => {
-        if (el === submitButton && event === 'click') {
+        if (isSubmitClick(el, event)) {
           handlers.click = handler;
         }
       }),
@@ -75,10 +76,11 @@ describe('getModuleInitializer minimal invoke', () => {
       ['div.output > p', paragraph],
       ['select.output', outputSelect],
     ]);
+    const isSubmitClick = (el, event) => el === submitButton && event === 'click';
     const dom = {
       querySelector: jest.fn((el, selector) => selectorMap.get(selector)),
       addEventListener: jest.fn((el, event, handler) => {
-        if (el === submitButton && event === 'click') {
+        if (isSubmitClick(el, event)) {
           handlers.click = handler;
         }
       }),


### PR DESCRIPTION
## Summary
- extract a helper function `isSubmitClick` in `toys.getModuleInitializer.invoke.test.js`
- use the helper to simplify event listener logic

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68655b38c074832ebf94c69ff363d56f