### PR TITLE
Remove duplicate deepMerge in toy script

### DIFF
--- a/src/toys/2025-03-29/setTemporary.js
+++ b/src/toys/2025-03-29/setTemporary.js
@@ -1,44 +1,5 @@
-/**
- * Checks if an item is a plain object (not an array or null).
- * @param {*} item - The item to check.
- * @returns {boolean}
- */
-function isObject(item) {
-  return item && isNonArrayObject(item);
-}
-
-function isNonArrayObject(item) {
-  return typeof item === 'object' && !Array.isArray(item);
-}
-
-/**
- * Deeply merges two objects. Creates a new object with merged properties.
- * Properties in source will overwrite properties in target, unless both
- * properties are plain objects, in which case they are recursively merged.
- * Arrays and other types are overwritten, not merged.
- * @param {object} target - The target object.
- * @param {object} source - The source object.
- * @returns {object} A new object representing the merged result.
- */
-function deepMerge(target, source) {
-  const output = { ...target };
-  const mergeKey = key => {
-    const targetValue = target[key];
-    const sourceValue = source[key];
-    if (shouldDeepMerge(targetValue, sourceValue)) {
-      output[key] = deepMerge(targetValue, sourceValue);
-    } else {
-      output[key] = sourceValue;
-    }
-  };
-  Object.keys(source).forEach(mergeKey);
-  return output;
-}
-
-function shouldDeepMerge(targetValue, sourceValue) {
-  return isObject(targetValue) && isObject(sourceValue);
-}
-
+import { isObject } from '../../browser/common.js';
+import { deepMerge } from '../../browser/data.js';
 
 /**
  * Parses input as JSON, deep merges it into the 'temporary' object obtained via env.getData(),
@@ -59,7 +20,7 @@ export function setTemporary(input, env) {
 
 function processSetTemporary(inputJson, env) {
   if (!isObject(inputJson)) {
-    return "Error: Input JSON must be a plain object.";
+    return 'Error: Input JSON must be a plain object.';
   }
   return handleValidTemporaryInput(inputJson, env);
 }
@@ -83,5 +44,4 @@ function mergeTemporaryData(getData, setData, inputJson) {
   newData.temporary = deepMerge(newData.temporary, inputJson);
   setData(newData);
   return `Success: Temporary data deep merged.`;
-
 }


### PR DESCRIPTION
## Summary
- refactor `setTemporary` to use shared `deepMerge` and `isObject` helpers
- run lint and tests

## Testing
- `npm run lint`
- `npm test`
- `npm run duplication`


------
https://chatgpt.com/codex/tasks/task_e_68659a8ff358832eac952de9a4dcf8db