### PR TITLE
Fix lint warning in TicTacToe tests

### DIFF
--- a/test/presenters/ticTacToeBoard.test.js
+++ b/test/presenters/ticTacToeBoard.test.js
@@ -1,6 +1,9 @@
 import { createTicTacToeBoardElement } from '../../src/presenters/ticTacToeBoard.js';
 
-/** Very small stub of the DOM abstraction used in tests */
+/**
+ * Very small stub of the DOM abstraction used in tests
+ * @returns {object} DOM stub with createElement and setTextContent
+ */
 function mockDom() {
   return {
     createElement: tag => ({ tagName: tag, textContent: '' }),


### PR DESCRIPTION
## Summary
- add a return description to the `mockDom` helper so ESLint no longer warns

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68666ba83c5c832e909385c7bbf149a4