### PR TITLE
Fix lint warning

### DIFF
--- a/test/presenters/validateCluesObject.import.test.js
+++ b/test/presenters/validateCluesObject.import.test.js
@@ -3,17 +3,23 @@ import path from 'path';
 import { pathToFileURL } from 'url';
 import { it /*, describe, expect */ } from '@jest/globals';
 
+/**
+ * Dynamically loads the `validateCluesObject` function from the source module.
+ * @returns {Promise<Function>} resolves with the `validateCluesObject` function
+ */
 export async function loadValidateCluesObject() {
-  const srcPath = path.join(process.cwd(), 'src/presenters/battleshipSolitaireClues.js');
+  const srcPath = path.join(
+    process.cwd(),
+    'src/presenters/battleshipSolitaireClues.js'
+  );
   let src = fs.readFileSync(srcPath, 'utf8');
   src = src.replace(/from '((?:\.\.?\/).*?)'/g, (_, p) => {
     const abs = pathToFileURL(path.join(path.dirname(srcPath), p));
     return `from '${abs.href}'`;
   });
   src += '\nexport { validateCluesObject };';
-  return (
-    await import(`data:text/javascript,${encodeURIComponent(src)}`)
-  ).validateCluesObject;
+  return (await import(`data:text/javascript,${encodeURIComponent(src)}`))
+    .validateCluesObject;
 }
 
 /*


### PR DESCRIPTION
## Summary
- add missing JSDoc `@returns` to `loadValidateCluesObject` test helper

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6866288d5704832e8d7f4f3fb3417935