### PR TITLE
Remove ESLint ignore comments

### DIFF
--- a/.windsurf/workflows/characterization-testing.md
+++ b/.windsurf/workflows/characterization-testing.md
@@ -66,7 +66,7 @@ npm test -- path/to/file.test.js
 
 ## Linting
 
-* Temporarily disable unrelated warnings (`// eslint-disable-next-line`)
+* Avoid disabling ESLint warnings
 * Address and document remaining issues later
 
 ## Organization

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ The following Jest features cause issues with Stryker mutation testing and must 
 
 - Follow the guidelines in `CLAUDE.md` for naming and formatting.
 - Use Prettier with the configuration in `.prettierrc`.
+- Never use `eslint-disable` comments. Fix the offending code or allow the warning.
 
 ## Commit Messages
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,3 +18,4 @@
 - **Security**: Always use escapeHtml for user-provided content
 - **Formatting**: Use consistent indentation (2 spaces)
 - **File Structure**: Modular components in separate files
+- **Linting**: Never use `eslint-disable` comments. Resolve warnings instead of suppressing them.

--- a/public/2025-07-04/transformDendriteStory.js
+++ b/public/2025-07-04/transformDendriteStory.js
@@ -30,7 +30,6 @@ function ensureDend2(data) {
  * @param {string} obj.content - Story content.
  * @returns {boolean} True when valid.
  */
-// eslint-disable-next-line complexity
 function isValidInput(obj) {
   if (!obj) {
     return false;

--- a/public/2025-07-05/getDend2Titles.js
+++ b/public/2025-07-05/getDend2Titles.js
@@ -7,7 +7,6 @@
  * @param {Map<string, Function>} env - Environment with a `getData` accessor.
  * @returns {string} JSON array string of story titles.
  */
-// eslint-disable-next-line complexity
 export function getDend2Titles(input, env) {
   const getData = env.get('getData');
   if (typeof getData !== 'function') {

--- a/src/toys/2025-07-04/transformDendriteStory.js
+++ b/src/toys/2025-07-04/transformDendriteStory.js
@@ -30,7 +30,6 @@ function ensureDend2(data) {
  * @param {string} obj.content - Story content.
  * @returns {boolean} True when valid.
  */
-// eslint-disable-next-line complexity
 function isValidInput(obj) {
   if (!obj) {
     return false;

--- a/src/toys/2025-07-05/getDend2Titles.js
+++ b/src/toys/2025-07-05/getDend2Titles.js
@@ -7,7 +7,6 @@
  * @param {Map<string, Function>} env - Environment with a `getData` accessor.
  * @returns {string} JSON array string of story titles.
  */
-// eslint-disable-next-line complexity
 export function getDend2Titles(input, env) {
   const getData = env.get('getData');
   if (typeof getData !== 'function') {


### PR DESCRIPTION
## Summary
- ban `eslint-disable` comments in instructions
- clean up docs to avoid recommending disable comments
- remove ESLint disable comments from code
- install dependencies so npm scripts run

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6868ff9b9298832e97284557634a8173