### PR TITLE
Fix lint warning

### DIFF
--- a/src/utils/jsonUtils.js
+++ b/src/utils/jsonUtils.js
@@ -13,7 +13,10 @@ export function safeParseJson(json) {
 }
 
 export function valueOr(value, fallback) {
-  return value === undefined ? fallback : value;
+  if (value === undefined) {
+    return fallback;
+  }
+  return value;
 }
 
 export function parseJsonOrDefault(json, fallback = {}) {


### PR DESCRIPTION
## Summary
- refactor `valueOr` to avoid ternary usage

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865634fc960832e8bd9e63c4b17e738