### PR TITLE
Fix eslint warning

### DIFF
--- a/test/presenters/paragraph.test.js
+++ b/test/presenters/paragraph.test.js
@@ -2,6 +2,10 @@
 import { describe, test, expect } from '@jest/globals';
 import { createParagraphElement } from '../../src/presenters/paragraph.js';
 
+/**
+ * Creates a minimal DOM mock used in tests.
+ * @returns {object} mock DOM utilities
+ */
 function createMockDom() {
   const element = { textContent: '' };
   return {


### PR DESCRIPTION
## Summary
- add a missing JSDoc `@returns` tag in the paragraph test to clear a lint warning

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68665f8339c8832ea67fba731c715845