### PR TITLE
Fix duplicate properties in toys tests

### DIFF
--- a/test/browser/toys.test.js
+++ b/test/browser/toys.test.js
@@ -767,14 +767,12 @@ describe('toys', () => {
         querySelector,
         addEventListener: jest.fn(),
         setTextContent: jest.fn(),
-        removeAllChildren: jest.fn(),
         removeWarning: jest.fn(),
         enable: jest.fn(),
         removeChild: jest.fn(),
         appendChild: jest.fn(),
         createElement: jest.fn(() => paragraph),
         contains: () => true,
-        removeAllChildren: jest.fn(),
       };
       // Pass globalState, createEnv, error, and fetch directly
       // Create config object as passed to initializeAndRenderComponent
@@ -843,7 +841,6 @@ describe('toys', () => {
         setTextContent: jest.fn((el, text) => {
           el.textContent = text;
         }),
-        removeAllChildren: jest.fn(),
         removeWarning: jest.fn(),
         enable: jest.fn(),
         contains: () => true,
@@ -939,11 +936,9 @@ describe('toys', () => {
         setTextContent: jest.fn((el, text) => {
           el.textContent = text;
         }),
-        removeAllChildren: jest.fn(),
         removeWarning: jest.fn(),
         enable: jest.fn(),
         contains: () => true,
-        removeAllChildren: jest.fn(),
       };
       const processingFunction = jest.fn(() => 'processed result');
       const config = {


### PR DESCRIPTION
## Summary
- remove repeated `removeAllChildren` properties from test DOM objects

## Testing
- `npm test` *(fails: Cannot find module 'jest')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6865758ac0b4832e89d0b61b5c0e0b25