### PR TITLE
Fix lint warning

### DIFF
--- a/test/toys/2025-05-08/battleshipSolitaireFleet.segmentBounds.test.js
+++ b/test/toys/2025-05-08/battleshipSolitaireFleet.segmentBounds.test.js
@@ -3,6 +3,8 @@ import { describe, test, expect } from '@jest/globals';
 
 /**
  * Ensure generated ship segments stay within board bounds.
+ * @param {{start: {x: number, y: number}, direction: 'H' | 'V', length: number}} ship - Ship configuration
+ * @param {{width: number, height: number}} fleet - Board configuration
  */
 function assertSegmentInsideBoard(ship, fleet) {
   for (let i = 0; i < ship.length; i++) {


### PR DESCRIPTION
## Summary
- document parameters in battleshipSolitaireFleet.segmentBounds.test.js

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68662552916c832eaa45bcce0899a326