### PR TITLE
Rename setData to setLocalTemporaryData

### DIFF
--- a/public/2025-03-30/cyberpunkAdventure.js
+++ b/public/2025-03-30/cyberpunkAdventure.js
@@ -327,7 +327,7 @@ function runAdventure(input, env) {
   const getRandomNumber = env.get('getRandomNumber');
   const getCurrentTime = env.get('getCurrentTime');
   const getData = env.get('getData');
-  const setTemporaryData = env.get('setData');
+  const setTemporaryData = env.get('setLocalTemporaryData');
   const scoped = getScopedState(getData());
 
   const name = getPlayerName(scoped, input);

--- a/public/2025-06-09/startLocalDendriteStory.js
+++ b/public/2025-06-09/startLocalDendriteStory.js
@@ -45,7 +45,7 @@ export function startLocalDendriteStory(input, env) {
     const data = JSON.parse(input);
     const getUuid = env.get('getUuid');
     const getData = env.get('getData');
-    const setData = env.get('setData');
+    const setLocalTemporaryData = env.get('setLocalTemporaryData');
 
     const result = {
       id: getUuid(),
@@ -58,7 +58,7 @@ export function startLocalDendriteStory(input, env) {
     const newData = deepClone(currentData);
     ensureTemporaryData(newData);
     newData.temporary.DEND1.push(result);
-    setData(newData);
+    setLocalTemporaryData(newData);
 
     return JSON.stringify(result);
   } catch {

--- a/public/2025-07-04/transformDendriteStory.js
+++ b/public/2025-07-04/transformDendriteStory.js
@@ -53,7 +53,7 @@ function createOptions(data, getUuid) {
 /**
  * Transform and store a Dendrite story submission.
  * @param {string} input - JSON string of a Dendrite story submission.
- * @param {Map<string, Function>} env - Environment providing getData/setData.
+ * @param {Map<string, Function>} env - Environment providing getData/setLocalTemporaryData.
  * @returns {string} JSON string of the new objects.
  */
 export function transformDendriteStory(input, env) {
@@ -65,7 +65,7 @@ export function transformDendriteStory(input, env) {
 
     const getUuid = env.get('getUuid');
     const getData = env.get('getData');
-    const setData = env.get('setData');
+    const setLocalTemporaryData = env.get('setLocalTemporaryData');
     const storyId = getUuid();
     const pageId = getUuid();
     const opts = createOptions(parsed, getUuid).map(o => ({
@@ -81,7 +81,7 @@ export function transformDendriteStory(input, env) {
     newData.temporary.DEND2.stories.push(story);
     newData.temporary.DEND2.pages.push(page);
     newData.temporary.DEND2.options.push(...opts);
-    setData(newData);
+    setLocalTemporaryData(newData);
 
     return JSON.stringify({ stories: [story], pages: [page], options: opts });
   } catch {

--- a/public/2025-07-05/addDendritePage.js
+++ b/public/2025-07-05/addDendritePage.js
@@ -70,7 +70,7 @@ export function addDendritePage(input, env) {
 
     const getUuid = env.get('getUuid');
     const getData = env.get('getData');
-    const setData = env.get('setData');
+    const setLocalTemporaryData = env.get('setLocalTemporaryData');
     const pageId = getUuid();
     const opts = createOptions(parsed, pageId, getUuid);
     const page = {
@@ -84,7 +84,7 @@ export function addDendritePage(input, env) {
     ensureDend2(newData);
     newData.temporary.DEND2.pages.push(page);
     newData.temporary.DEND2.options.push(...opts);
-    setData(newData);
+    setLocalTemporaryData(newData);
 
     return JSON.stringify({ pages: [page], options: opts });
   } catch {

--- a/public/browser/createSectionSetter.js
+++ b/public/browser/createSectionSetter.js
@@ -78,13 +78,13 @@ function ensureSectionObject(data, section) {
  */
 function mergeSection(section, inputJson, env) {
   const getData = env.get('getData');
-  const setData = env.get('setData');
+  const setLocalTemporaryData = env.get('setLocalTemporaryData');
   try {
     const currentData = getData();
     const newData = deepClone(currentData);
     ensureSectionObject(newData, section);
     newData[section] = deepMerge(newData[section], inputJson);
-    setData(newData);
+    setLocalTemporaryData(newData);
     const sectionName = section.charAt(0).toUpperCase() + section.slice(1);
     return `Success: ${sectionName} data deep merged.`;
   } catch (error) {

--- a/public/browser/data.js
+++ b/public/browser/data.js
@@ -236,9 +236,9 @@ function isInvalidState(value) {
  */
 function validateIncomingState(incomingState, errorFn) {
   if (isInvalidState(incomingState)) {
-    errorFn('setData received invalid data structure:', incomingState);
+    errorFn('setLocalTemporaryData received invalid data structure:', incomingState);
     throw new Error(
-      "setData requires an object with at least a 'temporary' property."
+      "setLocalTemporaryData requires an object with at least a 'temporary' property."
     );
   }
 }
@@ -334,7 +334,7 @@ export const getData = (state, fetch, loggers) => {
  * @param {Function} loggers.logInfo - Information logger.
  * @param {Function} loggers.logError - Error logger.
  */
-export const setData = (state, loggers) => {
+export const setLocalTemporaryData = (state, loggers) => {
   const { desired, current } = state;
   const { logError } = loggers;
   // Validate incoming state

--- a/public/browser/main.js
+++ b/public/browser/main.js
@@ -3,7 +3,7 @@ import { handleTagLinks } from './tags.js';
 import {
   fetchAndCacheBlogData,
   getData,
-  setData,
+  setLocalTemporaryData,
   getEncodeBase64,
 } from './data.js';
 import {
@@ -60,8 +60,9 @@ function createEnv() {
     ['getUuid', getUuid],
     ['getData', () => getData(globalState, fetch, loggers)],
     [
-      'setData',
-      newData => setData({ desired: newData, current: globalState }, loggers),
+      'setLocalTemporaryData',
+      newData =>
+        setLocalTemporaryData({ desired: newData, current: globalState }, loggers),
     ],
     ['encodeBase64', getEncodeBase64(btoa, encodeURIComponent)],
   ]);

--- a/src/browser/createSectionSetter.js
+++ b/src/browser/createSectionSetter.js
@@ -78,13 +78,13 @@ function ensureSectionObject(data, section) {
  */
 function mergeSection(section, inputJson, env) {
   const getData = env.get('getData');
-  const setData = env.get('setData');
+  const setLocalTemporaryData = env.get('setLocalTemporaryData');
   try {
     const currentData = getData();
     const newData = deepClone(currentData);
     ensureSectionObject(newData, section);
     newData[section] = deepMerge(newData[section], inputJson);
-    setData(newData);
+    setLocalTemporaryData(newData);
     const sectionName = section.charAt(0).toUpperCase() + section.slice(1);
     return `Success: ${sectionName} data deep merged.`;
   } catch (error) {

--- a/src/browser/data.js
+++ b/src/browser/data.js
@@ -236,9 +236,12 @@ function isInvalidState(value) {
  */
 function validateIncomingState(incomingState, errorFn) {
   if (isInvalidState(incomingState)) {
-    errorFn('setData received invalid data structure:', incomingState);
+    errorFn(
+      'setLocalTemporaryData received invalid data structure:',
+      incomingState
+    );
     throw new Error(
-      "setData requires an object with at least a 'temporary' property."
+      "setLocalTemporaryData requires an object with at least a 'temporary' property."
     );
   }
 }
@@ -334,7 +337,7 @@ export const getData = (state, fetch, loggers) => {
  * @param {Function} loggers.logInfo - Information logger.
  * @param {Function} loggers.logError - Error logger.
  */
-export const setData = (state, loggers) => {
+export const setLocalTemporaryData = (state, loggers) => {
   const { desired, current } = state;
   const { logError } = loggers;
   // Validate incoming state

--- a/src/browser/main.js
+++ b/src/browser/main.js
@@ -3,7 +3,7 @@ import { handleTagLinks } from './tags.js';
 import {
   fetchAndCacheBlogData,
   getData,
-  setData,
+  setLocalTemporaryData,
   getEncodeBase64,
 } from './data.js';
 import {
@@ -60,8 +60,12 @@ function createEnv() {
     ['getUuid', getUuid],
     ['getData', () => getData(globalState, fetch, loggers)],
     [
-      'setData',
-      newData => setData({ desired: newData, current: globalState }, loggers),
+      'setLocalTemporaryData',
+      newData =>
+        setLocalTemporaryData(
+          { desired: newData, current: globalState },
+          loggers
+        ),
     ],
     ['encodeBase64', getEncodeBase64(btoa, encodeURIComponent)],
   ]);

--- a/src/toys/2025-03-30/cyberpunkAdventure.js
+++ b/src/toys/2025-03-30/cyberpunkAdventure.js
@@ -327,7 +327,7 @@ function runAdventure(input, env) {
   const getRandomNumber = env.get('getRandomNumber');
   const getCurrentTime = env.get('getCurrentTime');
   const getData = env.get('getData');
-  const setTemporaryData = env.get('setData');
+  const setTemporaryData = env.get('setLocalTemporaryData');
   const scoped = getScopedState(getData());
 
   const name = getPlayerName(scoped, input);

--- a/src/toys/2025-06-09/startLocalDendriteStory.js
+++ b/src/toys/2025-06-09/startLocalDendriteStory.js
@@ -45,7 +45,7 @@ export function startLocalDendriteStory(input, env) {
     const data = JSON.parse(input);
     const getUuid = env.get('getUuid');
     const getData = env.get('getData');
-    const setData = env.get('setData');
+    const setLocalTemporaryData = env.get('setLocalTemporaryData');
 
     const result = {
       id: getUuid(),
@@ -58,7 +58,7 @@ export function startLocalDendriteStory(input, env) {
     const newData = deepClone(currentData);
     ensureTemporaryData(newData);
     newData.temporary.DEND1.push(result);
-    setData(newData);
+    setLocalTemporaryData(newData);
 
     return JSON.stringify(result);
   } catch {

--- a/src/toys/2025-07-04/transformDendriteStory.js
+++ b/src/toys/2025-07-04/transformDendriteStory.js
@@ -53,7 +53,7 @@ function createOptions(data, getUuid) {
 /**
  * Transform and store a Dendrite story submission.
  * @param {string} input - JSON string of a Dendrite story submission.
- * @param {Map<string, Function>} env - Environment providing getData/setData.
+ * @param {Map<string, Function>} env - Environment providing getData/setLocalTemporaryData.
  * @returns {string} JSON string of the new objects.
  */
 export function transformDendriteStory(input, env) {
@@ -65,7 +65,7 @@ export function transformDendriteStory(input, env) {
 
     const getUuid = env.get('getUuid');
     const getData = env.get('getData');
-    const setData = env.get('setData');
+    const setLocalTemporaryData = env.get('setLocalTemporaryData');
     const storyId = getUuid();
     const pageId = getUuid();
     const opts = createOptions(parsed, getUuid).map(o => ({
@@ -81,7 +81,7 @@ export function transformDendriteStory(input, env) {
     newData.temporary.DEND2.stories.push(story);
     newData.temporary.DEND2.pages.push(page);
     newData.temporary.DEND2.options.push(...opts);
-    setData(newData);
+    setLocalTemporaryData(newData);
 
     return JSON.stringify({ stories: [story], pages: [page], options: opts });
   } catch {

--- a/src/toys/2025-07-05/addDendritePage.js
+++ b/src/toys/2025-07-05/addDendritePage.js
@@ -70,7 +70,7 @@ export function addDendritePage(input, env) {
 
     const getUuid = env.get('getUuid');
     const getData = env.get('getData');
-    const setData = env.get('setData');
+    const setLocalTemporaryData = env.get('setLocalTemporaryData');
     const pageId = getUuid();
     const opts = createOptions(parsed, pageId, getUuid);
     const page = {
@@ -84,7 +84,7 @@ export function addDendritePage(input, env) {
     ensureDend2(newData);
     newData.temporary.DEND2.pages.push(page);
     newData.temporary.DEND2.options.push(...opts);
-    setData(newData);
+    setLocalTemporaryData(newData);
 
     return JSON.stringify({ pages: [page], options: opts });
   } catch {

--- a/test/browser/createHandleSubmit.string.test.js
+++ b/test/browser/createHandleSubmit.string.test.js
@@ -17,7 +17,7 @@ describe('createHandleSubmit string representation', () => {
         () =>
           new Map([
             ['getData', jest.fn()],
-            ['setData', jest.fn()],
+            ['setLocalTemporaryData', jest.fn()],
           ])
       ),
       errorFn: jest.fn(),

--- a/test/browser/data.restoreBlogState.test.js
+++ b/test/browser/data.restoreBlogState.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect, jest } from '@jest/globals';
-import { setData } from '../../src/browser/data.js';
+import { setLocalTemporaryData as setData } from '../../src/browser/data.js';
 
-describe('restoreBlogState via setData', () => {
+describe('restoreBlogState via setLocalTemporaryData', () => {
   it('restores blog fetch fields when incoming state provides them', () => {
     const oldError = new Error('old');
     const oldPromise = Promise.resolve('old');

--- a/test/browser/data.test.js
+++ b/test/browser/data.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 import {
   fetchAndCacheBlogData,
   getData,
-  setData,
+  setLocalTemporaryData as setData,
   getDeepStateCopy,
   shouldUseExistingFetch,
   deepMerge,
@@ -380,10 +380,10 @@ describe('getData, setData, and getDeepStateCopy', () => {
         { logInfo: logFn, logError: errorFn }
       )
     ).toThrow(
-      "setData requires an object with at least a 'temporary' property."
+      "setLocalTemporaryData requires an object with at least a 'temporary' property."
     );
     expect(errorFn).toHaveBeenCalledWith(
-      'setData received invalid data structure:',
+      'setLocalTemporaryData received invalid data structure:',
       {}
     );
   });
@@ -395,7 +395,7 @@ describe('getData, setData, and getDeepStateCopy', () => {
         { logInfo: logFn, logError: errorFn }
       )
     ).toThrow(
-      "setData requires an object with at least a 'temporary' property."
+      "setLocalTemporaryData requires an object with at least a 'temporary' property."
     );
   });
 
@@ -411,7 +411,7 @@ describe('getData, setData, and getDeepStateCopy', () => {
       )
     ).toThrow();
     expect(errorFn).toHaveBeenCalledWith(
-      'setData received invalid data structure:',
+      'setLocalTemporaryData received invalid data structure:',
       invalidState
     );
   });
@@ -427,7 +427,7 @@ describe('getData, setData, and getDeepStateCopy', () => {
         { logInfo: logFn, logError: errorFn }
       )
     ).toThrow(
-      "setData requires an object with at least a 'temporary' property."
+      "setLocalTemporaryData requires an object with at least a 'temporary' property."
     );
   });
 
@@ -442,7 +442,7 @@ describe('getData, setData, and getDeepStateCopy', () => {
       )
     ).toThrow();
     expect(errorFn).toHaveBeenCalledWith(
-      'setData received invalid data structure:',
+      'setLocalTemporaryData received invalid data structure:',
       null
     );
   });
@@ -458,7 +458,7 @@ describe('getData, setData, and getDeepStateCopy', () => {
       )
     ).toThrow();
     expect(errorFn).toHaveBeenCalledWith(
-      'setData received invalid data structure:',
+      'setLocalTemporaryData received invalid data structure:',
       undefined
     );
   });
@@ -475,7 +475,7 @@ describe('getData, setData, and getDeepStateCopy', () => {
       )
     ).toThrow();
     expect(errorFn).toHaveBeenCalledWith(
-      'setData received invalid data structure:',
+      'setLocalTemporaryData received invalid data structure:',
       invalidState
     );
   });

--- a/test/browser/processInputAndSetOutput.handleParsedArg.test.js
+++ b/test/browser/processInputAndSetOutput.handleParsedArg.test.js
@@ -11,7 +11,7 @@ describe('processInputAndSetOutput parsed arg', () => {
     };
     const toyEnv = new Map([
       ['getData', () => ({ output: {} })],
-      ['setData', () => {}],
+      ['setLocalTemporaryData', () => {}],
     ]);
     const env = {
       createEnv: () => toyEnv,

--- a/test/browser/processInputAndSetOutput.invalidJson.test.js
+++ b/test/browser/processInputAndSetOutput.invalidJson.test.js
@@ -12,7 +12,7 @@ describe('processInputAndSetOutput invalid JSON handling', () => {
 
     const toyEnv = new Map([
       ['getData', () => ({})],
-      ['setData', jest.fn()],
+      ['setLocalTemporaryData', jest.fn()],
     ]);
 
     const dom = {

--- a/test/browser/processInputAndSetOutput.setOutput.test.js
+++ b/test/browser/processInputAndSetOutput.setOutput.test.js
@@ -16,7 +16,7 @@ describe('processInputAndSetOutput integration', () => {
     };
     toyEnv = new Map([
       ['getData', () => ({ output: {} })],
-      ['setData', jest.fn()],
+      ['setLocalTemporaryData', jest.fn()],
     ]);
     env = {
       createEnv: jest.fn(() => toyEnv),
@@ -41,7 +41,7 @@ describe('processInputAndSetOutput integration', () => {
 
   it('stores result with article id key via setOutput', () => {
     processInputAndSetOutput(elements, processingFunction, env);
-    const callArg = toyEnv.get('setData').mock.calls[0][0];
+    const callArg = toyEnv.get('setLocalTemporaryData').mock.calls[0][0];
     expect(callArg.output).toEqual({ [elements.article.id]: 'result' });
   });
 });

--- a/test/browser/processInputAndSetOutput.test.js
+++ b/test/browser/processInputAndSetOutput.test.js
@@ -22,7 +22,7 @@ beforeEach(() => {
   };
   toyEnv = new Map([
     ['getData', () => ({ output: {} })],
-    ['setData', jest.fn()],
+    ['setLocalTemporaryData', jest.fn()],
   ]);
   env = {
     createEnv: jest.fn(() => toyEnv),
@@ -96,7 +96,7 @@ describe('processInputAndSetOutput', () => {
 
     processInputAndSetOutput(elements, processingFunction, env);
 
-    const setData = toyEnv.get('setData');
+    const setData = toyEnv.get('setLocalTemporaryData');
     const callArg = setData.mock.calls[0][0];
     expect(callArg.output).toEqual({ [elements.article.id]: result });
   });

--- a/test/browser/setOutput.test.js
+++ b/test/browser/setOutput.test.js
@@ -21,7 +21,7 @@ describe('setOutput', () => {
           throw new Error('fail');
         },
       ],
-      ['setData', jest.fn()],
+      ['setLocalTemporaryData', jest.fn()],
     ]);
     const result = setOutput('{"foo": "bar"}', env);
     expect(result).toMatch(/Error updating output data/);
@@ -32,7 +32,7 @@ describe('setOutput', () => {
     const setData = jest.fn();
     const env = new Map([
       ['getData', () => initial],
-      ['setData', setData],
+      ['setLocalTemporaryData', setData],
     ]);
     const input = '{"b":2}';
     const result = setOutput(input, env);
@@ -47,7 +47,7 @@ describe('setOutput', () => {
     const setData = jest.fn();
     const env = new Map([
       ['getData', () => initial],
-      ['setData', setData],
+      ['setLocalTemporaryData', setData],
     ]);
     const input = '{"b":2}';
     const result = setOutput(input, env);
@@ -57,12 +57,12 @@ describe('setOutput', () => {
     expect(callArg.output).toMatchObject({ b: 2 });
   });
 
-  it('merges output data and calls setData', () => {
+  it('merges output data and calls setLocalTemporaryData', () => {
     const initial = { output: { a: 1 } };
     const setData = jest.fn();
     const env = new Map([
       ['getData', () => initial],
-      ['setData', setData],
+      ['setLocalTemporaryData', setData],
     ]);
     const input = '{"b":2}';
     const result = setOutput(input, env);

--- a/test/browser/toys.createHandleSubmit.test.js
+++ b/test/browser/toys.createHandleSubmit.test.js
@@ -86,7 +86,7 @@ describe('createHandleSubmit', () => {
     };
     const toyEnv = new Map([
       ['getData', () => ({ output: {} })],
-      ['setData', jest.fn()],
+      ['setLocalTemporaryData', jest.fn()],
     ]);
     const env = {
       dom,
@@ -132,7 +132,7 @@ describe('createHandleSubmit', () => {
         () =>
           new Map([
             ['getData', jest.fn()],
-            ['setData', jest.fn()],
+            ['setLocalTemporaryData', jest.fn()],
           ])
       ),
       errorFn: jest.fn(),

--- a/test/toys/2025-03-29/setTemporary.test.js
+++ b/test/toys/2025-03-29/setTemporary.test.js
@@ -17,11 +17,11 @@ describe('setTemporary function (getData -> merge -> setData)', () => {
     mockSetData = jest.fn(); // Mock for setData
     env = new Map([
       ['getData', mockGetData],
-      ['setData', mockSetData], // Add setData mock to env
+      ['setLocalTemporaryData', mockSetData], // Add setData mock to env
     ]);
   });
 
-  test('should call setData with merged JSON when temporary exists', () => {
+  test('should call setLocalTemporaryData with merged JSON when temporary exists', () => {
     // Modify initialData for this test case before freezing (or create a new one)
     initialData = Object.freeze({
       existing: 'value',
@@ -57,7 +57,7 @@ describe('setTemporary function (getData -> merge -> setData)', () => {
     }
   });
 
-  test('should call setData creating temporary if it does not exist', () => {
+  test('should call setLocalTemporaryData creating temporary if it does not exist', () => {
     // initialData already lacks temporary from beforeEach
     const inputJson = JSON.stringify({ firstKey: 123 });
     const expectedFinalData = {
@@ -76,7 +76,7 @@ describe('setTemporary function (getData -> merge -> setData)', () => {
     expect(mockSetData.mock.calls[0][0]).not.toBe(initialData);
   });
 
-  test('should call setData creating temporary if it exists but is not a valid object', () => {
+  test('should call setLocalTemporaryData creating temporary if it exists but is not a valid object', () => {
     initialData = Object.freeze({ existing: 'value', temporary: 'a string' });
     mockGetData.mockReturnValue(initialData);
     const inputJson = JSON.stringify({ key: 'val' });
@@ -120,7 +120,7 @@ describe('setTemporary function (getData -> merge -> setData)', () => {
     expect(mockSetData).toHaveBeenCalledTimes(3);
   });
 
-  test('should return error for invalid JSON input and not call setData', () => {
+  test('should return error for invalid JSON input and not call setLocalTemporaryData', () => {
     const input = 'not json';
     const result = setTemporary(input, env);
     expect(result).toMatch(/^Error: Invalid JSON input./);
@@ -128,7 +128,7 @@ describe('setTemporary function (getData -> merge -> setData)', () => {
     expect(mockSetData).not.toHaveBeenCalled(); // Verify setData not called
   });
 
-  test('should return error if input JSON is not a plain object and not call setData', () => {
+  test('should return error if input JSON is not a plain object and not call setLocalTemporaryData', () => {
     const input = JSON.stringify([1, 2, 3]); // Array
     expect(setTemporary(input, env)).toBe(
       'Error: Input JSON must be a plain object.'
@@ -137,7 +137,7 @@ describe('setTemporary function (getData -> merge -> setData)', () => {
     expect(mockSetData).not.toHaveBeenCalled();
   });
 
-  test('should return error if getData throws an error and not call setData', () => {
+  test('should return error if getData throws an error and not call setLocalTemporaryData', () => {
     const errorMessage = 'Failed to retrieve data';
     mockGetData.mockImplementation(() => {
       throw new Error(errorMessage);

--- a/test/toys/2025-03-30/cyberpunkAdventure.test.js
+++ b/test/toys/2025-03-30/cyberpunkAdventure.test.js
@@ -12,7 +12,7 @@ describe('Cyberpunk Text Game', () => {
       ['getCurrentTime', () => '23:59'],
       ['getData', () => ({ temporary: { CYBE1: tempData } })],
       [
-        'setData',
+        'setLocalTemporaryData',
         data => {
           tempData = { ...tempData, ...data.temporary?.CYBE1 };
         },

--- a/test/toys/2025-03-30/cyberpunkAdventure.trim.test.js
+++ b/test/toys/2025-03-30/cyberpunkAdventure.trim.test.js
@@ -9,7 +9,7 @@ describe('cyberpunkAdventure input trimming', () => {
       ['getCurrentTime', () => '00:00'],
       ['getData', () => ({ temporary: { CYBE1: tempData } })],
       [
-        'setData',
+        'setLocalTemporaryData',
         data => {
           tempData = { ...tempData, ...data.temporary?.CYBE1 };
         },

--- a/test/toys/2025-06-09/startLocalDendriteStory.branch.test.js
+++ b/test/toys/2025-06-09/startLocalDendriteStory.branch.test.js
@@ -6,7 +6,7 @@ describe('startLocalDendriteStory missing temporary', () => {
     const env = new Map([
       ['getUuid', () => 'id-1'],
       ['getData', () => ({})],
-      ['setData', jest.fn()],
+      ['setLocalTemporaryData', jest.fn()],
     ]);
     const inputObj = { title: 't', content: 'c' };
     const output = JSON.parse(
@@ -14,7 +14,7 @@ describe('startLocalDendriteStory missing temporary', () => {
     );
     const expected = { id: 'id-1', title: 't', content: 'c', options: [] };
     expect(output).toEqual(expected);
-    expect(env.get('setData')).toHaveBeenCalledWith({
+    expect(env.get('setLocalTemporaryData')).toHaveBeenCalledWith({
       temporary: { DEND1: [expected] },
     });
   });
@@ -23,14 +23,14 @@ describe('startLocalDendriteStory missing temporary', () => {
     const env = new Map([
       ['getUuid', () => 'id-2'],
       ['getData', () => ({ temporary: 42 })],
-      ['setData', jest.fn()],
+      ['setLocalTemporaryData', jest.fn()],
     ]);
     const output = JSON.parse(
       startLocalDendriteStory('{"title":"x","content":"y"}', env)
     );
     const expected = { id: 'id-2', title: 'x', content: 'y', options: [] };
     expect(output).toEqual(expected);
-    expect(env.get('setData')).toHaveBeenCalledWith({
+    expect(env.get('setLocalTemporaryData')).toHaveBeenCalledWith({
       temporary: { DEND1: [expected] },
     });
   });

--- a/test/toys/2025-06-09/startLocalDendriteStory.nonArray.test.js
+++ b/test/toys/2025-06-09/startLocalDendriteStory.nonArray.test.js
@@ -5,14 +5,14 @@ test('startLocalDendriteStory replaces non-array DEND1', () => {
   const env = new Map([
     ['getUuid', () => 'id-1'],
     ['getData', () => ({ temporary: { DEND1: 42 } })],
-    ['setData', jest.fn()],
+    ['setLocalTemporaryData', jest.fn()],
   ]);
   const result = JSON.parse(
     startLocalDendriteStory('{"title":"t","content":"c"}', env)
   );
   const expected = { id: 'id-1', title: 't', content: 'c', options: [] };
   expect(result).toEqual(expected);
-  expect(env.get('setData')).toHaveBeenCalledWith({
+  expect(env.get('setLocalTemporaryData')).toHaveBeenCalledWith({
     temporary: { DEND1: [expected] },
   });
 });

--- a/test/toys/2025-06-09/startLocalDendriteStory.test.js
+++ b/test/toys/2025-06-09/startLocalDendriteStory.test.js
@@ -10,7 +10,7 @@ describe('startLocalDendriteStory', () => {
     const env = new Map([
       ['getUuid', () => uuids[idx++]],
       ['getData', mockGetData],
-      ['setData', mockSetData],
+      ['setLocalTemporaryData', mockSetData],
     ]);
     const inputObj = {
       title: 'Question',
@@ -44,7 +44,7 @@ describe('startLocalDendriteStory', () => {
     const env = new Map([
       ['getUuid', () => uuids[idx++]],
       ['getData', () => ({ temporary: { DEND1: [] } })],
-      ['setData', jest.fn()],
+      ['setLocalTemporaryData', jest.fn()],
     ]);
     const inputObj = {
       title: 'Prompt',
@@ -69,7 +69,7 @@ describe('startLocalDendriteStory', () => {
     const env = new Map([
       ['getUuid', () => uuids[idx++]],
       ['getData', () => ({ temporary: { DEND1: [] } })],
-      ['setData', jest.fn()],
+      ['setLocalTemporaryData', jest.fn()],
     ]);
     const inputObj = {
       title: 'Prompt2',
@@ -93,7 +93,7 @@ describe('startLocalDendriteStory', () => {
     const env = new Map([
       ['getUuid', () => uuids[idx++]],
       ['getData', () => ({ temporary: { DEND1: [existing] } })],
-      ['setData', jest.fn()],
+      ['setLocalTemporaryData', jest.fn()],
     ]);
 
     const inputObj = {
@@ -106,7 +106,7 @@ describe('startLocalDendriteStory', () => {
       startLocalDendriteStory(JSON.stringify(inputObj), env)
     );
 
-    expect(env.get('setData')).toHaveBeenCalledWith({
+    expect(env.get('setLocalTemporaryData')).toHaveBeenCalledWith({
       temporary: { DEND1: [existing, output] },
     });
   });
@@ -115,7 +115,7 @@ describe('startLocalDendriteStory', () => {
     const mockSetData = jest.fn();
     const env = new Map([
       ['getData', () => ({})],
-      ['setData', mockSetData],
+      ['setLocalTemporaryData', mockSetData],
     ]);
     const result = startLocalDendriteStory('not-json', env);
     expect(result).toBe(JSON.stringify({}));

--- a/test/toys/2025-07-04/transformDendriteStory.test.js
+++ b/test/toys/2025-07-04/transformDendriteStory.test.js
@@ -12,7 +12,7 @@ describe('transformDendriteStory', () => {
           temporary: { DEND2: { stories: [], pages: [], options: [] } },
         }),
       ],
-      ['setData', jest.fn()],
+      ['setLocalTemporaryData', jest.fn()],
       ['getUuid', () => uuids[idx++]],
     ]);
     const input = JSON.stringify({
@@ -30,7 +30,7 @@ describe('transformDendriteStory', () => {
         { id: 'b', pageId: 'page', content: 'B' },
       ],
     });
-    expect(env.get('setData')).toHaveBeenCalledWith({
+    expect(env.get('setLocalTemporaryData')).toHaveBeenCalledWith({
       temporary: {
         DEND2: {
           stories: [{ id: 'story', title: 'Title' }],
@@ -49,13 +49,13 @@ describe('transformDendriteStory', () => {
     let i = 0;
     const env = new Map([
       ['getData', () => ({})],
-      ['setData', jest.fn()],
+      ['setLocalTemporaryData', jest.fn()],
       ['getUuid', () => uuids[i++]],
     ]);
     const input = JSON.stringify({ title: 't', content: 'c' });
     const result = JSON.parse(transformDendriteStory(input, env));
     expect(result.stories[0]).toEqual({ id: 's', title: 't' });
-    expect(env.get('setData')).toHaveBeenCalledWith({
+    expect(env.get('setLocalTemporaryData')).toHaveBeenCalledWith({
       temporary: {
         DEND2: {
           stories: [{ id: 's', title: 't' }],
@@ -69,11 +69,11 @@ describe('transformDendriteStory', () => {
   test('returns empty arrays on parse error', () => {
     const env = new Map([
       ['getData', () => ({})],
-      ['setData', jest.fn()],
+      ['setLocalTemporaryData', jest.fn()],
     ]);
     const result = transformDendriteStory('not json', env);
     expect(JSON.parse(result)).toEqual({ stories: [], pages: [], options: [] });
-    expect(env.get('setData')).not.toHaveBeenCalled();
+    expect(env.get('setLocalTemporaryData')).not.toHaveBeenCalled();
   });
   test('repairs invalid DEND2 structure', () => {
     const uuids = ['s', 'p'];
@@ -84,12 +84,12 @@ describe('transformDendriteStory', () => {
           temporary: { DEND2: { stories: {}, pages: null, options: 1 } },
         }),
       ],
-      ['setData', jest.fn()],
+      ['setLocalTemporaryData', jest.fn()],
       ['getUuid', () => uuids.shift()],
     ]);
     const input = JSON.stringify({ title: 'title', content: 'body' });
     transformDendriteStory(input, env);
-    expect(env.get('setData')).toHaveBeenCalledWith({
+    expect(env.get('setLocalTemporaryData')).toHaveBeenCalledWith({
       temporary: {
         DEND2: {
           stories: [{ id: 's', title: 'title' }],
@@ -103,34 +103,34 @@ describe('transformDendriteStory', () => {
   test('returns empty arrays for invalid fields', () => {
     const env = new Map([
       ['getData', () => ({})],
-      ['setData', jest.fn()],
+      ['setLocalTemporaryData', jest.fn()],
       ['getUuid', () => 'id'],
     ]);
     const bad = JSON.stringify({ title: 1 });
     const result = transformDendriteStory(bad, env);
     expect(JSON.parse(result)).toEqual({ stories: [], pages: [], options: [] });
-    expect(env.get('setData')).not.toHaveBeenCalled();
+    expect(env.get('setLocalTemporaryData')).not.toHaveBeenCalled();
   });
 
   test('returns empty arrays for null input', () => {
     const env = new Map([
       ['getData', () => ({})],
-      ['setData', jest.fn()],
+      ['setLocalTemporaryData', jest.fn()],
     ]);
     const result = transformDendriteStory('null', env);
     expect(JSON.parse(result)).toEqual({ stories: [], pages: [], options: [] });
-    expect(env.get('setData')).not.toHaveBeenCalled();
+    expect(env.get('setLocalTemporaryData')).not.toHaveBeenCalled();
   });
 
   test('returns empty arrays for invalid content', () => {
     const env = new Map([
       ['getData', () => ({})],
-      ['setData', jest.fn()],
+      ['setLocalTemporaryData', jest.fn()],
       ['getUuid', () => 'id'],
     ]);
     const bad = JSON.stringify({ title: 'ok', content: 1 });
     const result = transformDendriteStory(bad, env);
     expect(JSON.parse(result)).toEqual({ stories: [], pages: [], options: [] });
-    expect(env.get('setData')).not.toHaveBeenCalled();
+    expect(env.get('setLocalTemporaryData')).not.toHaveBeenCalled();
   });
 });

--- a/test/toys/2025-07-05/addDendritePage.test.js
+++ b/test/toys/2025-07-05/addDendritePage.test.js
@@ -12,7 +12,7 @@ describe('addDendritePage', () => {
           temporary: { DEND2: { stories: [], pages: [], options: [] } },
         }),
       ],
-      ['setData', jest.fn()],
+      ['setLocalTemporaryData', jest.fn()],
       ['getUuid', () => uuids[idx++]],
     ]);
     const input = JSON.stringify({
@@ -29,7 +29,7 @@ describe('addDendritePage', () => {
         { id: 'b', pageId: 'page', content: 'B' },
       ],
     });
-    expect(env.get('setData')).toHaveBeenCalledWith({
+    expect(env.get('setLocalTemporaryData')).toHaveBeenCalledWith({
       temporary: {
         DEND2: {
           stories: [],
@@ -48,13 +48,13 @@ describe('addDendritePage', () => {
     let i = 0;
     const env = new Map([
       ['getData', () => ({})],
-      ['setData', jest.fn()],
+      ['setLocalTemporaryData', jest.fn()],
       ['getUuid', () => uuids[i++]],
     ]);
     const input = JSON.stringify({ optionId: 'o', content: 'c' });
     const result = JSON.parse(addDendritePage(input, env));
     expect(result.pages[0]).toEqual({ id: 'p', optionId: 'o', content: 'c' });
-    expect(env.get('setData')).toHaveBeenCalledWith({
+    expect(env.get('setLocalTemporaryData')).toHaveBeenCalledWith({
       temporary: {
         DEND2: {
           stories: [],
@@ -74,12 +74,12 @@ describe('addDendritePage', () => {
           temporary: { DEND2: { stories: {}, pages: null, options: 1 } },
         }),
       ],
-      ['setData', jest.fn()],
+      ['setLocalTemporaryData', jest.fn()],
       ['getUuid', () => uuids.shift()],
     ]);
     const input = JSON.stringify({ optionId: 'o', content: 'c' });
     addDendritePage(input, env);
-    expect(env.get('setData')).toHaveBeenCalledWith({
+    expect(env.get('setLocalTemporaryData')).toHaveBeenCalledWith({
       temporary: {
         DEND2: {
           stories: [],
@@ -93,44 +93,44 @@ describe('addDendritePage', () => {
   test('returns empty arrays on parse error', () => {
     const env = new Map([
       ['getData', () => ({})],
-      ['setData', jest.fn()],
+      ['setLocalTemporaryData', jest.fn()],
     ]);
     const result = addDendritePage('not json', env);
     expect(JSON.parse(result)).toEqual({ pages: [], options: [] });
-    expect(env.get('setData')).not.toHaveBeenCalled();
+    expect(env.get('setLocalTemporaryData')).not.toHaveBeenCalled();
   });
 
   test('returns empty arrays for invalid fields', () => {
     const env = new Map([
       ['getData', () => ({})],
-      ['setData', jest.fn()],
+      ['setLocalTemporaryData', jest.fn()],
       ['getUuid', () => 'id'],
     ]);
     const bad = JSON.stringify({ optionId: 1 });
     const result = addDendritePage(bad, env);
     expect(JSON.parse(result)).toEqual({ pages: [], options: [] });
-    expect(env.get('setData')).not.toHaveBeenCalled();
+    expect(env.get('setLocalTemporaryData')).not.toHaveBeenCalled();
   });
 
   test('returns empty arrays for null input', () => {
     const env = new Map([
       ['getData', () => ({})],
-      ['setData', jest.fn()],
+      ['setLocalTemporaryData', jest.fn()],
     ]);
     const result = addDendritePage('null', env);
     expect(JSON.parse(result)).toEqual({ pages: [], options: [] });
-    expect(env.get('setData')).not.toHaveBeenCalled();
+    expect(env.get('setLocalTemporaryData')).not.toHaveBeenCalled();
   });
 
   test('returns empty arrays for invalid content', () => {
     const env = new Map([
       ['getData', () => ({})],
-      ['setData', jest.fn()],
+      ['setLocalTemporaryData', jest.fn()],
       ['getUuid', () => 'id'],
     ]);
     const bad = JSON.stringify({ optionId: 'o', content: 1 });
     const result = addDendritePage(bad, env);
     expect(JSON.parse(result)).toEqual({ pages: [], options: [] });
-    expect(env.get('setData')).not.toHaveBeenCalled();
+    expect(env.get('setLocalTemporaryData')).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- rename `setData` to `setLocalTemporaryData`
- update environment map and toys
- regenerate public build and adjust tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68691b698488832eab2f72d27958d708