### PR TITLE
Move ensureNumberInput

### DIFF
--- a/src/browser/toys.js
+++ b/src/browser/toys.js
@@ -491,46 +491,6 @@ export const createNumberInput = (value, onChange, dom) => {
 };
 
 /**
- * Positions the number input in the DOM relative to the text input
- * @param {HTMLElement} container - The container element
- * @param {HTMLInputElement} textInput - The text input element
- * @param {HTMLInputElement} numberInput - The number input element to position
- * @param {Object} dom - The DOM utilities object
- * @returns {void}
- */
-const positionNumberInput = ({ container, textInput, numberInput, dom }) => {
-  const nextSibling = dom.getNextSibling(textInput);
-  container.insertBefore(numberInput, nextSibling);
-};
-
-/**
- * Ensures a single <input type="number"> exists just after the text input
- * @param {HTMLElement} container - The container element
- * @param {HTMLInputElement} textInput - The text input element
- * @param {Object} dom - The DOM utilities object
- * @returns {HTMLInputElement} The number input element
- */
-export const ensureNumberInput = (container, textInput, dom) => {
-  let numberInput = dom.querySelector(container, 'input[type="number"]');
-
-  if (!numberInput) {
-    numberInput = createNumberInput(
-      textInput.value, // textInput is assumed to be truthy
-      createUpdateTextInputValue(textInput, dom),
-      dom
-    );
-    positionNumberInput({
-      container,
-      textInput,
-      numberInput,
-      dom,
-    });
-  }
-
-  return numberInput;
-};
-
-/**
  * Creates an event handler that updates a text input's value from an event
  * @param {HTMLInputElement} textInput - The text input element to update
  * @param {Object} dom - The DOM utilities object

--- a/src/inputHandlers/number.js
+++ b/src/inputHandlers/number.js
@@ -1,5 +1,33 @@
-import { ensureNumberInput } from '../browser/toys.js';
+import {
+  createNumberInput,
+  createUpdateTextInputValue,
+} from '../browser/toys.js';
 import { maybeRemoveElement } from './disposeHelpers.js';
+
+const positionNumberInput = ({ container, textInput, numberInput, dom }) => {
+  const nextSibling = dom.getNextSibling(textInput);
+  container.insertBefore(numberInput, nextSibling);
+};
+
+export const ensureNumberInput = (container, textInput, dom) => {
+  let numberInput = dom.querySelector(container, 'input[type="number"]');
+
+  if (!numberInput) {
+    numberInput = createNumberInput(
+      textInput.value,
+      createUpdateTextInputValue(textInput, dom),
+      dom
+    );
+    positionNumberInput({
+      container,
+      textInput,
+      numberInput,
+      dom,
+    });
+  }
+
+  return numberInput;
+};
 
 function maybeRemoveKV(container, dom) {
   const kvContainer = dom.querySelector(container, '.kv-container');

--- a/test/browser/toys.ensureNumberInput.test.js
+++ b/test/browser/toys.ensureNumberInput.test.js
@@ -1,5 +1,5 @@
 import { describe, test, expect, jest } from '@jest/globals';
-import { ensureNumberInput } from '../../src/browser/toys.js';
+import { ensureNumberInput } from '../../src/inputHandlers/number.js';
 
 describe('ensureNumberInput', () => {
   test('should return existing number input without creating a new one', () => {


### PR DESCRIPTION
## Summary
- move ensureNumberInput from toys.js to number handler
- adjust tests
- clean up unused comments

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68656fd21324832e957933ea78eb82ba