### PR TITLE
Reduce eslint warnings by adding JSDoc

### DIFF
--- a/test/presenters/paragraph.test.js
+++ b/test/presenters/paragraph.test.js
@@ -2,6 +2,10 @@
 import { describe, test, expect } from '@jest/globals';
 import { createParagraphElement } from '../../src/presenters/paragraph.js';
 
+/**
+ * Creates a lightweight DOM used for testing.
+ * @returns {object} mock DOM interface
+ */
 function createMockDom() {
   const element = { textContent: '' };
   return {


### PR DESCRIPTION
## Summary
- document `createMockDom` return value for test

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68665f830c2c832e8577a8ea22f17213