### PR TITLE
Fix jsdoc warning

### DIFF
--- a/test/presenters/paragraph.test.js
+++ b/test/presenters/paragraph.test.js
@@ -2,6 +2,14 @@
 import { describe, test, expect } from '@jest/globals';
 import { createParagraphElement } from '../../src/presenters/paragraph.js';
 
+/**
+ * Creates a DOM mock for testing.
+ * @returns {{
+ *   element: { textContent: string },
+ *   createElement: () => { textContent: string },
+ *   setTextContent: (el: { textContent: string }, text: string) => void
+ * }} Mock DOM helpers
+ */
 function createMockDom() {
   const element = { textContent: '' };
   return {


### PR DESCRIPTION
## Summary
- add JSDoc comment to `createMockDom`

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68665f824f74832ebeb98b17cc7afc8c