### PR TITLE
Refactor duplicated parsing and merge utilities

### DIFF
--- a/src/browser/common.js
+++ b/src/browser/common.js
@@ -1,14 +1,5 @@
 // Shared utility functions
 
-/**
- * Checks if a value is a non-null object (but not an array).
- * @param {*} val
- * @returns {boolean}
- */
-function isNonNullNonArray(val) {
-  return val !== null && !Array.isArray(val);
-}
+import { isObject } from '../utils/objectUtils.js';
 
-export function isObject(val) {
-  return isNonNullNonArray(val) && typeof val === 'object';
-}
+export { isObject };

--- a/src/browser/setOutput.js
+++ b/src/browser/setOutput.js
@@ -1,41 +1,5 @@
-import { isObject } from './common.js';
-import { deepMerge } from './data.js';
+import { mergeIntoStateProperty } from '../utils/stateMerge.js';
 
 export function setOutput(input, env) {
-  let inputJson;
-  try {
-    inputJson = JSON.parse(input);
-  } catch (parseError) {
-    return `Error: Invalid JSON input. ${parseError.message}`;
-  }
-  return processSetOutput(inputJson, env);
-}
-
-function processSetOutput(inputJson, env) {
-  if (!isObject(inputJson)) {
-    return "Error: Input JSON must be a plain object.";
-  }
-  return handleValidOutputInput(inputJson, env);
-}
-
-function handleValidOutputInput(inputJson, env) {
-  // Assume env.get is always a function
-  const getData = env.get('getData');
-  const setData = env.get('setData');
-  try {
-    return mergeOutputData(getData, setData, inputJson);
-  } catch (error) {
-    return `Error updating output data: ${error.message}`;
-  }
-}
-
-function mergeOutputData(getData, setData, inputJson) {
-  const currentData = getData();
-  const newData = JSON.parse(JSON.stringify(currentData));
-  if (!isObject(newData.output)) {
-    newData.output = {};
-  }
-  newData.output = deepMerge(newData.output, inputJson);
-  setData(newData);
-  return `Success: Output data deep merged.`;
+  return mergeIntoStateProperty('output', input, env);
 }

--- a/src/presenters/battleshipSolitaireClues.js
+++ b/src/presenters/battleshipSolitaireClues.js
@@ -23,9 +23,8 @@
  *    (ones) is closest to the grid
  */
 
