### PR TITLE
Move number helpers into number handler

### DIFF
--- a/src/browser/toys.js
+++ b/src/browser/toys.js
@@ -102,16 +102,6 @@ import { createTicTacToeBoardElement } from '../presenters/ticTacToeBoard.js';
 import { createBattleshipFleetBoardElement } from '../presenters/battleshipSolitaireFleet.js';
 import { createBattleshipCluesBoardElement } from '../presenters/battleshipSolitaireClues.js';
 
-/**
- * Creates a basic number input element
- * @param {Object} dom - The DOM utilities object
- * @returns {HTMLInputElement} The created input element
- */
-const createBaseNumberInput = dom => {
-  const input = dom.createElement('input');
-  dom.setType(input, 'number');
-  return input;
-};
 
 /**
  * Creates a handler for input dropdown changes
@@ -152,17 +142,6 @@ export const createInputDropdownHandler = dom => {
   };
 };
 
-/**
- * Sets up the event listener and disposal for the input
- * @param {HTMLInputElement} input - The input element
- * @param {Function} onChange - The change handler
- * @param {Object} dom - The DOM utilities object
- * @returns {void}
- */
-const setupInputEvents = (input, onChange, dom) => {
-  dom.addEventListener(input, 'input', onChange);
-  input._dispose = createRemoveValueListener(dom, input, onChange);
-};
 
 /**
  * Creates a component initializer function for setting up intersection observers.
@@ -479,25 +458,6 @@ import { isObject } from './common.js';
  * @param {Object} dom - The DOM utilities object
  * @returns {HTMLInputElement} The created number input element
  */
-export const createNumberInput = (value, onChange, dom) => {
-  const input = createBaseNumberInput(dom);
-  if (value) {
-    dom.setValue(input, value);
-  }
-  setupInputEvents(input, onChange, dom);
-  return input;
-};
-
-/**
- * Creates an event handler that updates a text input's value from an event
- * @param {HTMLInputElement} textInput - The text input element to update
- * @param {Object} dom - The DOM utilities object
- * @returns {Function} An event handler function
- */
-export const createUpdateTextInputValue = (textInput, dom) => event => {
-  const targetValue = dom.getTargetValue(event);
-  dom.setValue(textInput, targetValue);
-};
 
 function hasRequestField(val) {
   return Object.hasOwn(val, 'request');

--- a/src/inputHandlers/number.js
+++ b/src/inputHandlers/number.js
@@ -1,8 +1,32 @@
-import {
-  createNumberInput,
-  createUpdateTextInputValue,
-} from '../browser/toys.js';
 import { maybeRemoveElement } from './disposeHelpers.js';
+
+const createRemoveValueListener = (dom, el, handler) => () =>
+  dom.removeEventListener(el, 'input', handler);
+
+const createBaseNumberInput = dom => {
+  const input = dom.createElement('input');
+  dom.setType(input, 'number');
+  return input;
+};
+
+const setupInputEvents = (input, onChange, dom) => {
+  dom.addEventListener(input, 'input', onChange);
+  input._dispose = createRemoveValueListener(dom, input, onChange);
+};
+
+export const createNumberInput = (value, onChange, dom) => {
+  const input = createBaseNumberInput(dom);
+  if (value) {
+    dom.setValue(input, value);
+  }
+  setupInputEvents(input, onChange, dom);
+  return input;
+};
+
+export const createUpdateTextInputValue = (textInput, dom) => event => {
+  const targetValue = dom.getTargetValue(event);
+  dom.setValue(textInput, targetValue);
+};
 
 const positionNumberInput = ({ container, textInput, numberInput, dom }) => {
   const nextSibling = dom.getNextSibling(textInput);

--- a/test/browser/createNumberInput.dispose.test.js
+++ b/test/browser/createNumberInput.dispose.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, jest } from '@jest/globals';
-import { createNumberInput } from '../../src/browser/toys.js';
+import { createNumberInput } from '../../src/inputHandlers/number.js';
 
 describe('createNumberInput disposer', () => {
   it('removes the input event listener when _dispose is called', () => {

--- a/test/browser/createRemoveValueListener.handleKVType.integration.test.js
+++ b/test/browser/createRemoveValueListener.handleKVType.integration.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, jest } from '@jest/globals';
 import * as toys from '../../src/browser/toys.js';
+import { createNumberInput } from '../../src/inputHandlers/number.js';
 
 // Test ensuring createRemoveValueListener disposer runs when handleKVType removes a number input
 
@@ -30,7 +31,7 @@ describe('handleKVType integration with createRemoveValueListener', () => {
     const textInput = { value: '1' };
     const onChange = jest.fn();
 
-    const numberInput = toys.createNumberInput('1', onChange, dom);
+    const numberInput = createNumberInput('1', onChange, dom);
 
     dom.querySelector.mockImplementation((el, selector) => {
       if (selector === 'input[type="number"]') {

--- a/test/browser/toys.createNumberInput.test.js
+++ b/test/browser/toys.createNumberInput.test.js
@@ -1,5 +1,5 @@
 import { jest } from '@jest/globals';
-import { createNumberInput } from '../../src/browser/toys.js';
+import { createNumberInput } from '../../src/inputHandlers/number.js';
 
 describe('createNumberInput', () => {
   let mockDom;

--- a/test/browser/toys.createUpdateTextInputValue.test.js
+++ b/test/browser/toys.createUpdateTextInputValue.test.js
@@ -1,5 +1,5 @@
 import { jest } from '@jest/globals';
-import { createUpdateTextInputValue } from '../../src/browser/toys.js';
+import { createUpdateTextInputValue } from '../../src/inputHandlers/number.js';
 
 describe('createUpdateTextInputValue', () => {
   let textInput;


### PR DESCRIPTION
## Summary
- relocate `createNumberInput` and `createUpdateTextInputValue` into `number.js`
- inline number-input helpers in `number.js`
- update tests to import from the new location

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865785e36fc832eb451dcb05d83eceb