### PR TITLE
Fix lint warning with JSDoc

### DIFF
--- a/test/generator/html.replacements.integrity.test.js
+++ b/test/generator/html.replacements.integrity.test.js
@@ -1,6 +1,13 @@
 import { describe, test, expect } from '@jest/globals';
 import { htmlEscapeReplacements } from '../../src/generator/html.js';
 
+/**
+ * Replace characters in `text` using the provided replacement pairs.
+ *
+ * @param {string} text - The text to update.
+ * @param {{from: RegExp, to: string}[]} replacements - Pairs of values to replace.
+ * @returns {string} The escaped text.
+ */
 function escapeWithReplacements(text, replacements) {
   return replacements.reduce((acc, { from, to }) => acc.replace(from, to), text);
 }


### PR DESCRIPTION
## Summary
- document escapeWithReplacements helper to satisfy lint

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68666bac969c832eb8edffebafacfc88