-function isObject(value) {
-  return value && typeof value === 'object';
-}
+import { isObject } from '../browser/common.js';
+import { parseJsonOrDefault } from '../utils/jsonUtils.js';
 
 function hasValidClueArrays(obj) {
   return Array.isArray(obj.rowClues) && Array.isArray(obj.colClues);
@@ -73,14 +72,6 @@ const DEFAULT_CLUES = {
   colClues: Array(10).fill(0),
 };
 
-function safeJsonParse(str) {
-  try {
-    return JSON.parse(str);
-  } catch {
-    return null;
-  }
-}
-
 const INVALID_CLUE_CHECKS = [
   obj => obj === null,
   obj => Boolean(findValidationError(obj)),
@@ -105,7 +96,7 @@ function buildColumnDigitMatrix(colClues) {
  * @returns {{rowClues: number[], colClues: number[]}}
  */
 function parseCluesOrDefault(inputString) {
-  const obj = safeJsonParse(inputString);
+  const obj = parseJsonOrDefault(inputString, null);
   if (INVALID_CLUE_CHECKS.some(fn => fn(obj))) {
     return DEFAULT_CLUES;
   }

--- a/src/toys/2025-03-29/setTemporary.js
+++ b/src/toys/2025-03-29/setTemporary.js
@@ -1,5 +1,4 @@
-import { isObject } from '../../browser/common.js';
-import { deepMerge } from '../../browser/data.js';
+import { mergeIntoStateProperty } from '../../utils/stateMerge.js';
 
 /**
  * Parses input as JSON, deep merges it into the 'temporary' object obtained via env.getData(),
@@ -9,39 +8,5 @@ import { deepMerge } from '../../browser/data.js';
  * @returns {string} A confirmation message or an error message.
  */
 export function setTemporary(input, env) {
-  let inputJson;
-  try {
-    inputJson = JSON.parse(input);
-  } catch (parseError) {
-    return `Error: Invalid JSON input. ${parseError.message}`;
-  }
-  return processSetTemporary(inputJson, env);
-}
-
-function processSetTemporary(inputJson, env) {
-  if (!isObject(inputJson)) {
-    return 'Error: Input JSON must be a plain object.';
-  }
-  return handleValidTemporaryInput(inputJson, env);
-}
-
-function handleValidTemporaryInput(inputJson, env) {
-  const getData = env.get('getData');
-  const setData = env.get('setData');
-  try {
-    return mergeTemporaryData(getData, setData, inputJson);
-  } catch (error) {
-    return `Error updating temporary data: ${error.message}`;
-  }
-}
-
-function mergeTemporaryData(getData, setData, inputJson) {
-  const currentData = getData();
-  const newData = JSON.parse(JSON.stringify(currentData));
-  if (!isObject(newData.temporary)) {
-    newData.temporary = {};
-  }
-  newData.temporary = deepMerge(newData.temporary, inputJson);
-  setData(newData);
-  return `Success: Temporary data deep merged.`;
+  return mergeIntoStateProperty('temporary', input, env);
 }

--- a/src/toys/2025-04-06/ticTacToe.js
+++ b/src/toys/2025-04-06/ticTacToe.js
@@ -6,20 +6,11 @@ function getOpponent(player) {
   }
 }
 
-function tryParseJSON(input) {
-  try {
-    return JSON.parse(input);
-  } catch {
-    return null;
-  }
-}
+import { parseJsonOrDefault } from '../../utils/jsonUtils.js';
+import { isObject } from '../../browser/common.js';
 
 function respectsTurnOrder({ move, index, moves }) {
   return index === 0 || move.player !== moves[index - 1].player;
-}
-
-function isObject(val) {
-  return typeof val === "object" && val !== null;
 }
 
 function getValidParsedMoves(parsed) {
@@ -50,7 +41,7 @@ function hasMovesArray(val) {
 }
 
 function parseInputSafely(input) {
-  const parsed = tryParseJSON(input);
+  const parsed = parseJsonOrDefault(input, null);
   return getValidParsedMoves(parsed);
 }
 
@@ -303,7 +294,7 @@ function simulateMoves(board, accumulateScores) {
 
 
 
-function minimax(depth, isMax, params) {
+export function minimax(depth, isMax, params) {
   const opponent = getOpponent(params.player);
   const isWinPlayer = () => isWin(params.board, params.player);
   const isWinOpponent = () => isWin(params.board, opponent);

--- a/src/toys/2025-05-08/battleshipSolitaireFleet.js
+++ b/src/toys/2025-05-08/battleshipSolitaireFleet.js
@@ -11,6 +11,8 @@
  *   • No diagonal placement; honours optional noTouching flag.
  */
 
+import { parseJsonOrDefault } from '../../utils/jsonUtils.js';
+
 // ────────────────────── Helper utilities ────────────────────── //
 
 /** Fisher‑Yates shuffle (in‑place) using env RNG */
@@ -318,13 +320,6 @@ function ensureShipsArray(cfg) {
 
 // ─────────────────────────── Public toy ─────────────────────────── //
 
-function safeJsonParse(input) {
-  try {
-    return JSON.parse(input);
-  } catch {
-    return { width: 10, height: 10, ships: [] };
-  }
-}
 
 function convertShipsToArray(cfg) {
   if (typeof cfg.ships === 'string') {
@@ -348,7 +343,7 @@ function parseDimensions(cfg) {
 }
 
 function parseConfig(input) {
-  const cfg = safeJsonParse(input);
+  const cfg = parseJsonOrDefault(input, { width: 10, height: 10, ships: [] });
   convertShipsToArray(cfg);
   parseDimensions(cfg);
   ensureShipsArray(cfg);

--- a/src/utils/objectUtils.js
+++ b/src/utils/objectUtils.js
@@ -33,3 +33,13 @@ export function mapValues(obj, fn) {
   }
   return transformEntries(obj, fn);
 }
+
+/**
+ * Determines if a value is a plain object.
+ * Arrays and null are not considered objects.
+ * @param {*} value - Value to check.
+ * @returns {boolean} True when value is a non-null object and not an array.
+ */
+export function isObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}

--- a/src/utils/stateMerge.js
+++ b/src/utils/stateMerge.js
@@ -1,0 +1,44 @@
+import { isObject } from '../browser/common.js';
+import { deepMerge } from '../browser/data.js';
+
+function capitalize(word) {
+  return word.charAt(0).toUpperCase() + word.slice(1);
+}
+
+/**
+ * Parses JSON input and deep merges it into the given property of the global
+ * state via env.get/ set functions.
+ *
+ * @param {string} property - Name of the property to merge into.
+ * @param {string} input - JSON string representing an object.
+ * @param {Map<string,Function>} env - Environment providing getData/setData.
+ * @returns {string} Success or error message.
+ */
+export function mergeIntoStateProperty(property, input, env) {
+  let inputJson;
+  try {
+    inputJson = JSON.parse(input);
+  } catch (parseError) {
+    return `Error: Invalid JSON input. ${parseError.message}`;
+  }
+
+  if (!isObject(inputJson)) {
+    return 'Error: Input JSON must be a plain object.';
+  }
+
+  const getData = env.get('getData');
+  const setData = env.get('setData');
+
+  try {
+    const currentData = getData();
+    const newData = JSON.parse(JSON.stringify(currentData));
+    if (!isObject(newData[property])) {
+      newData[property] = {};
+    }
+    newData[property] = deepMerge(newData[property], inputJson);
+    setData(newData);
+    return `Success: ${capitalize(property)} data deep merged.`;
+  } catch (error) {
+    return `Error updating ${property} data: ${error.message}`;
+  }
+}

--- a/test/toys/2025-04-06/minimax.earlyreturn.mutant.test.js
+++ b/test/toys/2025-04-06/minimax.earlyreturn.mutant.test.js
@@ -1,22 +1,12 @@
-import fs from 'fs';
-import path from 'path';
 import { describe, test, expect } from '@jest/globals';
-
-async function loadMinimax() {
-  const filePath = path.join(process.cwd(), 'src/toys/2025-04-06/ticTacToe.js');
-  let src = fs.readFileSync(filePath, 'utf8');
-  src += '\nexport { minimax };';
-  const mod = await import(`data:text/javascript,${encodeURIComponent(src)}`);
-  return mod.minimax;
-}
+import { minimax } from '../../../src/toys/2025-04-06/ticTacToe.js';
 
 describe('minimax early return', () => {
-  test('returns terminal score when player has already won', async () => {
-    const minimax = await loadMinimax();
+  test('returns terminal score when player has already won', () => {
     const board = [
       ['X', 'X', 'X'],
       [null, null, null],
-      [null, null, null]
+      [null, null, null],
     ];
     const params = { board, player: 'X', moves: [] };
     const score = minimax(0, true, params);


### PR DESCRIPTION
## Summary
- add general `isObject` helper to `objectUtils`
- import helper from browser utilities
- centralize JSON merge logic in new `stateMerge` module
- update `setOutput` and `setTemporary` to use shared helper
- reuse parsing helpers in presenters and toys
- export `minimax` and update the mutant test to import it

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68662897ae70832e90fd8b7124718d7b