### PR TITLE
Use BLOG_STATUS constant in idle check test

### DIFF
--- a/test/browser/createInputDropdownHandler.number.test.js
+++ b/test/browser/createInputDropdownHandler.number.test.js
@@ -50,5 +50,6 @@ describe('createInputDropdownHandler number type', () => {
     expect(() => handler(event)).not.toThrow();
     expect(dom.removeChild).toHaveBeenCalledWith(container, kvContainer);
     expect(container.insertBefore).toHaveBeenCalledWith(expect.anything(), null);
+    expect(dom.createElement).toHaveBeenCalledWith('input');
   });
 });

--- a/test/browser/shouldCopyStateForFetch.idleConstant.test.js
+++ b/test/browser/shouldCopyStateForFetch.idleConstant.test.js
@@ -1,8 +1,8 @@
 import { describe, it, expect } from '@jest/globals';
-import { shouldCopyStateForFetch } from '../../src/browser/data.js';
+import { shouldCopyStateForFetch, BLOG_STATUS } from '../../src/browser/data.js';
 
 describe('shouldCopyStateForFetch idle constant usage', () => {
-  it('returns true when passed the string "idle"', () => {
-    expect(shouldCopyStateForFetch('idle')).toBe(true);
+  it('returns true when passed BLOG_STATUS.IDLE', () => {
+    expect(shouldCopyStateForFetch(BLOG_STATUS.IDLE)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- verify shouldCopyStateForFetch() using BLOG_STATUS.IDLE
- run npm install to restore dependencies

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686578132adc832e8ad2d48ede7c11d5