### PR TITLE
Refactor input handlers

### DIFF
--- a/src/inputHandlers/default.js
+++ b/src/inputHandlers/default.js
@@ -1,21 +1,13 @@
-import { maybeRemoveElement } from './disposeHelpers.js';
 import {
-  NUMBER_INPUT_SELECTOR,
-  KV_CONTAINER_SELECTOR,
-  DENDRITE_FORM_SELECTOR,
-} from '../constants/selectors.js';
-
-export function dispose(element, dom, container) {
-  maybeRemoveElement(element, container, dom);
-}
+  maybeRemoveNumber,
+  maybeRemoveKV,
+  maybeRemoveDendrite,
+} from './removeElements.js';
+import { hideAndDisable } from './inputState.js';
 
 export function defaultHandler(dom, container, textInput) {
-  dom.hide(textInput);
-  dom.disable(textInput);
-  const numberInput = dom.querySelector(container, NUMBER_INPUT_SELECTOR);
-  dispose(numberInput, dom, container);
-  const kvContainer = dom.querySelector(container, KV_CONTAINER_SELECTOR);
-  dispose(kvContainer, dom, container);
-  const dendriteForm = dom.querySelector(container, DENDRITE_FORM_SELECTOR);
-  dispose(dendriteForm, dom, container);
+  hideAndDisable(textInput, dom);
+  maybeRemoveNumber(container, dom);
+  maybeRemoveKV(container, dom);
+  maybeRemoveDendrite(container, dom);
 }

--- a/src/inputHandlers/dendriteStory.js
+++ b/src/inputHandlers/dendriteStory.js
@@ -6,6 +6,7 @@ import {
   maybeRemoveKV,
 } from './removeElements.js';
 import { DENDRITE_FORM_SELECTOR } from '../constants/selectors.js';
+import { hideAndDisable } from './inputState.js';
 
 function disposeIfPossible(node) {
   if (typeof node._dispose === 'function') {
@@ -86,8 +87,7 @@ function buildForm(dom, { container, textInput, data, disposers }) {
 }
 
 function prepareTextInput(dom, textInput) {
-  dom.hide(textInput);
-  dom.disable(textInput);
+  hideAndDisable(textInput, dom);
 }
 
 function cleanContainer(dom, container) {

--- a/src/inputHandlers/inputState.js
+++ b/src/inputHandlers/inputState.js
@@ -1,0 +1,9 @@
+export function hideAndDisable(element, dom) {
+  dom.hide(element);
+  dom.disable(element);
+}
+
+export function revealAndEnable(element, dom) {
+  dom.reveal(element);
+  dom.enable(element);
+}

--- a/src/inputHandlers/kv.js
+++ b/src/inputHandlers/kv.js
@@ -9,6 +9,7 @@ import {
   maybeRemoveDendrite,
 } from './removeElements.js';
 import { KV_CONTAINER_SELECTOR } from '../constants/selectors.js';
+import { hideAndDisable } from './inputState.js';
 
 export const ensureKeyValueInput = (container, textInput, dom) => {
   let kvContainer = dom.querySelector(container, KV_CONTAINER_SELECTOR);
@@ -52,7 +53,6 @@ export function handleKVType(dom, container, textInput) {
 }
 
 export function kvHandler(dom, container, textInput) {
-  dom.hide(textInput);
-  dom.disable(textInput);
+  hideAndDisable(textInput, dom);
   handleKVType(dom, container, textInput);
 }

--- a/src/inputHandlers/number.js
+++ b/src/inputHandlers/number.js
@@ -3,6 +3,7 @@ import {
   maybeRemoveDendrite,
 } from './removeElements.js';
 import { NUMBER_INPUT_SELECTOR } from '../constants/selectors.js';
+import { hideAndDisable } from './inputState.js';
 
 const createRemoveValueListener = (dom, el, handler) => () =>
   dom.removeEventListener(el, 'input', handler);
@@ -59,8 +60,7 @@ export const ensureNumberInput = (container, textInput, dom) => {
 
 
 export function numberHandler(dom, container, textInput) {
-  dom.hide(textInput);
-  dom.disable(textInput);
+  hideAndDisable(textInput, dom);
   maybeRemoveKV(container, dom);
   maybeRemoveDendrite(container, dom);
   ensureNumberInput(container, textInput, dom);

--- a/src/inputHandlers/text.js
+++ b/src/inputHandlers/text.js
@@ -1,14 +1,13 @@
-import { dispose } from './default.js';
 import {
-  NUMBER_INPUT_SELECTOR,
-  KV_CONTAINER_SELECTOR,
-  DENDRITE_FORM_SELECTOR,
-} from '../constants/selectors.js';
+  maybeRemoveNumber,
+  maybeRemoveKV,
+  maybeRemoveDendrite,
+} from './removeElements.js';
+import { revealAndEnable } from './inputState.js';
 
 export function textHandler(dom, container, textInput) {
-  dom.reveal(textInput);
-  dom.enable(textInput);
-  dispose(dom.querySelector(container, NUMBER_INPUT_SELECTOR), dom, container);
-  dispose(dom.querySelector(container, KV_CONTAINER_SELECTOR), dom, container);
-  dispose(dom.querySelector(container, DENDRITE_FORM_SELECTOR), dom, container);
+  revealAndEnable(textInput, dom);
+  maybeRemoveNumber(container, dom);
+  maybeRemoveKV(container, dom);
+  maybeRemoveDendrite(container, dom);
 }


### PR DESCRIPTION
## Summary
- extract hide/reveal helpers to new `inputState` module
- update input handlers to use shared removal helpers

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68663157a040832ebec30e886cb2b5a7