### PR TITLE
Fix lint warning in createSectionSetter

### DIFF
--- a/src/browser/createSectionSetter.js
+++ b/src/browser/createSectionSetter.js
@@ -18,6 +18,11 @@ export function createSectionSetter(section) {
   };
 }
 
+/**
+ * Parse JSON input into an object.
+ * @param {string} input - JSON string to parse.
+ * @returns {{ok: boolean, message?: string, data?: object}} Result object.
+ */
 function parseJsonObject(input) {
   let json;
   try {


### PR DESCRIPTION
## Summary
- add JSDoc block to `parseJsonObject`

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866466344dc832eab49908d84d62d07