### PR TITLE
Improve JSDoc comments

### DIFF
--- a/src/constants/markdown.js
+++ b/src/constants/markdown.js
@@ -1,5 +1,6 @@
 /**
- * Markdown formatting markers
+ * Markdown formatting markers.
+ * @returns {Readonly<Record<string, string>>} Object of marker characters.
  */
 export function markdownMarkers() {
   return Object.freeze({
@@ -23,7 +24,8 @@ export function markdownMarkers() {
 }
 
 /**
- * HTML tags for markdown elements
+ * HTML tag names for supported markdown elements.
+ * @returns {Readonly<Record<string, string>>} Map of element keys to tag names.
  */
 export function htmlTags() {
   return Object.freeze({
@@ -46,7 +48,8 @@ export function htmlTags() {
 }
 
 /**
- * Common CSS class names
+ * Common CSS class names used when rendering markdown.
+ * @returns {Readonly<Record<string, string>>} Object of class names.
  */
 export function cssClasses() {
   return Object.freeze({
@@ -65,7 +68,8 @@ export function cssClasses() {
 }
 
 /**
- * Default options for markdown parsing
+ * Default options for markdown parsing.
+ * @returns {Readonly<Record<string, unknown>>} Default configuration values.
  */
 export function defaultOptions() {
   return Object.freeze({

--- a/src/presenters/paragraph.js
+++ b/src/presenters/paragraph.js
@@ -1,7 +1,8 @@
 /**
- *
- * @param inputString
- * @param dom
+ * Create a paragraph element containing the provided text.
+ * @param {string} inputString - Text to place inside the paragraph.
+ * @param {{createElement: Function, setTextContent: Function}} dom - DOM utilities.
+ * @returns {HTMLElement} The created paragraph element.
  */
 export function createParagraphElement(inputString, dom) {
   const paragraph = dom.createElement('p');

--- a/src/presenters/pre.js
+++ b/src/presenters/pre.js
@@ -2,27 +2,27 @@
 // Creates a <pre> element with the given string as its text content using a DOM abstraction
 
 /**
- * Create a <pre> DOM element with pre-formatted text.
- * @param {string} inputString - The text to display (may include newlines and spaces).
- * @param {object} dom - An object with createElement and setTextContent methods.
- * @param str
- * @returns {HTMLElement} The <pre> element with the provided text content.
+ * Determine if a string starts with '[' and ends with ']'.
+ * @param {string} str - The string to check.
+ * @returns {boolean} Whether the string is enclosed in brackets.
  */
 function isSurroundedByBrackets(str) {
   return str.startsWith('[') && str.endsWith(']');
 }
 
 /**
- *
- * @param str
+ * Check if the given value is a bracketed list string.
+ * @param {unknown} str - Value to evaluate.
+ * @returns {boolean} True if str is a bracketed list string.
  */
 function isBracketedListString(str) {
   return typeof str === 'string' && isSurroundedByBrackets(str);
 }
 
 /**
- *
- * @param inputString
+ * Format a bracketed list string into newline-separated items.
+ * @param {string} inputString - The bracketed list string.
+ * @returns {string} Newline-separated list items.
  */
 function formatBracketedListString(inputString) {
   const inner = inputString.slice(1, -1).trim();
@@ -37,8 +37,9 @@ function formatBracketedListString(inputString) {
 }
 
 /**
- *
- * @param inputString
+ * Determine the pre element content for a given input string.
+ * @param {string} inputString - The input provided to the presenter.
+ * @returns {string} The formatted string for the <pre> element.
  */
 function getPreContent(inputString) {
   if (isBracketedListString(inputString)) {
@@ -48,9 +49,10 @@ function getPreContent(inputString) {
 }
 
 /**
- *
- * @param inputString
- * @param dom
+ * Create a <pre> element with the provided text.
+ * @param {string} inputString - The raw input text or list string.
+ * @param {{createElement: Function, setTextContent: Function}} dom - DOM utilities.
+ * @returns {HTMLElement} The <pre> element populated with content.
  */
 export function createPreElement(inputString, dom) {
   const pre = dom.createElement('pre');

--- a/src/toys/2025-03-21/booleanCoercer.js
+++ b/src/toys/2025-03-21/booleanCoercer.js
@@ -1,8 +1,9 @@
 import { isType } from '../../utils/validation.js';
 
 /**
- *
- * @param input
+ * Attempt to coerce a value to boolean.
+ * @param {unknown} input - Value that may represent a boolean.
+ * @returns {boolean|undefined} The coerced boolean or undefined.
  */
 function tryBooleanCoercion(input) {
   if (isType(input, 'boolean')) {
@@ -12,11 +13,12 @@ function tryBooleanCoercion(input) {
 }
 
 /**
- * Coerces input to a boolean value if possible.
- * Returns a string representation of an object with a 'value' property if coercion is successful,
- * or a string representation of an empty object if coercion fails.
- * @param {any} input - The value to coerce to boolean
- * @returns {string} - String representation of object with 'value' property if coercion successful, '{}' if not
+ * Coerce input to a boolean value if possible.
+ *
+ * Returns `"{ value: true }"` or `"{ value: false }"` when coercion succeeds.
+ * Otherwise returns `'{}'`.
+ * @param {unknown} input - Value to coerce.
+ * @returns {string} JSON string describing the result.
  */
 export function coerceToBoolean(input) {
   const value = tryBooleanCoercion(input);
@@ -28,8 +30,9 @@ export function coerceToBoolean(input) {
 }
 
 /**
- *
- * @param input
+ * Normalize a string that may represent a boolean.
+ * @param {unknown} input - Value to normalize.
+ * @returns {string|undefined} Lowercased string or undefined if not a string.
  */
 function normalizeBooleanString(input) {
   if (!isType(input, 'string')) {
@@ -39,8 +42,9 @@ function normalizeBooleanString(input) {
 }
 
 /**
- *
- * @param str
+ * Parse 'true' or 'false' strings into booleans.
+ * @param {string} str - String value to parse.
+ * @returns {boolean|undefined} Parsed boolean or undefined.
  */
 function parseBooleanString(str) {
   return { true: true, false: false }[str];

--- a/src/toys/2025-03-21/italics.js
+++ b/src/toys/2025-03-21/italics.js
@@ -6,16 +6,18 @@ const UNDERSCORE_MARKER = '_';
 const REGEX_SPECIAL_CHARS = /[.*+?^${}()|[\]\\]/;
 
 /**
- *
- * @param text
+ * Determine whether a string is empty or whitespace only.
+ * @param {string} text - Text to evaluate.
+ * @returns {boolean} True if text has no visible characters.
  */
 function isEmptyText(text) {
   return !text?.trim();
 }
 
 /**
- *
- * @param text
+ * Check that the provided text contains no bold Markdown segments.
+ * @param {string} text - Text to inspect.
+ * @returns {boolean} True if there are no bold segments.
  */
 function hasNoBoldSegments(text) {
   return !findBoldSegments(text);

--- a/src/toys/2025-04-16/colorPalette.js
+++ b/src/toys/2025-04-16/colorPalette.js
@@ -1,7 +1,8 @@
 /**
- *
- * @param input
- * @param env
+ * Generate a palette of grayscale colors.
+ * @param {string|number} input - Desired number of colors.
+ * @param {{get: Function}} env - Environment with a `getRandomNumber` function.
+ * @returns {string} JSON string with a `palette` array.
  */
 export function generatePalette(input, env) {
   const getRand = env.get('getRandomNumber');


### PR DESCRIPTION
## Summary
- add full JSDoc details for paragraph presenter
- document helper functions in the pre presenter
- clarify constants markdown exports
- improve boolean coercer docs
- document italics helpers
- explain color palette toy

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6867819a8428832e84ead85952707266