### PR TITLE
Remove observer callback logs

### DIFF
--- a/public/browser/toys.js
+++ b/public/browser/toys.js
@@ -393,11 +393,9 @@ export function makeObserverCallback(moduleInfo, env, dom) {
     `[${moduleInfo.article.id}]`
   );
   const handleEntryFactory = getEntryHandler(moduleInfo, moduleConfig);
-  const logInfo = moduleConfig.loggers.logInfo;
   return (entries, observer) => {
     const handleEntry = handleEntryFactory(observer);
     entries.forEach(entry => {
-      logInfo('Observer callback for article', moduleInfo.article.id);
       handleEntry(entry);
     });
   };

--- a/src/browser/toys.js
+++ b/src/browser/toys.js
@@ -393,11 +393,9 @@ export function makeObserverCallback(moduleInfo, env, dom) {
     `[${moduleInfo.article.id}]`
   );
   const handleEntryFactory = getEntryHandler(moduleInfo, moduleConfig);
-  const logInfo = moduleConfig.loggers.logInfo;
   return (entries, observer) => {
     const handleEntry = handleEntryFactory(observer);
     entries.forEach(entry => {
-      logInfo('Observer callback for article', moduleInfo.article.id);
       handleEntry(entry);
     });
   };

--- a/test/browser/makeObserverCallback.logInfo.order.test.js
+++ b/test/browser/makeObserverCallback.logInfo.order.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect, jest } from '@jest/globals';
 import { makeObserverCallback } from '../../src/browser/toys.js';
 
 describe('makeObserverCallback logging order', () => {
-  it('logs observer callback then module import', () => {
+  it('logs module import first', () => {
     const dom = {
       removeAllChildren: jest.fn(),
       importModule: jest.fn(),
@@ -27,17 +27,11 @@ describe('makeObserverCallback logging order', () => {
     expect(logInfo).toHaveBeenNthCalledWith(
       1,
       `[${moduleInfo.article.id}]`,
-      'Observer callback for article',
-      moduleInfo.article.id
-    );
-    expect(logInfo).toHaveBeenNthCalledWith(
-      2,
-      `[${moduleInfo.article.id}]`,
       'Starting module import for article',
       moduleInfo.article.id,
       'module',
       moduleInfo.modulePath
     );
-    expect(logInfo).toHaveBeenCalledTimes(2);
+    expect(logInfo).toHaveBeenCalledTimes(1);
   });
 });

--- a/test/browser/makeObserverCallback.logInfo.test.js
+++ b/test/browser/makeObserverCallback.logInfo.test.js
@@ -26,12 +26,6 @@ describe('makeObserverCallback logging', () => {
 
     expect(logInfo).toHaveBeenCalledWith(
       `[${moduleInfo.article.id}]`,
-      'Observer callback for article',
-      moduleInfo.article.id
-    );
-
-    expect(logInfo).toHaveBeenCalledWith(
-      `[${moduleInfo.article.id}]`,
       'Starting module import for article',
       moduleInfo.article.id,
       'module',
@@ -39,7 +33,7 @@ describe('makeObserverCallback logging', () => {
     );
   });
 
-  it('logs observer callback when entry is intersecting', () => {
+  it('logs module import when entry is intersecting once', () => {
     const dom = {
       removeAllChildren: jest.fn(),
       importModule: jest.fn(),
@@ -64,8 +58,10 @@ describe('makeObserverCallback logging', () => {
     expect(logInfo).toHaveBeenNthCalledWith(
       1,
       `[${moduleInfo.article.id}]`,
-      'Observer callback for article',
-      moduleInfo.article.id
+      'Starting module import for article',
+      moduleInfo.article.id,
+      'module',
+      moduleInfo.modulePath
     );
   });
 

--- a/test/browser/makeObserverCallback.observerLog.test.js
+++ b/test/browser/makeObserverCallback.observerLog.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect, jest } from '@jest/globals';
 import { makeObserverCallback } from '../../src/browser/toys.js';
 
 describe('makeObserverCallback observer log', () => {
-  it('logs a message for each observer entry when intersecting', () => {
+  it('logs when observer entry intersects', () => {
     const dom = {
       removeAllChildren: jest.fn(),
       importModule: jest.fn(),
@@ -24,8 +24,10 @@ describe('makeObserverCallback observer log', () => {
     observerCallback([entry], observer);
     expect(logInfo).toHaveBeenCalledWith(
       `[${moduleInfo.article.id}]`,
-      'Observer callback for article',
-      moduleInfo.article.id
+      'Starting module import for article',
+      moduleInfo.article.id,
+      'module',
+      moduleInfo.modulePath
     );
   });
 });

--- a/test/browser/makeObserverCallback.observerMessage.test.js
+++ b/test/browser/makeObserverCallback.observerMessage.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect, jest } from '@jest/globals';
 import { makeObserverCallback } from '../../src/browser/toys.js';
 
 describe('makeObserverCallback observer message', () => {
-  it('logs observer callback for each entry', () => {
+  it('logs a message for each entry', () => {
     const dom = {
       removeAllChildren: jest.fn(),
       importModule: jest.fn(),
@@ -26,8 +26,10 @@ describe('makeObserverCallback observer message', () => {
 
     expect(logInfo).toHaveBeenCalledWith(
       `[${moduleInfo.article.id}]`,
-      'Observer callback for article',
-      moduleInfo.article.id
+      'Starting module import for article',
+      moduleInfo.article.id,
+      'module',
+      moduleInfo.modulePath
     );
   });
 });


### PR DESCRIPTION
## Summary
- drop unnecessary log from `makeObserverCallback`
- update generated browser bundle
- adjust related observer tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686577c17f2c832eb41e093188a58de0