### PR TITLE
Refactor duplicate data setters

### DIFF
--- a/src/browser/setOutput.js
+++ b/src/browser/setOutput.js
@@ -1,41 +1,6 @@
-import { isObject } from './common.js';
-import { deepMerge } from './data.js';
+import { createMergeSetter } from '../utils/createMergeSetter.js';
 
-export function setOutput(input, env) {
-  let inputJson;
-  try {
-    inputJson = JSON.parse(input);
-  } catch (parseError) {
-    return `Error: Invalid JSON input. ${parseError.message}`;
-  }
-  return processSetOutput(inputJson, env);
-}
-
-function processSetOutput(inputJson, env) {
-  if (!isObject(inputJson)) {
-    return "Error: Input JSON must be a plain object.";
-  }
-  return handleValidOutputInput(inputJson, env);
-}
-
-function handleValidOutputInput(inputJson, env) {
-  // Assume env.get is always a function
-  const getData = env.get('getData');
-  const setData = env.get('setData');
-  try {
-    return mergeOutputData(getData, setData, inputJson);
-  } catch (error) {
-    return `Error updating output data: ${error.message}`;
-  }
-}
-
-function mergeOutputData(getData, setData, inputJson) {
-  const currentData = getData();
-  const newData = JSON.parse(JSON.stringify(currentData));
-  if (!isObject(newData.output)) {
-    newData.output = {};
-  }
-  newData.output = deepMerge(newData.output, inputJson);
-  setData(newData);
-  return `Success: Output data deep merged.`;
-}
+export const setOutput = createMergeSetter(
+  'output',
+  'Success: Output data deep merged.'
+);

--- a/src/presenters/battleshipSolitaireClues.js
+++ b/src/presenters/battleshipSolitaireClues.js
@@ -23,9 +23,7 @@
  *    (ones) is closest to the grid
  */
 
-function isObject(value) {
-  return value && typeof value === 'object';
-}
+import { isObject } from '../browser/common.js';
 
 function hasValidClueArrays(obj) {
   return Array.isArray(obj.rowClues) && Array.isArray(obj.colClues);
@@ -73,13 +71,7 @@ const DEFAULT_CLUES = {
   colClues: Array(10).fill(0),
 };
 
-function safeJsonParse(str) {
-  try {
-    return JSON.parse(str);
-  } catch {
-    return null;
-  }
-}
+import { parseJsonOrDefault } from '../utils/jsonUtils.js';
 
 const INVALID_CLUE_CHECKS = [
   obj => obj === null,
@@ -105,7 +97,7 @@ function buildColumnDigitMatrix(colClues) {
  * @returns {{rowClues: number[], colClues: number[]}}
  */
 function parseCluesOrDefault(inputString) {
-  const obj = safeJsonParse(inputString);
+  const obj = parseJsonOrDefault(inputString, null);
   if (INVALID_CLUE_CHECKS.some(fn => fn(obj))) {
     return DEFAULT_CLUES;
   }

--- a/src/toys/2025-03-29/setTemporary.js
+++ b/src/toys/2025-03-29/setTemporary.js
@@ -1,47 +1,6 @@
-import { isObject } from '../../browser/common.js';
-import { deepMerge } from '../../browser/data.js';
+import { createMergeSetter } from '../../utils/createMergeSetter.js';
 
-/**
- * Parses input as JSON, deep merges it into the 'temporary' object obtained via env.getData(),
- * and then passes the entire modified data structure back to env.setData().
- * @param {string} input - A JSON string to parse and merge.
- * @param {Map<string, Function>} env - Environment map. Expected: 'getData()', 'setData(data)'.
- * @returns {string} A confirmation message or an error message.
- */
-export function setTemporary(input, env) {
-  let inputJson;
-  try {
-    inputJson = JSON.parse(input);
-  } catch (parseError) {
-    return `Error: Invalid JSON input. ${parseError.message}`;
-  }
-  return processSetTemporary(inputJson, env);
-}
-
-function processSetTemporary(inputJson, env) {
-  if (!isObject(inputJson)) {
-    return 'Error: Input JSON must be a plain object.';
-  }
-  return handleValidTemporaryInput(inputJson, env);
-}
-
-function handleValidTemporaryInput(inputJson, env) {
-  const getData = env.get('getData');
-  const setData = env.get('setData');
-  try {
-    return mergeTemporaryData(getData, setData, inputJson);
-  } catch (error) {
-    return `Error updating temporary data: ${error.message}`;
-  }
-}
-
-function mergeTemporaryData(getData, setData, inputJson) {
-  const currentData = getData();
-  const newData = JSON.parse(JSON.stringify(currentData));
-  if (!isObject(newData.temporary)) {
-    newData.temporary = {};
-  }
-  newData.temporary = deepMerge(newData.temporary, inputJson);
-  setData(newData);
-  return `Success: Temporary data deep merged.`;
-}
+export const setTemporary = createMergeSetter(
+  'temporary',
+  'Success: Temporary data deep merged.'
+);

--- a/src/toys/2025-05-08/battleshipSolitaireFleet.js
+++ b/src/toys/2025-05-08/battleshipSolitaireFleet.js
@@ -318,13 +318,7 @@ function ensureShipsArray(cfg) {
 
 // ─────────────────────────── Public toy ─────────────────────────── //
 
-function safeJsonParse(input) {
-  try {
-    return JSON.parse(input);
-  } catch {
-    return { width: 10, height: 10, ships: [] };
-  }
-}
+import { parseJsonOrDefault } from '../../utils/jsonUtils.js';
 
 function convertShipsToArray(cfg) {
   if (typeof cfg.ships === 'string') {
@@ -348,7 +342,7 @@ function parseDimensions(cfg) {
 }
 
 function parseConfig(input) {
-  const cfg = safeJsonParse(input);
+  const cfg = parseJsonOrDefault(input, { width: 10, height: 10, ships: [] });
   convertShipsToArray(cfg);
   parseDimensions(cfg);
   ensureShipsArray(cfg);

--- a/src/utils/createMergeSetter.js
+++ b/src/utils/createMergeSetter.js
@@ -1,0 +1,38 @@
+import { isObject } from '../browser/common.js';
+import { deepMerge } from '../browser/data.js';
+
+/**
+ * Creates a function that parses JSON input and deep merges it into a
+ * property of the data object obtained via `env.getData()`.
+ *
+ * @param {string} property - The property name to merge into.
+ * @param {string} successMessage - Message returned on success.
+ * @returns {(input: string, env: Map<string, Function>) => string}
+ */
+export function createMergeSetter(property, successMessage) {
+  return function setProperty(input, env) {
+    let inputJson;
+    try {
+      inputJson = JSON.parse(input);
+    } catch (parseError) {
+      return `Error: Invalid JSON input. ${parseError.message}`;
+    }
+    if (!isObject(inputJson)) {
+      return 'Error: Input JSON must be a plain object.';
+    }
+    const getData = env.get('getData');
+    const setData = env.get('setData');
+    try {
+      const currentData = getData();
+      const newData = JSON.parse(JSON.stringify(currentData));
+      if (!isObject(newData[property])) {
+        newData[property] = {};
+      }
+      newData[property] = deepMerge(newData[property], inputJson);
+      setData(newData);
+      return successMessage;
+    } catch (error) {
+      return `Error updating ${property} data: ${error.message}`;
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- create `createMergeSetter` utility
- refactor `setOutput` and `setTemporary` to use the new helper
- use shared helpers in battleship clue and fleet modules

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686628973e94832ea373a07f1e84655e