### PR TITLE
Update build workflow to push with PAT

### DIFF
--- a/.github/workflows/build-and-commit.yml
+++ b/.github/workflows/build-and-commit.yml
@@ -41,6 +41,5 @@ jobs:
             echo "No changes in public/, skipping commit."
           else
             git commit -m "chore: update public output from build"
-            git push
+            git push https://x-access-token:${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/${{ github.repository }} HEAD:main
           fi
-


### PR DESCRIPTION
## Summary
- push build output using `PERSONAL_ACCESS_TOKEN`

## Testing
- `npm test` *(fails: Cannot find module '/workspace/dadeto/node_modules/.bin/jest')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6868e0d631cc832ea0daba9108e63db0