### PR TITLE
Fix sonar duplication by removing redundant KV handler

### DIFF
--- a/src/browser/toys.js
+++ b/src/browser/toys.js
@@ -117,7 +117,7 @@ import { textHandler } from '../inputHandlers/text.js';
 import { numberHandler } from '../inputHandlers/number.js';
 import { defaultHandler } from '../inputHandlers/default.js';
 import { dendriteStoryHandler } from '../inputHandlers/dendriteStory.js';
-import { maybeRemoveElement } from '../inputHandlers/disposeHelpers.js';
+import { kvHandler } from '../inputHandlers/kv.js';
 
 const inputHandlersMap = {
   text: textHandler,
@@ -1159,62 +1159,3 @@ export const createDropdownInitializer = (
 export const getDeepStateCopy = globalState =>
   JSON.parse(JSON.stringify(globalState));
 
-export const ensureKeyValueInput = (container, textInput, dom) => {
-  let kvContainer = dom.querySelector(container, '.kv-container');
-  if (!kvContainer) {
-    kvContainer = dom.createElement('div');
-    dom.setClassName(kvContainer, 'kv-container');
-    const nextSibling = dom.getNextSibling(textInput);
-    dom.insertBefore(container, kvContainer, nextSibling);
-  }
-
-  const rows = parseExistingRows(dom, textInput);
-  const disposers = [];
-
-  const render = createRenderer({
-    dom,
-    disposersArray: disposers,
-    container: kvContainer,
-    rows,
-    textInput,
-    syncHiddenField,
-  });
-
-  render();
-
-  const dispose = createDispose({
-    disposers,
-    dom,
-    container: kvContainer,
-    rows,
-  });
-  kvContainer._dispose = dispose;
-
-  return kvContainer;
-};
-
-export const maybeRemoveNumber = (container, dom) =>
-  maybeRemoveElement(
-    dom.querySelector(container, 'input[type="number"]'),
-    container,
-    dom
-  );
-
-export const maybeRemoveDendrite = (container, dom) =>
-  maybeRemoveElement(
-    dom.querySelector(container, '.dendrite-form'),
-    container,
-    dom
-  );
-
-export function handleKVType(dom, container, textInput) {
-  maybeRemoveNumber(container, dom);
-  maybeRemoveDendrite(container, dom);
-  ensureKeyValueInput(container, textInput, dom);
-}
-
-export function kvHandler(dom, container, textInput) {
-  dom.hide(textInput);
-  dom.disable(textInput);
-  handleKVType(dom, container, textInput);
-}

--- a/test/browser/createRemoveValueListener.handleKVType.integration.test.js
+++ b/test/browser/createRemoveValueListener.handleKVType.integration.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, jest } from '@jest/globals';
-import * as toys from '../../src/browser/toys.js';
+import { handleKVType } from '../../src/inputHandlers/kv.js';
 import { createNumberInput } from '../../src/inputHandlers/number.js';
 
 // Test ensuring createRemoveValueListener disposer runs when handleKVType removes a number input
@@ -40,7 +40,7 @@ describe('handleKVType integration with createRemoveValueListener', () => {
       return null;
     });
 
-    toys.handleKVType(dom, container, textInput);
+    handleKVType(dom, container, textInput);
 
     const handler = dom.addEventListener.mock.calls[0][2];
     expect(dom.removeEventListener).toHaveBeenCalledWith(numberInput, 'input', handler);

--- a/test/browser/toys.handleKVType.effects.test.js
+++ b/test/browser/toys.handleKVType.effects.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, jest } from '@jest/globals';
-import { handleKVType } from '../../src/browser/toys.js';
+import { handleKVType } from '../../src/inputHandlers/kv.js';
 
 describe('handleKVType effects', () => {
   it('removes number input and sets up key-value container', () => {

--- a/test/browser/toys.handleKVType.test.js
+++ b/test/browser/toys.handleKVType.test.js
@@ -1,5 +1,5 @@
 import { describe, test, expect, jest } from '@jest/globals';
-import * as toys from '../../src/browser/toys.js';
+import { handleKVType } from '../../src/inputHandlers/kv.js';
 
 describe('handleKVType', () => {
   test('can be invoked with an empty DOM object', () => {
@@ -30,7 +30,7 @@ describe('handleKVType', () => {
 
     // This test verifies the function can be called with an empty DOM object without throwing an error
     expect(() => {
-      toys.handleKVType(dom, {}, {});
+      handleKVType(dom, {}, {});
     }).not.toThrow();
   });
 
@@ -67,7 +67,7 @@ describe('handleKVType', () => {
       createTextNode: jest.fn(),
     };
 
-    toys.handleKVType(dom, container, textInput);
+    handleKVType(dom, container, textInput);
 
     expect(querySelector).toHaveBeenCalledWith(
       container,


### PR DESCRIPTION
## Summary
- run Sonar script to check issues
- remove duplicated key/value handler code from `toys.js`
- import kv handler from `inputHandlers/kv.js`
- update tests to use the new import

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6865946df544832e9a1bd47b35ccf82f