### PR TITLE
Refactor duplicated input handler logic

### DIFF
--- a/src/constants/selectors.js
+++ b/src/constants/selectors.js
@@ -1,0 +1,6 @@
+/**
+ * Common DOM selectors used by input handlers.
+ */
+export const NUMBER_INPUT_SELECTOR = "input[type=\"number\"]";
+export const KV_CONTAINER_SELECTOR = ".kv-container";
+export const DENDRITE_FORM_SELECTOR = ".dendrite-form";

--- a/src/inputHandlers/default.js
+++ b/src/inputHandlers/default.js
@@ -1,4 +1,9 @@
 import { maybeRemoveElement } from './disposeHelpers.js';
+import {
+  NUMBER_INPUT_SELECTOR,
+  KV_CONTAINER_SELECTOR,
+  DENDRITE_FORM_SELECTOR,
+} from '../constants/selectors.js';
 
 export function dispose(element, dom, container) {
   maybeRemoveElement(element, container, dom);
@@ -7,10 +12,10 @@ export function dispose(element, dom, container) {
 export function defaultHandler(dom, container, textInput) {
   dom.hide(textInput);
   dom.disable(textInput);
-  const numberInput = dom.querySelector(container, 'input[type="number"]');
+  const numberInput = dom.querySelector(container, NUMBER_INPUT_SELECTOR);
   dispose(numberInput, dom, container);
-  const kvContainer = dom.querySelector(container, '.kv-container');
+  const kvContainer = dom.querySelector(container, KV_CONTAINER_SELECTOR);
   dispose(kvContainer, dom, container);
-  const dendriteForm = dom.querySelector(container, '.dendrite-form');
+  const dendriteForm = dom.querySelector(container, DENDRITE_FORM_SELECTOR);
   dispose(dendriteForm, dom, container);
 }

--- a/src/inputHandlers/dendriteStory.js
+++ b/src/inputHandlers/dendriteStory.js
@@ -1,16 +1,11 @@
 import { DENDRITE_FIELDS } from '../constants/dendrite.js';
 import { maybeRemoveElement } from './disposeHelpers.js';
 import { parseJsonOrDefault } from '../utils/jsonUtils.js';
-
-function maybeRemoveNumber(container, dom) {
-  const numberInput = dom.querySelector(container, 'input[type="number"]');
-  maybeRemoveElement(numberInput, container, dom);
-}
-
-function maybeRemoveKV(container, dom) {
-  const kvContainer = dom.querySelector(container, '.kv-container');
-  maybeRemoveElement(kvContainer, container, dom);
-}
+import {
+  maybeRemoveNumber,
+  maybeRemoveKV,
+} from './removeElements.js';
+import { DENDRITE_FORM_SELECTOR } from '../constants/selectors.js';
 
 function disposeIfPossible(node) {
   if (typeof node._dispose === 'function') {
@@ -19,7 +14,7 @@ function disposeIfPossible(node) {
 }
 
 function removeExistingForm(container, dom) {
-  const existing = dom.querySelector(container, '.dendrite-form');
+  const existing = dom.querySelector(container, DENDRITE_FORM_SELECTOR);
   if (existing) {
     disposeIfPossible(existing);
     dom.removeChild(container, existing);
@@ -67,7 +62,7 @@ function createField(
 
 function buildForm(dom, { container, textInput, data, disposers }) {
   const form = dom.createElement('div');
-  dom.setClassName(form, 'dendrite-form');
+  dom.setClassName(form, DENDRITE_FORM_SELECTOR.slice(1));
   const nextSibling = dom.getNextSibling(textInput);
   dom.insertBefore(container, form, nextSibling);
 

--- a/src/inputHandlers/kv.js
+++ b/src/inputHandlers/kv.js
@@ -4,13 +4,17 @@ import {
   createDispose,
   syncHiddenField,
 } from '../browser/toys.js';
-import { maybeRemoveElement } from './disposeHelpers.js';
+import {
+  maybeRemoveNumber,
+  maybeRemoveDendrite,
+} from './removeElements.js';
+import { KV_CONTAINER_SELECTOR } from '../constants/selectors.js';
 
 export const ensureKeyValueInput = (container, textInput, dom) => {
-  let kvContainer = dom.querySelector(container, '.kv-container');
+  let kvContainer = dom.querySelector(container, KV_CONTAINER_SELECTOR);
   if (!kvContainer) {
     kvContainer = dom.createElement('div');
-    dom.setClassName(kvContainer, 'kv-container');
+    dom.setClassName(kvContainer, KV_CONTAINER_SELECTOR.slice(1));
     const nextSibling = dom.getNextSibling(textInput);
     dom.insertBefore(container, kvContainer, nextSibling);
   }
@@ -40,19 +44,6 @@ export const ensureKeyValueInput = (container, textInput, dom) => {
   return kvContainer;
 };
 
-export const maybeRemoveNumber = (container, dom) =>
-  maybeRemoveElement(
-    dom.querySelector(container, 'input[type="number"]'),
-    container,
-    dom
-  );
-
-export const maybeRemoveDendrite = (container, dom) =>
-  maybeRemoveElement(
-    dom.querySelector(container, '.dendrite-form'),
-    container,
-    dom
-  );
 
 export function handleKVType(dom, container, textInput) {
   maybeRemoveNumber(container, dom);

--- a/src/inputHandlers/number.js
+++ b/src/inputHandlers/number.js
@@ -1,4 +1,8 @@
-import { maybeRemoveElement } from './disposeHelpers.js';
+import {
+  maybeRemoveKV,
+  maybeRemoveDendrite,
+} from './removeElements.js';
+import { NUMBER_INPUT_SELECTOR } from '../constants/selectors.js';
 
 const createRemoveValueListener = (dom, el, handler) => () =>
   dom.removeEventListener(el, 'input', handler);
@@ -34,7 +38,7 @@ const positionNumberInput = ({ container, textInput, numberInput, dom }) => {
 };
 
 export const ensureNumberInput = (container, textInput, dom) => {
-  let numberInput = dom.querySelector(container, 'input[type="number"]');
+  let numberInput = dom.querySelector(container, NUMBER_INPUT_SELECTOR);
 
   if (!numberInput) {
     numberInput = createNumberInput(
@@ -53,15 +57,6 @@ export const ensureNumberInput = (container, textInput, dom) => {
   return numberInput;
 };
 
-function maybeRemoveKV(container, dom) {
-  const kvContainer = dom.querySelector(container, '.kv-container');
-  maybeRemoveElement(kvContainer, container, dom);
-}
-
-function maybeRemoveDendrite(container, dom) {
-  const dendriteForm = dom.querySelector(container, '.dendrite-form');
-  maybeRemoveElement(dendriteForm, container, dom);
-}
 
 export function numberHandler(dom, container, textInput) {
   dom.hide(textInput);

--- a/src/inputHandlers/removeElements.js
+++ b/src/inputHandlers/removeElements.js
@@ -1,0 +1,36 @@
+import { maybeRemoveElement } from "./disposeHelpers.js";
+import {
+  NUMBER_INPUT_SELECTOR,
+  KV_CONTAINER_SELECTOR,
+  DENDRITE_FORM_SELECTOR,
+} from "../constants/selectors.js";
+
+/**
+ * Removes a number input element if present.
+ * @param {*} container - DOM container
+ * @param {object} dom - DOM abstraction
+ */
+export function maybeRemoveNumber(container, dom) {
+  const numberInput = dom.querySelector(container, NUMBER_INPUT_SELECTOR);
+  maybeRemoveElement(numberInput, container, dom);
+}
+
+/**
+ * Removes a key-value container if present.
+ * @param {*} container - DOM container
+ * @param {object} dom - DOM abstraction
+ */
+export function maybeRemoveKV(container, dom) {
+  const kvContainer = dom.querySelector(container, KV_CONTAINER_SELECTOR);
+  maybeRemoveElement(kvContainer, container, dom);
+}
+
+/**
+ * Removes a dendrite form if present.
+ * @param {*} container - DOM container
+ * @param {object} dom - DOM abstraction
+ */
+export function maybeRemoveDendrite(container, dom) {
+  const dendriteForm = dom.querySelector(container, DENDRITE_FORM_SELECTOR);
+  maybeRemoveElement(dendriteForm, container, dom);
+}

--- a/src/inputHandlers/text.js
+++ b/src/inputHandlers/text.js
@@ -1,9 +1,14 @@
 import { dispose } from './default.js';
+import {
+  NUMBER_INPUT_SELECTOR,
+  KV_CONTAINER_SELECTOR,
+  DENDRITE_FORM_SELECTOR,
+} from '../constants/selectors.js';
 
 export function textHandler(dom, container, textInput) {
   dom.reveal(textInput);
   dom.enable(textInput);
-  dispose(dom.querySelector(container, 'input[type="number"]'), dom, container);
-  dispose(dom.querySelector(container, '.kv-container'), dom, container);
-  dispose(dom.querySelector(container, '.dendrite-form'), dom, container);
+  dispose(dom.querySelector(container, NUMBER_INPUT_SELECTOR), dom, container);
+  dispose(dom.querySelector(container, KV_CONTAINER_SELECTOR), dom, container);
+  dispose(dom.querySelector(container, DENDRITE_FORM_SELECTOR), dom, container);
 }

--- a/test/inputHandlers/kvHandler.test.js
+++ b/test/inputHandlers/kvHandler.test.js
@@ -2,7 +2,7 @@ import { describe, test, expect, jest } from '@jest/globals';
 import {
   maybeRemoveNumber,
   maybeRemoveDendrite,
-} from "../../src/inputHandlers/kv.js";
+} from "../../src/inputHandlers/removeElements.js";
 
 // kvHandler relies on ensureKeyValueInput which is complex to mock in ES modules.
 // These tests focus on the removable helper functions to achieve full branch coverage.


### PR DESCRIPTION
## Summary
- centralize DOM selectors
- extract helper functions to remove elements
- update input handlers to use shared helpers
- refactor kvHandler tests for new module

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686625c85ef0832e863c305e08153427