### PR TITLE
Refactor duplicated helpers

### DIFF
--- a/src/browser/common.js
+++ b/src/browser/common.js
@@ -1,14 +1,4 @@
 // Shared utility functions
+import { isObject } from '../utils/typeUtils.js';
 
-/**
- * Checks if a value is a non-null object (but not an array).
- * @param {*} val
- * @returns {boolean}
- */
-function isNonNullNonArray(val) {
-  return val !== null && !Array.isArray(val);
-}
-
-export function isObject(val) {
-  return isNonNullNonArray(val) && typeof val === 'object';
-}
+export { isObject };

--- a/src/browser/setOutput.js
+++ b/src/browser/setOutput.js
@@ -1,4 +1,4 @@
-import { isObject } from './common.js';
+import { isObject } from '../utils/typeUtils.js';
 import { deepMerge } from './data.js';
 
 export function setOutput(input, env) {

--- a/src/browser/toys.js
+++ b/src/browser/toys.js
@@ -544,7 +544,7 @@ export function handleRequestResponse(url, env, options) {
   fetchFn(url).then(getText).then(displayBody).catch(handleFetchError);
 }
 
-import { isObject } from './common.js';
+import { isObject } from '../utils/typeUtils.js';
 
 /**
  * Creates a number input element with the specified value and change handler

--- a/src/presenters/battleshipSolitaireClues.js
+++ b/src/presenters/battleshipSolitaireClues.js
@@ -22,10 +22,9 @@
  *  – Column clues shown on top & bottom, stacked so lowest digit line
  *    (ones) is closest to the grid
  */
+import { isObject } from '../utils/typeUtils.js';
+import { parseJsonOrDefault } from '../utils/jsonUtils.js';
 
-function isObject(value) {
-  return value && typeof value === 'object';
-}
 
 function hasValidClueArrays(obj) {
   return Array.isArray(obj.rowClues) && Array.isArray(obj.colClues);
@@ -73,14 +72,6 @@ const DEFAULT_CLUES = {
   colClues: Array(10).fill(0),
 };
 
-function safeJsonParse(str) {
-  try {
-    return JSON.parse(str);
-  } catch {
-    return null;
-  }
-}
-
 const INVALID_CLUE_CHECKS = [
   obj => obj === null,
   obj => Boolean(findValidationError(obj)),
@@ -105,7 +96,7 @@ function buildColumnDigitMatrix(colClues) {
  * @returns {{rowClues: number[], colClues: number[]}}
  */
 function parseCluesOrDefault(inputString) {
-  const obj = safeJsonParse(inputString);
+  const obj = parseJsonOrDefault(inputString, null);
   if (INVALID_CLUE_CHECKS.some(fn => fn(obj))) {
     return DEFAULT_CLUES;
   }

--- a/src/presenters/ticTacToeBoard.js
+++ b/src/presenters/ticTacToeBoard.js
@@ -1,4 +1,4 @@
-import { isObject } from '../browser/common.js';
+import { isObject } from '../utils/typeUtils.js';
 
 /**
  * createTicTacToeBoardElement

--- a/src/toys/2025-03-29/setTemporary.js
+++ b/src/toys/2025-03-29/setTemporary.js
@@ -1,4 +1,4 @@
-import { isObject } from '../../browser/common.js';
+import { isObject } from '../../utils/typeUtils.js';
 import { deepMerge } from '../../browser/data.js';
 
 /**

--- a/src/toys/2025-04-06/ticTacToe.js
+++ b/src/toys/2025-04-06/ticTacToe.js
@@ -1,8 +1,8 @@
 function getOpponent(player) {
-  if (player === "X") {
-    return "O";
+  if (player === 'X') {
+    return 'O';
   } else {
-    return "X";
+    return 'X';
   }
 }
 
@@ -19,7 +19,7 @@ function respectsTurnOrder({ move, index, moves }) {
 }
 
 function isObject(val) {
-  return typeof val === "object" && val !== null;
+  return typeof val === 'object' && val !== null;
 }
 
 function getValidParsedMoves(parsed) {
@@ -73,21 +73,27 @@ export function ticTacToeMove(input) {
   const moves = parseInputSafely(input);
 
   // Inline validateAndApplyMoves
-  if (isInvalidMoves(moves)) {return returnInitialOptimalMove();}
+  if (isInvalidMoves(moves)) {
+    return returnInitialOptimalMove();
+  }
   return handleValidMoves(moves);
 }
 
 function handleValidMoves(moves) {
   const { board, seen } = initializeBoardAndSeen();
   const result = applyMovesSequentially(moves, board, seen);
-  if (!result.valid) {return returnInitialOptimalMove();}
+  if (!result.valid) {
+    return returnInitialOptimalMove();
+  }
   return handleValidAppliedMoves(moves, board, result);
 }
 
 function handleValidAppliedMoves(moves, board, result) {
   const earlyWin = result.earlyWin;
 
-  if (shouldSkipMove(earlyWin, moves)) {return buildMoveResponseWithoutNewMove(moves);}
+  if (shouldSkipMove(earlyWin, moves)) {
+    return buildMoveResponseWithoutNewMove(moves);
+  }
 
   const nextPlayer = determineNextPlayer(moves);
   const bestMove = findBestMove(board, nextPlayer, moves);
@@ -130,7 +136,7 @@ function shouldStop(valid, earlyWin) {
 }
 
 function applyMoveReducer(moves, board, seen) {
-  return function(acc, _, i) {
+  return function (acc, _, i) {
     if (acc.stop) {
       return acc;
     }
@@ -150,7 +156,6 @@ function applyMovesSequentially(moves, board, seen) {
   const result = moves.reduce(reducer, initial);
   return { valid: result.valid, earlyWin: result.earlyWin };
 }
-
 
 function copyBoard(board) {
   return board.map(row => row.slice());
@@ -210,21 +215,21 @@ function findBestMove(board, nextPlayer, moves) {
 }
 
 function getEmptyCells(board) {
-  return board.reduce((cells, row, r) =>
-    row.reduce((acc, cell, c) => {
-      if (!cell) {
-        acc.push({ r, c });
-      }
-      return acc;
-    }, cells),
-  []
+  return board.reduce(
+    (cells, row, r) =>
+      row.reduce((acc, cell, c) => {
+        if (!cell) {
+          acc.push({ r, c });
+        }
+        return acc;
+      }, cells),
+    []
   );
 }
 
-
 function determineNextPlayer(moves) {
   if (moves.length === 0) {
-    return "X";
+    return 'X';
   }
   return getOpponent(moves[moves.length - 1].player);
 }
@@ -252,7 +257,7 @@ function checkDiagonals(board, player) {
 }
 
 function checkEarlyWin(board) {
-  return isWin(board, "X") || isWin(board, "O");
+  return isWin(board, 'X') || isWin(board, 'O');
 }
 
 function applyMoveToBoard(board, move, seen) {
@@ -260,7 +265,9 @@ function applyMoveToBoard(board, move, seen) {
   const { row, column } = position;
 
   const key = `${row},${column}`;
-  if (seen.has(key)) {return false;}
+  if (seen.has(key)) {
+    return false;
+  }
   seen.add(key);
 
   board[row][column] = player;
@@ -286,14 +293,15 @@ function evaluateTerminalState(isWinPlayer, isWinOpponent, depth) {
 }
 
 function getAvailableMoves(board) {
-  return board.reduce((moves, row, r) =>
-    row.reduce((acc, cell, c) => {
-      if (!cell) {
-        acc.push([r, c]);
-      }
-      return acc;
-    }, moves),
-  []
+  return board.reduce(
+    (moves, row, r) =>
+      row.reduce((acc, cell, c) => {
+        if (!cell) {
+          acc.push([r, c]);
+        }
+        return acc;
+      }, moves),
+    []
   );
 }
 
@@ -301,13 +309,15 @@ function simulateMoves(board, accumulateScores) {
   return getAvailableMoves(board).reduce(accumulateScores, []);
 }
 
-
-
 function minimax(depth, isMax, params) {
   const opponent = getOpponent(params.player);
   const isWinPlayer = () => isWin(params.board, params.player);
   const isWinOpponent = () => isWin(params.board, opponent);
-  const terminalScore = evaluateTerminalState(isWinPlayer, isWinOpponent, depth);
+  const terminalScore = evaluateTerminalState(
+    isWinPlayer,
+    isWinOpponent,
+    depth
+  );
   if (terminalScore !== null) {
     return terminalScore;
   }
@@ -335,7 +345,11 @@ function makeAccumulateScores(params, depth, isMax) {
     // Deep copy the board
     const newBoard = params.board.map(row => row.slice());
     newBoard[r][c] = value;
-    const newParams = { board: newBoard, player: params.player, moves: params.moves };
+    const newParams = {
+      board: newBoard,
+      player: params.player,
+      moves: params.moves,
+    };
     const score = minimax(depth + 1, !isMax, newParams);
     scores.push(score);
     return scores;
@@ -343,12 +357,14 @@ function makeAccumulateScores(params, depth, isMax) {
 }
 
 function hasValidPlayer({ move }) {
-  return ["X", "O"].includes(move.player);
+  return ['X', 'O'].includes(move.player);
 }
 
 function hasValidPosition({ move }) {
   const position = move.position;
-  if (!isObject(position)) { return false; }
+  if (!isObject(position)) {
+    return false;
+  }
   const { row, column } = position;
   return isValidRowAndColumn(row, column);
 }
@@ -358,7 +374,9 @@ function isValidRowAndColumn(row, column) {
 }
 
 function canMoveBeApplied(move, index, moves) {
-  if (!isObject(move)) { return false; }
+  if (!isObject(move)) {
+    return false;
+  }
   return isMoveDetailsValid({ move, index, moves });
 }
 
@@ -374,6 +392,6 @@ function isWin(board, player) {
 
 function returnInitialOptimalMove() {
   // In an empty board, the optimal first move is the center
-  const optimal = { player: "X", position: { row: 1, column: 1 } };
+  const optimal = { player: 'X', position: { row: 1, column: 1 } };
   return JSON.stringify({ moves: [optimal] });
 }

--- a/src/toys/2025-05-08/battleshipSolitaireFleet.js
+++ b/src/toys/2025-05-08/battleshipSolitaireFleet.js
@@ -10,6 +10,7 @@
  *   • Assumes input is trusted – minimal sanity checks only.
  *   • No diagonal placement; honours optional noTouching flag.
  */
+import { parseJsonOrDefault } from '../../utils/jsonUtils.js';
 
 // ────────────────────── Helper utilities ────────────────────── //
 
@@ -318,13 +319,6 @@ function ensureShipsArray(cfg) {
 
 // ─────────────────────────── Public toy ─────────────────────────── //
 
-function safeJsonParse(input) {
-  try {
-    return JSON.parse(input);
-  } catch {
-    return { width: 10, height: 10, ships: [] };
-  }
-}
 
 function convertShipsToArray(cfg) {
   if (typeof cfg.ships === 'string') {
@@ -348,7 +342,7 @@ function parseDimensions(cfg) {
 }
 
 function parseConfig(input) {
-  const cfg = safeJsonParse(input);
+  const cfg = parseJsonOrDefault(input, { width: 10, height: 10, ships: [] });
   convertShipsToArray(cfg);
   parseDimensions(cfg);
   ensureShipsArray(cfg);

--- a/src/utils/typeUtils.js
+++ b/src/utils/typeUtils.js
@@ -1,0 +1,12 @@
+/**
+ * Utility type-checking helpers.
+ */
+
+/**
+ * Determines if a value is a plain object (not null and not an array).
+ * @param {*} val - Value to test.
+ * @returns {boolean} True when val is a non-null object.
+ */
+export function isObject(val) {
+  return val !== null && typeof val === 'object' && !Array.isArray(val);
+}


### PR DESCRIPTION
## Summary
- centralize object checks in `typeUtils.js`
- reuse shared helpers in browser modules and toys
- simplify battleship clue parsing logic
- keep ticTacToe self-contained for dynamic import tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68662897c85c832eb647420adf11d899