### PR TITLE
Fix lint warning

### DIFF
--- a/src/generator/generator.js
+++ b/src/generator/generator.js
@@ -942,6 +942,7 @@ function wrapIfPresent(prefix, value, suffix) {
   if (value) {
     return prefix + value + suffix;
   }
+  return undefined;
 }
 
 /**


### PR DESCRIPTION
## Summary
- explicitly return `undefined` from `wrapIfPresent` to satisfy ESLint

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6867e4936cc8832e8ee7ad52122e2d2b