### PR TITLE
Remove unnecessary escape characters

### DIFF
--- a/test/generator/fullWidthElement.begin.test.js
+++ b/test/generator/fullWidthElement.begin.test.js
@@ -14,7 +14,7 @@ describe('fullWidthElement placement', () => {
       ],
     };
     const html = generateBlog({ blog, header, footer }, wrapHtml);
-    expect(html).toContain(`<article class=\"entry\" id=\"FWX\">${fullWidthElement()}`);
+    expect(html).toContain(`<article class="entry" id="FWX">${fullWidthElement()}`);
   });
 
   test('fullWidthElement constant length is unchanged', () => {

--- a/test/generator/generator.constants.test.js
+++ b/test/generator/generator.constants.test.js
@@ -44,7 +44,7 @@ describe('generator constants usage', () => {
 
   test('blog output uses the key class for labels', () => {
     const html = generateBlogOuter({ posts: [] });
-    expect(html).toMatch(/<div class="key(?: |\")/);
+    expect(html).toMatch(/<div class="key(?: |")/);
   });
 
   test('blog output closes container before script tag', () => {

--- a/test/generator/toyOutputDropdown.test.js
+++ b/test/generator/toyOutputDropdown.test.js
@@ -58,7 +58,7 @@ describe('toy output dropdown', () => {
     const html = generateBlog({ blog, header, footer }, wrapHtml);
     const match = html.match(/<select class="output">([\s\S]*?)<\/select>/);
     expect(match).not.toBeNull();
-    const optionRegex = /<option value="([^\"]+)">([^<]*)<\/option>/g;
+    const optionRegex = /<option value="([^"]+)">([^<]*)<\/option>/g;
     const pairs = [];
     let m;
     while ((m = optionRegex.exec(match[1])) !== null) {

--- a/test/toys/2025-05-11/generateClues.nullFleet.new.test.js
+++ b/test/toys/2025-05-11/generateClues.nullFleet.new.test.js
@@ -1,7 +1,7 @@
 import { test, expect } from '@jest/globals';
 import { generateClues } from '../../../src/toys/2025-05-11/battleshipSolitaireClues.js';
 
-test('generateClues handles \"null\" input without throwing', () => {
+test('generateClues handles "null" input without throwing', () => {
   const result = generateClues('null');
   expect(result).toBe('{"error":"Invalid fleet structure"}');
 });


### PR DESCRIPTION
## Summary
- drop stray escape sequences from test assertions
- fix dropdown test after comment feedback

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686575ae56a8832e8263aedf75bcec75