### PR TITLE
Fix ESLint warning in pre presenter tests

### DIFF
--- a/test/presenters/pre.test.js
+++ b/test/presenters/pre.test.js
@@ -2,6 +2,10 @@ import { describe, test, expect, jest } from '@jest/globals';
 import { createPreElement } from '../../src/presenters/pre.js';
 
 // Simple mock DOM abstraction
+/**
+ * Creates a minimal mock DOM implementation for testing.
+ * @returns {object} mock DOM utilities
+ */
 function createMockDom() {
   return {
     createdElements: [],


### PR DESCRIPTION
## Summary
- add JSDoc @returns to `createMockDom` helper in `pre.test.js`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68664663fa70832e98060ec80d8ef8ff