### PR TITLE
Fix JSDoc warning in pre presenter test

### DIFF
--- a/test/presenters/pre.test.js
+++ b/test/presenters/pre.test.js
@@ -2,6 +2,10 @@ import { describe, test, expect, jest } from '@jest/globals';
 import { createPreElement } from '../../src/presenters/pre.js';
 
 // Simple mock DOM abstraction
+/**
+ * Creates a minimal DOM stub used in tests.
+ * @returns {{createdElements: any[], createElement: Function, setTextContent: Function}} DOM stub for tests
+ */
 function createMockDom() {
   return {
     createdElements: [],


### PR DESCRIPTION
## Summary
- document return type for `createMockDom` helper in tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686646635e14832e939506cba28ca461