### PR TITLE
Remove direct locale spy

### DIFF
--- a/test/generator/generateBlogOuter.dateFormat.test.js
+++ b/test/generator/generateBlogOuter.dateFormat.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, jest } from '@jest/globals';
+import { describe, it, expect } from '@jest/globals';
 import { generateBlogOuter } from '../../src/generator/generator.js';
 
 describe('generateBlogOuter date formatting', () => {
@@ -14,10 +14,7 @@ describe('generateBlogOuter date formatting', () => {
       ],
     };
 
-    const spy = jest.spyOn(Date.prototype, 'toLocaleDateString');
     const html = generateBlogOuter(blog);
     expect(html).toContain('<p class="value metadata">1 Jun 2024</p>');
-    expect(spy).toHaveBeenCalledWith('en-GB', expect.any(Object));
-    spy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- rely solely on HTML output to verify date formatting

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68657812621c832e86a38e581911cf1a