### PR TITLE
Fix lint max-params warning

### DIFF
--- a/src/browser/toys.js
+++ b/src/browser/toys.js
@@ -557,7 +557,7 @@ function isUniqueNonEmpty(key, rows) {
   return !(key in rows);
 }
 
-function migrateRowIfValid(prevKey, newKey, rows, keyEl, dom) {
+function migrateRowIfValid({ prevKey, newKey, rows, keyEl, dom }) {
   if (isUniqueNonEmpty(newKey, rows)) {
     rows[newKey] = rows[prevKey];
     delete rows[prevKey];
@@ -577,7 +577,7 @@ export function createKeyInputHandler(options) {
       return;
     }
 
-    migrateRowIfValid(prevKey, newKey, rows, keyEl, dom);
+    migrateRowIfValid({ prevKey, newKey, rows, keyEl, dom });
     syncHiddenField(textInput, rows, dom);
   };
 }


### PR DESCRIPTION
## Summary
- refactor `migrateRowIfValid` in `src/browser/toys.js` to accept a single options
  object
- update the call site to match

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686563507f40832eb81aa7b90a2aef36