### PR TITLE
Fix JSDoc warning in mockDom

### DIFF
--- a/test/presenters/ticTacToeBoard.test.js
+++ b/test/presenters/ticTacToeBoard.test.js
@@ -1,10 +1,16 @@
 import { createTicTacToeBoardElement } from '../../src/presenters/ticTacToeBoard.js';
 
-/** Very small stub of the DOM abstraction used in tests */
+/**
+ * Very small stub of the DOM abstraction used in tests
+ *
+ * @returns {object} mocked DOM helpers
+ */
 function mockDom() {
   return {
     createElement: tag => ({ tagName: tag, textContent: '' }),
-    setTextContent: (el, txt) => { el.textContent = txt; },
+    setTextContent: (el, txt) => {
+      el.textContent = txt;
+    },
   };
 }
 
@@ -13,21 +19,24 @@ describe('createTicTacToeBoardElement', () => {
     const el = createTicTacToeBoardElement(JSON.stringify({}), mockDom());
     expect(el.textContent).toBe(
       '   |   |   \n' +
-      '---+---+---\n' +
-      '   |   |   \n' +
-      '---+---+---\n' +
-      '   |   |   '
+        '---+---+---\n' +
+        '   |   |   \n' +
+        '---+---+---\n' +
+        '   |   |   '
     );
   });
 
   it('renders an empty board if moves is not an array', () => {
-    const el = createTicTacToeBoardElement(JSON.stringify({ moves: 5 }), mockDom());
+    const el = createTicTacToeBoardElement(
+      JSON.stringify({ moves: 5 }),
+      mockDom()
+    );
     expect(el.textContent).toBe(
       '   |   |   \n' +
-      '---+---+---\n' +
-      '   |   |   \n' +
-      '---+---+---\n' +
-      '   |   |   '
+        '---+---+---\n' +
+        '   |   |   \n' +
+        '---+---+---\n' +
+        '   |   |   '
     );
   });
 
@@ -35,16 +44,16 @@ describe('createTicTacToeBoardElement', () => {
     const input = JSON.stringify({
       moves: [
         { player: 'Q', position: { row: 0, column: 0 } },
-        { player: 'X', position: { row: 1, column: 1 } }
-      ]
+        { player: 'X', position: { row: 1, column: 1 } },
+      ],
     });
     const el = createTicTacToeBoardElement(input, mockDom());
     expect(el.textContent).toBe(
       '   |   |   \n' +
-      '---+---+---\n' +
-      '   | X |   \n' +
-      '---+---+---\n' +
-      '   |   |   '
+        '---+---+---\n' +
+        '   | X |   \n' +
+        '---+---+---\n' +
+        '   |   |   '
     );
   });
 
@@ -52,16 +61,16 @@ describe('createTicTacToeBoardElement', () => {
     const input = JSON.stringify({
       moves: [
         { player: 'X' },
-        { player: 'O', position: { row: 1, column: 1 } }
-      ]
+        { player: 'O', position: { row: 1, column: 1 } },
+      ],
     });
     const el = createTicTacToeBoardElement(input, mockDom());
     expect(el.textContent).toBe(
       '   |   |   \n' +
-      '---+---+---\n' +
-      '   | O |   \n' +
-      '---+---+---\n' +
-      '   |   |   '
+        '---+---+---\n' +
+        '   | O |   \n' +
+        '---+---+---\n' +
+        '   |   |   '
     );
   });
 
@@ -69,16 +78,16 @@ describe('createTicTacToeBoardElement', () => {
     const input = JSON.stringify({
       moves: [
         { player: 'X', position: { row: 3, column: 0 } },
-        { player: 'O', position: { row: 1, column: 1 } }
-      ]
+        { player: 'O', position: { row: 1, column: 1 } },
+      ],
     });
     const el = createTicTacToeBoardElement(input, mockDom());
     expect(el.textContent).toBe(
       '   |   |   \n' +
-      '---+---+---\n' +
-      '   | O |   \n' +
-      '---+---+---\n' +
-      '   |   |   '
+        '---+---+---\n' +
+        '   | O |   \n' +
+        '---+---+---\n' +
+        '   |   |   '
     );
   });
 
@@ -86,16 +95,16 @@ describe('createTicTacToeBoardElement', () => {
     const input = JSON.stringify({
       moves: [
         { player: 'X', position: { row: 0, column: 3 } },
-        { player: 'O', position: { row: 1, column: 1 } }
-      ]
+        { player: 'O', position: { row: 1, column: 1 } },
+      ],
     });
     const el = createTicTacToeBoardElement(input, mockDom());
     expect(el.textContent).toBe(
       '   |   |   \n' +
-      '---+---+---\n' +
-      '   | O |   \n' +
-      '---+---+---\n' +
-      '   |   |   '
+        '---+---+---\n' +
+        '   | O |   \n' +
+        '---+---+---\n' +
+        '   |   |   '
     );
   });
 
