### PR TITLE
Fix lint warning in getDefaultRowsJson

### DIFF
--- a/src/browser/toys.js
+++ b/src/browser/toys.js
@@ -46,7 +46,10 @@ function isBlank(value) {
  * @returns {string} The JSON to parse
  */
 function getDefaultRowsJson(value) {
-  return isBlank(value) ? '{}' : value;
+  if (isBlank(value)) {
+    return '{}';
+  }
+  return value;
 }
 
 function getRowsJson(dom, inputElement) {


### PR DESCRIPTION
## Summary
- fix `no-ternary` lint warning in `getDefaultRowsJson`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6865656333dc832e8163d84b24fdc9a2