### PR TITLE
Refactor utility duplication

### DIFF
--- a/src/browser/common.js
+++ b/src/browser/common.js
@@ -1,14 +1,3 @@
-// Shared utility functions
+import { isObject } from "../utils/objectUtils.js";
 
-/**
- * Checks if a value is a non-null object (but not an array).
- * @param {*} val
- * @returns {boolean}
- */
-function isNonNullNonArray(val) {
-  return val !== null && !Array.isArray(val);
-}
-
-export function isObject(val) {
-  return isNonNullNonArray(val) && typeof val === 'object';
-}
+export { isObject };

--- a/src/browser/createSectionSetter.js
+++ b/src/browser/createSectionSetter.js
@@ -1,4 +1,4 @@
-import { isObject } from './common.js';
+import { isObject } from '../utils/objectUtils.js';
 import { deepMerge } from './data.js';
 
 /**

--- a/src/browser/toys.js
+++ b/src/browser/toys.js
@@ -544,7 +544,7 @@ export function handleRequestResponse(url, env, options) {
   fetchFn(url).then(getText).then(displayBody).catch(handleFetchError);
 }
 
-import { isObject } from './common.js';
+import { isObject } from '../utils/objectUtils.js';
 
 /**
  * Creates a number input element with the specified value and change handler

--- a/src/presenters/battleshipSolitaireClues.js
+++ b/src/presenters/battleshipSolitaireClues.js
@@ -23,9 +23,7 @@
  *    (ones) is closest to the grid
  */
 
-function isObject(value) {
-  return value && typeof value === 'object';
-}
+import { isObject } from '../utils/objectUtils.js';
 
 function hasValidClueArrays(obj) {
   return Array.isArray(obj.rowClues) && Array.isArray(obj.colClues);

--- a/src/presenters/ticTacToeBoard.js
+++ b/src/presenters/ticTacToeBoard.js
@@ -1,4 +1,4 @@
-import { isObject } from '../browser/common.js';
+import { isObject } from '../utils/objectUtils.js';
 
 /**
  * createTicTacToeBoardElement

--- a/src/utils/objectUtils.js
+++ b/src/utils/objectUtils.js
@@ -33,3 +33,12 @@ export function mapValues(obj, fn) {
   }
   return transformEntries(obj, fn);
 }
+
+/**
+ * Determines if a value is a plain object (not null and not an array).
+ * @param {*} val - The value to check.
+ * @returns {boolean} True when val is a non-null, non-array object.
+ */
+export function isObject(val) {
+  return val !== null && typeof val === 'object' && !Array.isArray(val);
+}


### PR DESCRIPTION
## Summary
- extract a reusable `isObject` helper
- re-export helper in `browser/common.js`
- update modules to import the shared helper

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68663157441c832e9e4ba47ddd85f34f