### PR TITLE
Extract get variable in minimal args test

### DIFF
--- a/test/browser/toys.test.js
+++ b/test/browser/toys.test.js
@@ -745,7 +745,8 @@ describe('toys', () => {
     it('can be invoked with minimal arguments', () => {
       const functionName = 'process';
       const globalState = {};
-      const createEnv = () => ({ get: () => {} });
+      const get = () => {};
+      const createEnv = () => ({ get });
       const error = () => {};
       const fetch = () => {};
       const paragraph = {};


### PR DESCRIPTION
## Summary
- refactor `initialiseModule` minimal args unit test
- extract `get` variable from arrow function in `createEnv`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6865728a02c0832e90000bce89a5fed1