### PR TITLE
Fix lint warning

### DIFF
--- a/test/presenters/pre.test.js
+++ b/test/presenters/pre.test.js
@@ -2,6 +2,10 @@ import { describe, test, expect, jest } from '@jest/globals';
 import { createPreElement } from '../../src/presenters/pre.js';
 
 // Simple mock DOM abstraction
+/**
+ * Creates a mock DOM for testing purposes.
+ * @returns {object} mock DOM implementation
+ */
 function createMockDom() {
   return {
     createdElements: [],


### PR DESCRIPTION
## Summary
- add missing JSDoc `@returns` to `createMockDom`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6866466458d4832ea2f1488db2601a98