### PR TITLE
Fix lint warning by consolidating parameters

### DIFF
--- a/src/inputHandlers/dendriteStory.js
+++ b/src/inputHandlers/dendriteStory.js
@@ -39,7 +39,11 @@ function createInputElement(dom, key) {
   return element;
 }
 
-function createField(dom, form, key, placeholder, data, textInput, disposers) {
+function createField(
+  dom,
+  form,
+  { key, placeholder, data, textInput, disposers }
+) {
   const wrapper = dom.createElement('div');
   const label = dom.createElement('label');
   dom.setTextContent(label, placeholder);
@@ -76,7 +80,13 @@ function buildForm(dom, { container, textInput, data, disposers }) {
   ];
 
   fields.forEach(([key, placeholder]) =>
-    createField(dom, form, key, placeholder, data, textInput, disposers)
+    createField(dom, form, {
+      key,
+      placeholder,
+      data,
+      textInput,
+      disposers,
+    })
   );
 
   dom.setValue(textInput, JSON.stringify(data));


### PR DESCRIPTION
## Summary
- clean up `createField` by bundling parameters into an options object
- update call site accordingly

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68656565a60c832e80998834131a26b5