### PR TITLE
Fix jsdoc lint warning

### DIFF
--- a/src/toys/2025-07-04/transformDendriteStory.js
+++ b/src/toys/2025-07-04/transformDendriteStory.js
@@ -34,9 +34,10 @@ function isValidInput(obj) {
 }
 
 /**
- *
- * @param data
- * @param getUuid
+ * Create option objects for values present in the input data.
+ * @param {object} data - Source data that may contain option values.
+ * @param {Function} getUuid - Function that generates unique IDs.
+ * @returns {Array<{id: string, content: string}>} Array of option objects.
  */
 function createOptions(data, getUuid) {
   return DENDRITE_OPTION_KEYS.filter(key => data[key]).map(key => ({


### PR DESCRIPTION
## Summary
- document `createOptions` params and return value

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6868df1b77c4832eae6856e8610f5c8f