### PR TITLE
Fix ESLint warning

### DIFF
--- a/test/generator/html.replacements.integrity.test.js
+++ b/test/generator/html.replacements.integrity.test.js
@@ -1,6 +1,12 @@
 import { describe, test, expect } from '@jest/globals';
 import { htmlEscapeReplacements } from '../../src/generator/html.js';
-
+/**
+ * Escape special characters using the provided replacements.
+ *
+ * @param {string} text - String to escape.
+ * @param {{from: RegExp, to: string}[]} replacements - Replacement pairs.
+ * @returns {string} The escaped string.
+ */
 function escapeWithReplacements(text, replacements) {
   return replacements.reduce((acc, { from, to }) => acc.replace(from, to), text);
 }


### PR DESCRIPTION
## Summary
- document `escapeWithReplacements` in html.replacements.integrity.test.js

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68666baa19c4832e86a17855e7c09bad