### PR TITLE
Fix key label regex

### DIFF
--- a/test/generator/generator.constants.test.js
+++ b/test/generator/generator.constants.test.js
@@ -44,7 +44,7 @@ describe('generator constants usage', () => {
 
   test('blog output uses the key class for labels', () => {
     const html = generateBlogOuter({ posts: [] });
-    expect(html).toMatch(/<div class="key(?: |\")/);
+    expect(html).toMatch(/<div class="key[ "]/);
   });
 
   test('blog output closes container before script tag', () => {


### PR DESCRIPTION
## Summary
- replace alternation regex with character class in generator constants test

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686575e6aeb0832e8cc726b25f40b79a