### PR TITLE
Fix lint warning

### DIFF
--- a/test/generator/html.replacements.integrity.test.js
+++ b/test/generator/html.replacements.integrity.test.js
@@ -1,8 +1,18 @@
 import { describe, test, expect } from '@jest/globals';
 import { htmlEscapeReplacements } from '../../src/generator/html.js';
 
+/**
+ * Applies the replacements to the provided text.
+ *
+ * @param {string} text - The text to transform.
+ * @param {{from: RegExp, to: string}[]} replacements - Patterns to apply.
+ * @returns {string} The escaped text.
+ */
 function escapeWithReplacements(text, replacements) {
-  return replacements.reduce((acc, { from, to }) => acc.replace(from, to), text);
+  return replacements.reduce(
+    (acc, { from, to }) => acc.replace(from, to),
+    text
+  );
 }
 
 describe('HTML_ESCAPE_REPLACEMENTS integrity', () => {


### PR DESCRIPTION
## Summary
- add JSDoc to escapeWithReplacements helper used in tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68666bab1688832e9b1e04bbdd87a49b