### PR TITLE
Fix lint warning

### DIFF
--- a/test/presenters/paragraph.test.js
+++ b/test/presenters/paragraph.test.js
@@ -2,6 +2,14 @@
 import { describe, test, expect } from '@jest/globals';
 import { createParagraphElement } from '../../src/presenters/paragraph.js';
 
+/**
+ * Creates a minimal DOM mock used for testing.
+ * @returns {{
+ *   element: { textContent: string },
+ *   createElement: () => object,
+ *   setTextContent: (el: object, text: string) => void
+ * }} Mock DOM utilities
+ */
 function createMockDom() {
   const element = { textContent: '' };
   return {


### PR DESCRIPTION
## Summary
- add missing JSDoc return description in `createMockDom`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68665f824394832eb0e272eb4e2d1b18