### PR TITLE
Fix lint warning

### DIFF
--- a/src/generator/generator.js
+++ b/src/generator/generator.js
@@ -894,6 +894,7 @@ function prefixIfPresent(prefix, value) {
   if (value) {
     return `${prefix}${value}`;
   }
+  return undefined;
 }
 
 /**


### PR DESCRIPTION
## Summary
- eliminate ESLint `consistent-return` warning in `prefixIfPresent`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6867e1afa268832e96686126f45a371b