### PR TITLE
Fix ESLint warning in TicTacToeBoard test

### DIFF
--- a/test/presenters/ticTacToeBoard.test.js
+++ b/test/presenters/ticTacToeBoard.test.js
@@ -1,6 +1,10 @@
 import { createTicTacToeBoardElement } from '../../src/presenters/ticTacToeBoard.js';
 
-/** Very small stub of the DOM abstraction used in tests */
+/**
+ * Very small stub of the DOM abstraction used in tests
+ *
+ * @returns {object} DOM stub
+ */
 function mockDom() {
   return {
     createElement: tag => ({ tagName: tag, textContent: '' }),


### PR DESCRIPTION
## Summary
- add missing JSDoc return for `mockDom`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68666ba9c0b0832e98b56fb2451b71ff