### PR TITLE
Fix lint warning

### DIFF
--- a/test/generator/html.replacements.integrity.test.js
+++ b/test/generator/html.replacements.integrity.test.js
@@ -1,8 +1,18 @@
 import { describe, test, expect } from '@jest/globals';
 import { htmlEscapeReplacements } from '../../src/generator/html.js';
 
+/**
+ * Escape HTML special characters using provided replacements.
+ *
+ * @param {string} text - Text to transform.
+ * @param {Array<{from: RegExp, to: string}>} replacements - Replacement pairs.
+ * @returns {string} Escaped text.
+ */
 function escapeWithReplacements(text, replacements) {
-  return replacements.reduce((acc, { from, to }) => acc.replace(from, to), text);
+  return replacements.reduce(
+    (acc, { from, to }) => acc.replace(from, to),
+    text
+  );
 }
 
 describe('HTML_ESCAPE_REPLACEMENTS integrity', () => {


### PR DESCRIPTION
## Summary
- document escapeWithReplacements return value and parameters

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68666ba91d20832eae279cb6942f60ee