### PR TITLE
Fix a lint warning in paragraph presenter tests

### DIFF
--- a/test/presenters/paragraph.test.js
+++ b/test/presenters/paragraph.test.js
@@ -2,6 +2,10 @@
 import { describe, test, expect } from '@jest/globals';
 import { createParagraphElement } from '../../src/presenters/paragraph.js';
 
+/**
+ * Creates a mock DOM object for testing.
+ * @returns {object} mock DOM implementation
+ */
 function createMockDom() {
   const element = { textContent: '' };
   return {


### PR DESCRIPTION
## Summary
- add missing JSDoc to `createMockDom` test helper

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68665f836ecc832e91c107f2bdf4526c