### PR TITLE
Improve audio controls test

### DIFF
--- a/test/generator/mediaContentConfig.audioOnly.test.js
+++ b/test/generator/mediaContentConfig.audioOnly.test.js
@@ -19,6 +19,8 @@ describe('MEDIA_CONTENT_CONFIG single audio', () => {
     };
     const html = generateBlog({ blog, header, footer }, wrapHtml);
     expect(html).toContain('<audio');
+    // Ensure the audio tag includes the controls attribute
+    expect(html).toContain('<audio class="value" controls>');
     expect(html).not.toContain('<img');
     expect(html).not.toContain('<iframe');
   });


### PR DESCRIPTION
## Summary
- strengthen mediaContentConfig.audioOnly.test by checking `controls` attribute

## Testing
- `npx jest test/generator/mediaContentConfig.audioOnly.test.js`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68657813dd68832e91ddcdbe2dd91920