### PR TITLE
Add compareStrings for sort in test

### DIFF
--- a/test/generator/html.escapeReplacements.length.test.js
+++ b/test/generator/html.escapeReplacements.length.test.js
@@ -1,12 +1,14 @@
 import { describe, test, expect } from '@jest/globals';
 import { htmlEscapeReplacements } from '../../src/generator/html.js';
 
+const compareStrings = (a, b) => a.localeCompare(b);
+
 describe('HTML_ESCAPE_REPLACEMENTS length', () => {
   test('contains five standard replacements', () => {
     const reps = htmlEscapeReplacements();
     expect(Array.isArray(reps)).toBe(true);
     expect(reps).toHaveLength(5);
-    const keys = reps.map(r => Object.keys(r).sort());
+    const keys = reps.map(r => Object.keys(r).sort(compareStrings));
     keys.forEach(k => expect(k).toEqual(['from', 'to']));
   });
 });


### PR DESCRIPTION
## Summary
- specify a compareStrings comparator when sorting keys in the html escape replacements test

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6865730f5f18832e99edc5233a85315a