### PR TITLE
Fix one ESLint warning

### DIFF
--- a/test/presenters/validateCluesObject.import.test.js
+++ b/test/presenters/validateCluesObject.import.test.js
@@ -3,17 +3,23 @@ import path from 'path';
 import { pathToFileURL } from 'url';
 import { it /*, describe, expect */ } from '@jest/globals';
 
+/**
+ * Dynamically loads the `validateCluesObject` function.
+ * @returns {Promise<Function>} Resolves to the function under test
+ */
 export async function loadValidateCluesObject() {
-  const srcPath = path.join(process.cwd(), 'src/presenters/battleshipSolitaireClues.js');
+  const srcPath = path.join(
+    process.cwd(),
+    'src/presenters/battleshipSolitaireClues.js'
+  );
   let src = fs.readFileSync(srcPath, 'utf8');
   src = src.replace(/from '((?:\.\.?\/).*?)'/g, (_, p) => {
     const abs = pathToFileURL(path.join(path.dirname(srcPath), p));
     return `from '${abs.href}'`;
   });
   src += '\nexport { validateCluesObject };';
-  return (
-    await import(`data:text/javascript,${encodeURIComponent(src)}`)
-  ).validateCluesObject;
+  return (await import(`data:text/javascript,${encodeURIComponent(src)}`))
+    .validateCluesObject;
 }
 
 /*


### PR DESCRIPTION
## Summary
- add missing JSDoc return description for `loadValidateCluesObject`

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6866288d97a8832e8efd3ea18a568c81