### PR TITLE
Fix lint warning in import cache test

### DIFF
--- a/test/browser/getDeepStateCopy.importCache.test.js
+++ b/test/browser/getDeepStateCopy.importCache.test.js
@@ -1,6 +1,11 @@
 import { test, expect } from '@jest/globals';
 
 // Dynamically import with cache-busting query to avoid module caching
+/**
+ * Load the module with a cache-busting query string.
+ *
+ * @returns {Promise<Function>} getDeepStateCopy function from the module
+ */
 async function loadModule() {
   const suffix = `?cacheBust=${Date.now()}`;
   const module = await import(`../../src/browser/toys.js${suffix}`);


### PR DESCRIPTION
## Summary
- add JSDoc `@returns` to `loadModule` in `getDeepStateCopy.importCache.test.js`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68666f359614832e99f575c138ded820