@@ -104,16 +113,16 @@ describe('createTicTacToeBoardElement', () => {
       moves: [
         { player: 'X', position: { row: 0, column: 0 } },
         { player: 'O', position: { row: 0, column: 0 } },
-        { player: 'X', position: { row: 0, column: 0 } }
-      ]
+        { player: 'X', position: { row: 0, column: 0 } },
+      ],
     });
     const el = createTicTacToeBoardElement(input, mockDom());
     expect(el.textContent).toBe(
       ' X |   |   \n' +
-      '---+---+---\n' +
-      '   |   |   \n' +
-      '---+---+---\n' +
-      '   |   |   '
+        '---+---+---\n' +
+        '   |   |   \n' +
+        '---+---+---\n' +
+        '   |   |   '
     );
   });
 
@@ -121,16 +130,16 @@ describe('createTicTacToeBoardElement', () => {
     const input = JSON.stringify({
       moves: [
         { player: 'X', position: { row: 0, column: 0 } },
-        { player: 'O', position: { row: 0, column: 0 } }
-      ]
+        { player: 'O', position: { row: 0, column: 0 } },
+      ],
     });
     const el = createTicTacToeBoardElement(input, mockDom());
     expect(el.textContent).toBe(
       ' X |   |   \n' +
-      '---+---+---\n' +
-      '   |   |   \n' +
-      '---+---+---\n' +
-      '   |   |   '
+        '---+---+---\n' +
+        '   |   |   \n' +
+        '---+---+---\n' +
+        '   |   |   '
     );
   });
 
@@ -138,16 +147,16 @@ describe('createTicTacToeBoardElement', () => {
     const input = JSON.stringify({
       moves: [
         { player: 'X', position: { row: 0 } },
-        { player: 'O', position: { column: 1 } }
-      ]
+        { player: 'O', position: { column: 1 } },
+      ],
     });
     const el = createTicTacToeBoardElement(input, mockDom());
     expect(el.textContent).toBe(
       '   |   |   \n' +
-      '---+---+---\n' +
-      '   |   |   \n' +
-      '---+---+---\n' +
-      '   |   |   '
+        '---+---+---\n' +
+        '   |   |   \n' +
+        '---+---+---\n' +
+        '   |   |   '
     );
   });
 
@@ -156,30 +165,36 @@ describe('createTicTacToeBoardElement', () => {
       moves: [
         { player: 'X', position: { row: '0', column: 0 } },
         { player: 'O', position: { row: 1, column: '1' } },
-        { player: 'X', position: { row: 1, column: 1 } }
-      ]
+        { player: 'X', position: { row: 1, column: 1 } },
+      ],
     });
     const el = createTicTacToeBoardElement(input, mockDom());
     expect(el.textContent).toBe(
       '   |   |   \n' +
-      '---+---+---\n' +
-      '   | X |   \n' +
-      '---+---+---\n' +
-      '   |   |   '
+        '---+---+---\n' +
+        '   | X |   \n' +
+        '---+---+---\n' +
+        '   |   |   '
     );
   });
 
   it('ignores moves where the move is not an object (null, number, string, array)', () => {
     const input = JSON.stringify({
-      moves: [null, 42, "foo", [1,2,3], { player: 'X', position: { row: 0, column: 0 } }]
+      moves: [
+        null,
+        42,
+        'foo',
+        [1, 2, 3],
+        { player: 'X', position: { row: 0, column: 0 } },
+      ],
     });
     const el = createTicTacToeBoardElement(input, mockDom());
     expect(el.textContent).toBe(
       ' X |   |   \n' +
-      '---+---+---\n' +
-      '   |   |   \n' +
-      '---+---+---\n' +
-      '   |   |   '
+        '---+---+---\n' +
+        '   |   |   \n' +
+        '---+---+---\n' +
+        '   |   |   '
     );
   });
 
@@ -188,35 +203,35 @@ describe('createTicTacToeBoardElement', () => {
       moves: [
         { player: 'X', position: null },
         { player: 'O', position: 123 },
-        { player: 'X', position: "abc" },
-        { player: 'O', position: [1,2] },
-        { player: 'X', position: { row: 2, column: 2 } }
-      ]
+        { player: 'X', position: 'abc' },
+        { player: 'O', position: [1, 2] },
+        { player: 'X', position: { row: 2, column: 2 } },
+      ],
     });
     const el = createTicTacToeBoardElement(input, mockDom());
     expect(el.textContent).toBe(
       '   |   |   \n' +
-      '---+---+---\n' +
-      '   |   |   \n' +
-      '---+---+---\n' +
-      '   |   | X '
+        '---+---+---\n' +
+        '   |   |   \n' +
+        '---+---+---\n' +
+        '   |   | X '
     );
   });
 
   it('ignores moves with non-numeric column values', () => {
     const input = JSON.stringify({
       moves: [
-        { player: 'X', position: { row: 1, column: "2" } },
-        { player: 'O', position: { row: 1, column: 1 } }
-      ]
+        { player: 'X', position: { row: 1, column: '2' } },
+        { player: 'O', position: { row: 1, column: 1 } },
+      ],
     });
     const el = createTicTacToeBoardElement(input, mockDom());
     expect(el.textContent).toBe(
       '   |   |   \n' +
-      '---+---+---\n' +
-      '   | O |   \n' +
-      '---+---+---\n' +
-      '   |   |   '
+        '---+---+---\n' +
+        '   | O |   \n' +
+        '---+---+---\n' +
+        '   |   |   '
     );
   });
 
