### PR TITLE
Refactor input handlers to reuse common helper

### DIFF
--- a/src/inputHandlers/default.js
+++ b/src/inputHandlers/default.js
@@ -1,17 +1,29 @@
 import { maybeRemoveElement } from './disposeHelpers.js';
+import { hideAndDisableInput } from './inputHelpers.js';
 import {
   NUMBER_INPUT_SELECTOR,
   KV_CONTAINER_SELECTOR,
   DENDRITE_FORM_SELECTOR,
 } from '../constants/selectors.js';
 
+/**
+ *
+ * @param element
+ * @param dom
+ * @param container
+ */
 export function dispose(element, dom, container) {
   maybeRemoveElement(element, container, dom);
 }
 
+/**
+ *
+ * @param dom
+ * @param container
+ * @param textInput
+ */
 export function defaultHandler(dom, container, textInput) {
-  dom.hide(textInput);
-  dom.disable(textInput);
+  hideAndDisableInput(dom, textInput);
   const numberInput = dom.querySelector(container, NUMBER_INPUT_SELECTOR);
   dispose(numberInput, dom, container);
   const kvContainer = dom.querySelector(container, KV_CONTAINER_SELECTOR);

--- a/src/inputHandlers/dendriteStory.js
+++ b/src/inputHandlers/dendriteStory.js
@@ -1,18 +1,25 @@
 import { DENDRITE_FIELDS } from '../constants/dendrite.js';
 import { maybeRemoveElement } from './disposeHelpers.js';
 import { parseJsonOrDefault } from '../utils/jsonUtils.js';
-import {
-  maybeRemoveNumber,
-  maybeRemoveKV,
-} from './removeElements.js';
+import { hideAndDisableInput } from './inputHelpers.js';
+import { maybeRemoveNumber, maybeRemoveKV } from './removeElements.js';
 import { DENDRITE_FORM_SELECTOR } from '../constants/selectors.js';
 
+/**
+ *
+ * @param node
+ */
 function disposeIfPossible(node) {
   if (typeof node._dispose === 'function') {
     node._dispose();
   }
 }
 
+/**
+ *
+ * @param container
+ * @param dom
+ */
 function removeExistingForm(container, dom) {
   const existing = dom.querySelector(container, DENDRITE_FORM_SELECTOR);
   if (existing) {
@@ -21,11 +28,21 @@ function removeExistingForm(container, dom) {
   }
 }
 
+/**
+ *
+ * @param dom
+ * @param textInput
+ */
 function parseDendriteData(dom, textInput) {
   const value = dom.getValue(textInput) || '{}';
   return parseJsonOrDefault(value, {});
 }
 
+/**
+ *
+ * @param dom
+ * @param key
+ */
 function createInputElement(dom, key) {
   if (key === 'content') {
     return dom.createElement('textarea');
@@ -35,6 +52,17 @@ function createInputElement(dom, key) {
   return element;
 }
 
+/**
+ *
+ * @param dom
+ * @param form
+ * @param root0
+ * @param root0.key
+ * @param root0.placeholder
+ * @param root0.data
+ * @param root0.textInput
+ * @param root0.disposers
+ */
 function createField(
   dom,
   form,
@@ -60,6 +88,15 @@ function createField(
   dom.appendChild(form, wrapper);
 }
 
+/**
+ *
+ * @param dom
+ * @param root0
+ * @param root0.container
+ * @param root0.textInput
+ * @param root0.data
+ * @param root0.disposers
+ */
 function buildForm(dom, { container, textInput, data, disposers }) {
   const form = dom.createElement('div');
   dom.setClassName(form, DENDRITE_FORM_SELECTOR.slice(1));
@@ -85,25 +122,37 @@ function buildForm(dom, { container, textInput, data, disposers }) {
   return form;
 }
 
-function prepareTextInput(dom, textInput) {
-  dom.hide(textInput);
-  dom.disable(textInput);
-}
-
+/**
+ *
+ * @param dom
+ * @param container
+ */
 function cleanContainer(dom, container) {
   maybeRemoveNumber(container, dom);
   maybeRemoveKV(container, dom);
   removeExistingForm(container, dom);
 }
 
+/**
+ *
+ * @param dom
+ * @param container
+ * @param textInput
+ */
 function createDendriteForm(dom, container, textInput) {
   const disposers = [];
   const data = parseDendriteData(dom, textInput);
   return buildForm(dom, { container, textInput, data, disposers });
 }
 
+/**
+ *
+ * @param dom
+ * @param container
+ * @param textInput
+ */
 export function dendriteStoryHandler(dom, container, textInput) {
-  prepareTextInput(dom, textInput);
+  hideAndDisableInput(dom, textInput);
   cleanContainer(dom, container);
   return createDendriteForm(dom, container, textInput);
 }

--- a/src/inputHandlers/inputHelpers.js
+++ b/src/inputHandlers/inputHelpers.js
@@ -1,0 +1,14 @@
+/**
+ * Common helper functions for input elements.
+ * @module inputHelpers
+ */
+
+/**
+ * Hides and disables a text input element using the provided DOM helpers.
+ * @param {object} dom - DOM helper methods.
+ * @param {HTMLElement} input - The input element to modify.
+ */
+export function hideAndDisableInput(dom, input) {
+  dom.hide(input);
+  dom.disable(input);
+}

--- a/src/inputHandlers/kv.js
+++ b/src/inputHandlers/kv.js
@@ -4,10 +4,8 @@ import {
   createDispose,
   syncHiddenField,
 } from '../browser/toys.js';
-import {
-  maybeRemoveNumber,
-  maybeRemoveDendrite,
-} from './removeElements.js';
+import { maybeRemoveNumber, maybeRemoveDendrite } from './removeElements.js';
+import { hideAndDisableInput } from './inputHelpers.js';
 import { KV_CONTAINER_SELECTOR } from '../constants/selectors.js';
 
 export const ensureKeyValueInput = (container, textInput, dom) => {
@@ -44,15 +42,25 @@ export const ensureKeyValueInput = (container, textInput, dom) => {
   return kvContainer;
 };
 
-
+/**
+ *
+ * @param dom
+ * @param container
+ * @param textInput
+ */
 export function handleKVType(dom, container, textInput) {
   maybeRemoveNumber(container, dom);
   maybeRemoveDendrite(container, dom);
   ensureKeyValueInput(container, textInput, dom);
 }
 
+/**
+ *
+ * @param dom
+ * @param container
+ * @param textInput
+ */
 export function kvHandler(dom, container, textInput) {
-  dom.hide(textInput);
-  dom.disable(textInput);
+  hideAndDisableInput(dom, textInput);
   handleKVType(dom, container, textInput);
 }

--- a/src/inputHandlers/number.js
+++ b/src/inputHandlers/number.js
@@ -1,7 +1,5 @@
-import {
-  maybeRemoveKV,
-  maybeRemoveDendrite,
-} from './removeElements.js';
+import { maybeRemoveKV, maybeRemoveDendrite } from './removeElements.js';
+import { hideAndDisableInput } from './inputHelpers.js';
 import { NUMBER_INPUT_SELECTOR } from '../constants/selectors.js';
 
 const createRemoveValueListener = (dom, el, handler) => () =>
@@ -57,10 +55,14 @@ export const ensureNumberInput = (container, textInput, dom) => {
   return numberInput;
 };
 
-
+/**
+ *
+ * @param dom
+ * @param container
+ * @param textInput
+ */
 export function numberHandler(dom, container, textInput) {
-  dom.hide(textInput);
-  dom.disable(textInput);
+  hideAndDisableInput(dom, textInput);
   maybeRemoveKV(container, dom);
   maybeRemoveDendrite(container, dom);
   ensureNumberInput(container, textInput, dom);


### PR DESCRIPTION
## Summary
- extract hideAndDisableInput helper for input handlers
- update handlers to use the shared helper

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686631562534832e8755fd2d382b8abb