### PR TITLE
Fix sonar script and remove circular import

### DIFF
--- a/src/browser/toys.js
+++ b/src/browser/toys.js
@@ -115,11 +115,9 @@ export const createAddDropdownListener = (onChange, dom) => dropdown => {
 
 import { textHandler } from '../inputHandlers/text.js';
 import { numberHandler } from '../inputHandlers/number.js';
-import { kvHandler } from '../inputHandlers/kv.js';
 import { defaultHandler } from '../inputHandlers/default.js';
 import { dendriteStoryHandler } from '../inputHandlers/dendriteStory.js';
-
-export { handleKVType } from '../inputHandlers/kv.js';
+import { maybeRemoveElement } from '../inputHandlers/disposeHelpers.js';
 
 const inputHandlersMap = {
   text: textHandler,
@@ -1160,3 +1158,63 @@ export const createDropdownInitializer = (
  */
 export const getDeepStateCopy = globalState =>
   JSON.parse(JSON.stringify(globalState));
+
+export const ensureKeyValueInput = (container, textInput, dom) => {
+  let kvContainer = dom.querySelector(container, '.kv-container');
+  if (!kvContainer) {
+    kvContainer = dom.createElement('div');
+    dom.setClassName(kvContainer, 'kv-container');
+    const nextSibling = dom.getNextSibling(textInput);
+    dom.insertBefore(container, kvContainer, nextSibling);
+  }
+
+  const rows = parseExistingRows(dom, textInput);
+  const disposers = [];
+
+  const render = createRenderer({
+    dom,
+    disposersArray: disposers,
+    container: kvContainer,
+    rows,
+    textInput,
+    syncHiddenField,
+  });
+
+  render();
+
+  const dispose = createDispose({
+    disposers,
+    dom,
+    container: kvContainer,
+    rows,
+  });
+  kvContainer._dispose = dispose;
+
+  return kvContainer;
+};
+
+export const maybeRemoveNumber = (container, dom) =>
+  maybeRemoveElement(
+    dom.querySelector(container, 'input[type="number"]'),
+    container,
+    dom
+  );
+
+export const maybeRemoveDendrite = (container, dom) =>
+  maybeRemoveElement(
+    dom.querySelector(container, '.dendrite-form'),
+    container,
+    dom
+  );
+
+export function handleKVType(dom, container, textInput) {
+  maybeRemoveNumber(container, dom);
+  maybeRemoveDendrite(container, dom);
+  ensureKeyValueInput(container, textInput, dom);
+}
+
+export function kvHandler(dom, container, textInput) {
+  dom.hide(textInput);
+  dom.disable(textInput);
+  handleKVType(dom, container, textInput);
+}

--- a/src/scripts/get-sonar-issues.sh
+++ b/src/scripts/get-sonar-issues.sh
@@ -1,5 +1,3 @@
-
-
 #!/usr/bin/env bash
 #
 # Fetch the first page (max 500 rows) of *unresolved* SonarCloud issues for the


### PR DESCRIPTION
## Summary
- ensure `get-sonar-issues.sh` starts with a shebang
- break the toys/kv circular import by defining `kvHandler` and helpers in `toys.js`

## Testing
- `npm run lint`
- `npm test`
- `npm run sonar-issues` *(fails: SONAR_TOKEN environment variable is not set)*

------
https://chatgpt.com/codex/tasks/task_e_68658c336e60832e98bacaf07c75c91e