@@ -225,16 +240,16 @@ describe('createTicTacToeBoardElement', () => {
       moves: [
         { player: 'X', position: { row: -1, column: 0 } },
         { player: 'O', position: { row: 0, column: -1 } },
-        { player: 'X', position: { row: 1, column: 1 } }
-      ]
+        { player: 'X', position: { row: 1, column: 1 } },
+      ],
     });
     const el = createTicTacToeBoardElement(input, mockDom());
     expect(el.textContent).toBe(
       '   |   |   \n' +
-      '---+---+---\n' +
-      '   | X |   \n' +
-      '---+---+---\n' +
-      '   |   |   '
+        '---+---+---\n' +
+        '   | X |   \n' +
+        '---+---+---\n' +
+        '   |   |   '
     );
   });
 
@@ -243,10 +258,10 @@ describe('createTicTacToeBoardElement', () => {
     expect(el.tagName).toBe('pre');
     expect(el.textContent).toBe(
       '   |   |   \n' +
-      '---+---+---\n' +
-      '   |   |   \n' +
-      '---+---+---\n' +
-      '   |   |   '
+        '---+---+---\n' +
+        '   |   |   \n' +
+        '---+---+---\n' +
+        '   |   |   '
     );
   });
 
@@ -255,10 +270,10 @@ describe('createTicTacToeBoardElement', () => {
     expect(el.tagName).toBe('pre');
     expect(el.textContent).toBe(
       '   |   |   \n' +
-      '---+---+---\n' +
-      '   |   |   \n' +
-      '---+---+---\n' +
-      '   |   |   '
+        '---+---+---\n' +
+        '   |   |   \n' +
+        '---+---+---\n' +
+        '   |   |   '
     );
   });
 
@@ -275,10 +290,10 @@ describe('createTicTacToeBoardElement', () => {
     expect(el.tagName).toBe('pre');
     expect(el.textContent).toBe(
       ' X |   |   \n' +
-      '---+---+---\n' +
-      '   | O |   \n' +
-      '---+---+---\n' +
-      '   |   | X '
+        '---+---+---\n' +
+        '   | O |   \n' +
+        '---+---+---\n' +
+        '   |   | X '
     );
   });
 
@@ -290,10 +305,10 @@ describe('createTicTacToeBoardElement', () => {
 
     expect(el.textContent).toBe(
       '   |   |   \n' +
-      '---+---+---\n' +
-      '   |   |   \n' +
-      '---+---+---\n' +
-      '   |   |   '
+        '---+---+---\n' +
+        '   |   |   \n' +
+        '---+---+---\n' +
+        '   |   |   '
     );
   });
 
@@ -302,24 +317,24 @@ describe('createTicTacToeBoardElement', () => {
     expect(el.tagName).toBe('pre');
     expect(el.textContent).toBe(
       '   |   |   \n' +
-      '---+---+---\n' +
-      '   |   |   \n' +
-      '---+---+---\n' +
-      '   |   |   '
+        '---+---+---\n' +
+        '   |   |   \n' +
+        '---+---+---\n' +
+        '   |   |   '
     );
   });
 
   it('renders an empty board when the only move has an invalid player', () => {
     const input = JSON.stringify({
-      moves: [{ player: 'Q', position: { row: 0, column: 0 } }]
+      moves: [{ player: 'Q', position: { row: 0, column: 0 } }],
     });
     const el = createTicTacToeBoardElement(input, mockDom());
     expect(el.textContent).toBe(
       '   |   |   \n' +
-      '---+---+---\n' +
-      '   |   |   \n' +
-      '---+---+---\n' +
-      '   |   |   '
+        '---+---+---\n' +
+        '   |   |   \n' +
+        '---+---+---\n' +
+        '   |   |   '
     );
   });
 
@@ -327,16 +342,16 @@ describe('createTicTacToeBoardElement', () => {
     const input = JSON.stringify({
       moves: [
         { player: 'Q', position: { row: 0, column: 0 } },
-        { player: 'P', position: { row: 2, column: 2 } }
-      ]
+        { player: 'P', position: { row: 2, column: 2 } },
+      ],
     });
     const el = createTicTacToeBoardElement(input, mockDom());
     expect(el.textContent).toBe(
       '   |   |   \n' +
-      '---+---+---\n' +
-      '   |   |   \n' +
-      '---+---+---\n' +
-      '   |   |   '
+        '---+---+---\n' +
+        '   |   |   \n' +
+        '---+---+---\n' +
+        '   |   |   '
     );
   });
 });


### PR DESCRIPTION
## Summary
- add missing JSDoc for `mockDom`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68666badcd28832e9a05da9455b9afcc