### PR TITLE
Update sort calls in syncHiddenField tests

### DIFF
--- a/test/browser/toys.syncHiddenField.test.js
+++ b/test/browser/toys.syncHiddenField.test.js
@@ -1,6 +1,8 @@
 import { jest } from '@jest/globals';
 import { syncHiddenField } from '../../src/browser/toys.js';
 
+const compareStrings = (a, b) => a.localeCompare(b);
+
 describe('syncHiddenField', () => {
   let mockTextInput;
   let mockDom;
@@ -39,8 +41,8 @@ describe('syncHiddenField', () => {
     });
 
     // Verify no unexpected entries
-    expect(Object.keys(actual).sort()).toEqual(
-      ['key1', 'emptyValue', 'key2'].sort()
+    expect(Object.keys(actual).sort(compareStrings)).toEqual(
+      ['key1', 'emptyValue', 'key2'].sort(compareStrings)
     );
   });
 
@@ -82,8 +84,8 @@ describe('syncHiddenField', () => {
     });
 
     // Verify no unexpected entries
-    expect(Object.keys(actual).sort()).toEqual(
-      ['key1', '', 'key2', 'key3', '0', 'false'].sort()
+    expect(Object.keys(actual).sort(compareStrings)).toEqual(
+      ['key1', '', 'key2', 'key3', '0', 'false'].sort(compareStrings)
     );
   });
 
@@ -133,8 +135,8 @@ describe('syncHiddenField', () => {
     });
 
     // Verify no unexpected entries
-    expect(Object.keys(actual).sort()).toEqual(
-      ['  key  ', 'key2', '  ', '  key3  '].sort()
+    expect(Object.keys(actual).sort(compareStrings)).toEqual(
+      ['  key  ', 'key2', '  ', '  key3  '].sort(compareStrings)
     );
   });
 });


### PR DESCRIPTION
## Summary
- ensure sort calls use an explicit string comparator in `syncHiddenField` tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6865696c03ac832ead4c8f120ff7d11d