### PR TITLE
Add DEND2 titles toy

### DIFF
--- a/src/blog.json
+++ b/src/blog.json
@@ -1,6 +1,18 @@
 {
   "posts": [
     {
+      "key": "DEND3",
+      "title": "Get Dendrite Story Titles",
+      "publicationDate": "2025-07-05",
+      "content": ["Returns DEND2 story titles from temporary storage."],
+      "toy": {
+        "modulePath": "/2025-07-05/getDend2Titles.js",
+        "functionName": "getDend2Titles"
+      },
+      "release": "beta",
+      "tags": ["toy", "story", "dendrite"]
+    },
+    {
       "key": "DEND2",
       "title": "Transform Dendrite Story",
       "publicationDate": "2025-07-04",
@@ -128,7 +140,14 @@
         "fileType": "png",
         "altText": "abstract color-field painting with a soft gradient gray area on the left blending into an intense solid red block on the right, the two hues meeting in a hazy vertical transition"
       },
-      "tags": ["philosophy", "colour", "experience", "consciousness", "qualia", "physicalism"],
+      "tags": [
+        "philosophy",
+        "colour",
+        "experience",
+        "consciousness",
+        "qualia",
+        "physicalism"
+      ],
       "relatedLinks": [
         {
           "url": "#SYMP1",

--- a/src/toys/2025-07-05/getDend2Titles.js
+++ b/src/toys/2025-07-05/getDend2Titles.js
@@ -1,0 +1,25 @@
+// Toy: Get DEND2 Story Titles
+// (input, env) -> string
+
+/**
+ * Gather all DEND2 story titles from temporary storage.
+ * @param {*} input - Unused value.
+ * @param {Map<string, Function>} env - Environment with a `getData` accessor.
+ * @returns {string} JSON array string of story titles.
+ */
+export function getDend2Titles(input, env) {
+  try {
+    const getData = env.get('getData');
+    const data = getData();
+    const stories = data?.temporary?.DEND2?.stories;
+    if (!Array.isArray(stories)) {
+      return JSON.stringify([]);
+    }
+    const titles = stories
+      .map(story => story?.title)
+      .filter(title => typeof title === 'string');
+    return JSON.stringify(titles);
+  } catch {
+    return JSON.stringify([]);
+  }
+}

--- a/test/toys/2025-07-05/getDend2Titles.test.js
+++ b/test/toys/2025-07-05/getDend2Titles.test.js
@@ -1,0 +1,41 @@
+import { getDend2Titles } from '../../../src/toys/2025-07-05/getDend2Titles.js';
+import { describe, test, expect, jest } from '@jest/globals';
+
+describe('getDend2Titles', () => {
+  test('returns titles from DEND2 stories', () => {
+    const env = new Map([
+      [
+        'getData',
+        () => ({
+          temporary: {
+            DEND2: {
+              stories: [
+                { id: '1', title: 'First' },
+                { id: '2', title: 'Second' },
+              ],
+            },
+          },
+        }),
+      ],
+    ]);
+    const result = getDend2Titles('ignored', env);
+    expect(result).toBe(JSON.stringify(['First', 'Second']));
+  });
+
+  test('returns empty array when structure is missing', () => {
+    const env = new Map([['getData', () => ({ temporary: {} })]]);
+    expect(getDend2Titles('x', env)).toBe(JSON.stringify([]));
+  });
+
+  test('returns empty array on error', () => {
+    const env = new Map([
+      [
+        'getData',
+        jest.fn(() => {
+          throw new Error('fail');
+        }),
+      ],
+    ]);
+    expect(getDend2Titles('x', env)).toBe(JSON.stringify([]));
+  });
+});


### PR DESCRIPTION
## Summary
- register the DEND2 titles toy under the 5 July directory
- rename test and module paths to 2025-07-05
- remove illustration from DEND3 post per comment

## Testing
- `npm test`
- `npm run lint` (with warnings)


------
https://chatgpt.com/codex/tasks/task_e_6868d1442b2c832e9c735c3373ddbe91