### PR TITLE
Fix ESLint warning in tests

### DIFF
--- a/test/toys/2025-05-08/battleshipSolitaireFleet.test.js
+++ b/test/toys/2025-05-08/battleshipSolitaireFleet.test.js
@@ -27,6 +27,11 @@ describe('generateFleet', () => {
   });
 
   test('places a vertical ship of length 3 somewhere', () => {
+    /**
+     * Get occupied coordinates for a ship.
+     * @param {{start: {x: number, y: number}, length: number}} ship - Ship to inspect
+     * @returns {Array<[number, number]>} List of occupied cells
+     */
     function getOccupiedCells(ship) {
       const occupied = [];
       for (let i = 0; i < ship.length; i++) {


### PR DESCRIPTION
## Summary
- add missing JSDoc for `getOccupiedCells` helper in battleship test

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6866288ee448832e80ee4965bcfebaa7