### PR TITLE
Fix ESLint JSDoc warning

### DIFF
--- a/test/generator/html.replacements.integrity.test.js
+++ b/test/generator/html.replacements.integrity.test.js
@@ -1,8 +1,17 @@
 import { describe, test, expect } from '@jest/globals';
 import { htmlEscapeReplacements } from '../../src/generator/html.js';
 
+/**
+ * Replace characters in a string using a set of replacements.
+ * @param {string} text - Input to escape.
+ * @param {{from: RegExp, to: string}[]} replacements - Patterns to replace.
+ * @returns {string} Escaped string.
+ */
 function escapeWithReplacements(text, replacements) {
-  return replacements.reduce((acc, { from, to }) => acc.replace(from, to), text);
+  return replacements.reduce(
+    (acc, { from, to }) => acc.replace(from, to),
+    text
+  );
 }
 
 describe('HTML_ESCAPE_REPLACEMENTS integrity', () => {


### PR DESCRIPTION
## Summary
- add JSDoc comments for `escapeWithReplacements` in `html.replacements.integrity.test.js`

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68666ba91148832e83361c2340079604