### PR TITLE
Fix ESLint warning in fishing game test

### DIFF
--- a/test/toys/2025-03-29/fishingGame.modifier.test.js
+++ b/test/toys/2025-03-29/fishingGame.modifier.test.js
@@ -1,6 +1,13 @@
 import { fishingGame } from '../../../src/toys/2025-03-29/fishingGame.js';
 import { describe, test, expect } from '@jest/globals';
 
+/**
+ * Create environment map for the fishing game.
+ *
+ * @param {number} rand - Random value to return.
+ * @param {number} current - Current time value.
+ * @returns {Map<string, () => number>} Environment map with getters.
+ */
 function makeEnv(rand, current) {
   return new Map([
     ['getRandomNumber', () => rand],


### PR DESCRIPTION
## Summary
- add JSDoc to `makeEnv` helper in fishing game test

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68664663744c832e89b967f942d14fb7