### PR TITLE
Add build and commit workflow

### DIFF
--- a/.github/workflows/build-and-commit.yml
+++ b/.github/workflows/build-and-commit.yml
@@ -1,0 +1,46 @@
+name: Build and Commit Public
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'package.json'
+      - 'generate.js'
+      - '.github/workflows/build-and-commit.yml'
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build site
+        run: npm run build
+
+      - name: Commit public changes (if any)
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add public/
+          if git diff --cached --quiet; then
+            echo "No changes in public/, skipping commit."
+          else
+            git commit -m "chore: update public output from build"
+            git push
+          fi
+


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds the site when src changes and commits updates to the public directory

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6868ddb628a4832eabc1a0cf4d59b263