### PR TITLE
Fix lint warning in test file

### DIFF
--- a/test/presenters/pre.test.js
+++ b/test/presenters/pre.test.js
@@ -2,6 +2,10 @@ import { describe, test, expect, jest } from '@jest/globals';
 import { createPreElement } from '../../src/presenters/pre.js';
 
 // Simple mock DOM abstraction
+/**
+ * Creates a lightweight DOM used for testing.
+ * @returns {object} mock DOM interface
+ */
 function createMockDom() {
   return {
     createdElements: [],


### PR DESCRIPTION
## Summary
- add missing JSDoc returns for createMockDom helper

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68664662b234832eaf48e9910054bb26