### PR TITLE
Fix lint warning in dynamic import test

### DIFF
--- a/test/browser/getDeepStateCopy.importCache.test.js
+++ b/test/browser/getDeepStateCopy.importCache.test.js
@@ -1,6 +1,10 @@
 import { test, expect } from '@jest/globals';
 
 // Dynamically import with cache-busting query to avoid module caching
+/**
+ * Load the toys module with a cache-busting suffix.
+ * @returns {Promise<Function>} resolves with getDeepStateCopy
+ */
 async function loadModule() {
   const suffix = `?cacheBust=${Date.now()}`;
   const module = await import(`../../src/browser/toys.js${suffix}`);


### PR DESCRIPTION
## Summary
- add missing JSDoc @returns declaration in `getDeepStateCopy.importCache.test.js`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68666f352efc832ea71153bd6ef9f476