### PR TITLE
Fix eslint warning

### DIFF
--- a/test/browser/getDeepStateCopy.importCache.test.js
+++ b/test/browser/getDeepStateCopy.importCache.test.js
@@ -1,6 +1,11 @@
 import { test, expect } from '@jest/globals';
 
 // Dynamically import with cache-busting query to avoid module caching
+/**
+ * Load the module with a cache-busting suffix.
+ *
+ * @returns {Promise<function>} resolves to the getDeepStateCopy function
+ */
 async function loadModule() {
   const suffix = `?cacheBust=${Date.now()}`;
   const module = await import(`../../src/browser/toys.js${suffix}`);


### PR DESCRIPTION
## Summary
- add JSDoc return description in getDeepStateCopy.importCache.test.js

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68666f3644b8832eb817ea78e4389b74