### PR TITLE
Fix lint warning in html.replacements.integrity.test.js

### DIFF
--- a/test/generator/html.replacements.integrity.test.js
+++ b/test/generator/html.replacements.integrity.test.js
@@ -1,8 +1,17 @@
 import { describe, test, expect } from '@jest/globals';
 import { htmlEscapeReplacements } from '../../src/generator/html.js';
 
+/**
+ * Replace special characters in the text using provided replacements.
+ * @param {string} text
+ * @param {{ from: RegExp, to: string }[]} replacements
+ * @returns {string}
+ */
 function escapeWithReplacements(text, replacements) {
-  return replacements.reduce((acc, { from, to }) => acc.replace(from, to), text);
+  return replacements.reduce(
+    (acc, { from, to }) => acc.replace(from, to),
+    text
+  );
 }
 
 describe('HTML_ESCAPE_REPLACEMENTS integrity', () => {


### PR DESCRIPTION
## Summary
- add missing JSDoc return info for `escapeWithReplacements`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68666ba83170832e9122941d22bf1cbd