### PR TITLE
Refactor duplicated deep clone logic

### DIFF
--- a/src/browser/createSectionSetter.js
+++ b/src/browser/createSectionSetter.js
@@ -1,5 +1,6 @@
 import { isObject } from './common.js';
 import { deepMerge } from './data.js';
+import { deepClone } from '../utils/objectUtils.js';
 
 /**
  * Creates a function that merges JSON input into a section of the data object.
@@ -22,7 +23,10 @@ function parseJsonObject(input) {
   try {
     json = JSON.parse(input);
   } catch (parseError) {
-    return { ok: false, message: `Error: Invalid JSON input. ${parseError.message}` };
+    return {
+      ok: false,
+      message: `Error: Invalid JSON input. ${parseError.message}`,
+    };
   }
   if (!isObject(json)) {
     return { ok: false, message: 'Error: Input JSON must be a plain object.' };
@@ -35,7 +39,7 @@ function mergeSection(section, inputJson, env) {
   const setData = env.get('setData');
   try {
     const currentData = getData();
-    const newData = JSON.parse(JSON.stringify(currentData));
+    const newData = deepClone(currentData);
     if (!isObject(newData[section])) {
       newData[section] = {};
     }

--- a/src/browser/data.js
+++ b/src/browser/data.js
@@ -1,3 +1,5 @@
+import { deepClone } from '../utils/objectUtils.js';
+
 const INTERNAL_STATE_KEYS = ['blogStatus', 'blogError', 'blogFetchPromise'];
 
 export const BLOG_STATUS = {
@@ -101,8 +103,7 @@ export function fetchAndCacheBlogData(state, fetch, loggers) {
  * @param {object} globalState - The state to copy.
  * @returns {object} A cloned version of the state.
  */
-export const getDeepStateCopy = globalState =>
-  JSON.parse(JSON.stringify(globalState));
+export const getDeepStateCopy = globalState => deepClone(globalState);
 
 /**
  * Deeply merges two objects. Creates a new object with merged properties.
@@ -232,7 +233,7 @@ function shouldDeepCopyForFetch(status) {
 function getRelevantStateCopy(state) {
   const status = state.blogStatus;
   if (shouldDeepCopyForFetch(status)) {
-    return JSON.parse(JSON.stringify(state));
+    return deepClone(state);
   }
   return state;
 }

--- a/src/browser/toys.js
+++ b/src/browser/toys.js
@@ -1,6 +1,7 @@
 import { createParagraphElement } from '../presenters/paragraph.js';
 import { createPrefixedLoggers } from './document.js';
 import { parseJsonOrDefault } from '../utils/jsonUtils.js';
+import { deepClone } from '../utils/objectUtils.js';
 
 /**
  * Parses the existing rows from the text input
@@ -1333,5 +1334,4 @@ export const createDropdownInitializer = (
  * Helper function needed by getData
  * @param globalState
  */
-export const getDeepStateCopy = globalState =>
-  JSON.parse(JSON.stringify(globalState));
+export const getDeepStateCopy = globalState => deepClone(globalState);

--- a/src/toys/2025-06-09/startLocalDendriteStory.js
+++ b/src/toys/2025-06-09/startLocalDendriteStory.js
@@ -1,4 +1,5 @@
 import { DENDRITE_OPTION_KEYS } from '../../constants/dendrite.js';
+import { deepClone } from '../../utils/objectUtils.js';
 
 function createOptions(data, getUuid) {
   const keys = DENDRITE_OPTION_KEYS;
@@ -32,7 +33,7 @@ export function startLocalDendriteStory(input, env) {
     };
 
     const currentData = getData();
-    const newData = JSON.parse(JSON.stringify(currentData));
+    const newData = deepClone(currentData);
     ensureTemporaryData(newData);
     newData.temporary.DEND1.push(result);
     setData(newData);

--- a/src/utils/objectUtils.js
+++ b/src/utils/objectUtils.js
@@ -33,3 +33,12 @@ export function mapValues(obj, fn) {
   }
   return transformEntries(obj, fn);
 }
+
+/**
+ * Creates a deep clone of the provided value using JSON serialization.
+ * @param {*} value - The value to clone
+ * @returns {*} The cloned value
+ */
+export function deepClone(value) {
+  return JSON.parse(JSON.stringify(value));
+}


### PR DESCRIPTION
## Summary
- centralize object deep cloning in `deepClone`
- reuse the helper in various modules

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6866315764c4832e8daeb393c7636114