### PR TITLE
Convert ASCII header to h1

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -157,6 +157,14 @@
         overflow-x: auto;
         margin: 1.5em 0px;
       }
+      h1.ascii-art {
+        background: linear-gradient(0deg, #00ffff, #ff00ff);
+        -webkit-background-clip: text;
+        -webkit-text-fill-color: transparent;
+        overflow-x: auto;
+        margin: 1.5em 0px;
+        white-space: pre;
+      }
       #audio-controls {
         background-color: #1a1a1a;
         color: #00ffff;
@@ -331,17 +339,11 @@
       <div class="entry">
         <div class="key"></div>
         <div class="value">
-          <pre aria-label="Matt Heard" role="heading" aria-level="1">
-▗▖  ▗▖ ▗▄▖▗▄▄▄▖▗▄▄▄▖
-▐▛▚▞▜▌▐▌ ▐▌ █    █
-▐▌  ▐▌▐▛▀▜▌ █    █
-▐▌  ▐▌▐▌ ▐▌ █    █
-▗▖ ▗▖▗▄▄▄▖ ▗▄▖ ▗▄▄▖ ▗▄▄▄
-▐▌ ▐▌▐▌   ▐▌ ▐▌▐▌ ▐▌▐▌  █
-▐▛▀▜▌▐▛▀▀▘▐▛▀▜▌▐▛▀▚▖▐▌  █
-▐▌ ▐▌▐▙▄▄▖▐▌ ▐▌▐▌ ▐▌▐▙▄▄▀
-</pre
-          >
+          <h1 class="ascii-art" aria-label="Matt Heard">
+            ▗▖ ▗▖ ▗▄▖▗▄▄▄▖▗▄▄▄▖ ▐▛▚▞▜▌▐▌ ▐▌ █ █ ▐▌ ▐▌▐▛▀▜▌ █ █ ▐▌ ▐▌▐▌ ▐▌ █ █ ▗▖
+            ▗▖▗▄▄▄▖ ▗▄▖ ▗▄▄▖ ▗▄▄▄ ▐▌ ▐▌▐▌ ▐▌ ▐▌▐▌ ▐▌▐▌ █ ▐▛▀▜▌▐▛▀▀▘▐▛▀▜▌▐▛▀▚▖▐▌
+            █ ▐▌ ▐▌▐▙▄▄▖▐▌ ▐▌▐▌ ▐▌▐▙▄▄▀
+          </h1>
         </div>
         <div class="key"></div>
         <div class="value metadata">

--- a/src/generator/styles.js
+++ b/src/generator/styles.js
@@ -113,6 +113,14 @@ export function styles() {
     overflow-x: auto;
     margin: 1.5em 0px;
   }
+  h1.ascii-art {
+    background: linear-gradient(0deg, #00ffff, #ff00ff);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    overflow-x: auto;
+    margin: 1.5em 0px;
+    white-space: pre;
+  }
   #audio-controls {
     background-color: #1A1A1A;
     color: #00FFFF;

--- a/src/generator/title.js
+++ b/src/generator/title.js
@@ -8,7 +8,7 @@
  * @type {string}
  */
 export function headerBanner() {
-  return `<pre aria-label="Matt Heard" role="heading" aria-level="1">
+  return `<h1 class="ascii-art" aria-label="Matt Heard">
 ▗▖  ▗▖ ▗▄▖▗▄▄▄▖▗▄▄▄▖
 ▐▛▚▞▜▌▐▌ ▐▌ █    █
 ▐▌  ▐▌▐▛▀▜▌ █    █
@@ -17,5 +17,5 @@ export function headerBanner() {
 ▐▌ ▐▌▐▌   ▐▌ ▐▌▐▌ ▐▌▐▌  █
 ▐▛▀▜▌▐▛▀▀▘▐▛▀▜▌▐▛▀▚▖▐▌  █
 ▐▌ ▐▌▐▙▄▄▖▐▌ ▐▌▐▌ ▐▌▐▙▄▄▀
-</pre>`;
+</h1>`;
 }


### PR DESCRIPTION
## Summary
- generate ASCII art banner with `<h1>` rather than `<pre>`
- add CSS rule for `h1.ascii-art` to preserve gradient styling
- regenerate the static `public/index.html`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6865742a2a3c832e8fae70fb1d4313b2