### PR TITLE
Reduce ESLint warnings

### DIFF
--- a/test/browser/getDeepStateCopy.importCache.test.js
+++ b/test/browser/getDeepStateCopy.importCache.test.js
@@ -1,6 +1,10 @@
 import { test, expect } from '@jest/globals';
 
 // Dynamically import with cache-busting query to avoid module caching
+/**
+ * Load getDeepStateCopy from the module with a cache-busting query.
+ * @returns {Promise<Function>} getDeepStateCopy
+ */
 async function loadModule() {
   const suffix = `?cacheBust=${Date.now()}`;
   const module = await import(`../../src/browser/toys.js${suffix}`);


### PR DESCRIPTION
## Summary
- fix jsdoc lint warning in import cache test

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68666f35bc30832e8fed9ce78afb4959