### PR TITLE
Fix ESLint warning

### DIFF
--- a/src/browser/toys.js
+++ b/src/browser/toys.js
@@ -32,7 +32,10 @@ function normalizeExisting(existing) {
     [value => value && typeof value === 'object', value => ({ ...value })],
   ];
   const match = converters.find(([check]) => check(existing));
-  return match ? match[1](existing) : {};
+  if (match) {
+    return match[1](existing);
+  }
+  return {};
 }
 
 function isBlank(value) {


### PR DESCRIPTION
## Summary
- remove ternary from `normalizeExisting` to satisfy `no-ternary` rule

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686565649058832e9a30962fb92391f4