### PR TITLE
Remove input listener duplication

### DIFF
--- a/src/browser/document.js
+++ b/src/browser/document.js
@@ -195,6 +195,20 @@ export const removeEventListener = (target, event, handler) => {
 };
 
 /**
+ * Generates a disposer that removes an event listener.
+ * @param {object} options - Parameters for the remover.
+ * @param {object} options.dom - DOM helper utilities.
+ * @param {EventTarget} options.el - The element to detach from.
+ * @param {string} options.event - The event type to remove.
+ * @param {Function} options.handler - The handler to detach.
+ * @returns {Function} Disposer function removing the listener.
+ */
+export const createRemoveListener =
+  ({ dom, el, event, handler }) =>
+  () =>
+    dom.removeEventListener(el, event, handler);
+
+/**
  * Determines if the current URL contains the `beta` query parameter
  * @returns {boolean} True when the page URL includes `?beta`
  */
@@ -280,6 +294,7 @@ export const dom = {
   addClass,
   removeClass,
   removeEventListener,
+  createRemoveListener,
   appendChild,
   createTextNode,
   getElementsByTagName,

--- a/src/browser/toys.js
+++ b/src/browser/toys.js
@@ -1,5 +1,5 @@
 import { createParagraphElement } from '../presenters/paragraph.js';
-import { createPrefixedLoggers } from './document.js';
+import { createPrefixedLoggers, createRemoveListener } from './document.js';
 import { parseJsonOrDefault } from '../utils/jsonUtils.js';
 import { deepClone } from '../utils/objectUtils.js';
 
@@ -709,7 +709,12 @@ export const createValueElement = ({
     syncHiddenField,
   });
   dom.addEventListener(valueEl, 'input', onValue);
-  const removeValueListener = createRemoveValueListener(dom, valueEl, onValue);
+  const removeValueListener = createRemoveListener({
+    dom,
+    el: valueEl,
+    event: 'input',
+    handler: onValue,
+  });
   disposers.push(removeValueListener);
 
   return valueEl;
@@ -888,16 +893,6 @@ const createButton = ({ dom, isAddButton, rows, render, key, disposers }) => {
  */
 const createRemoveRemoveListener = (dom, btnEl, onRemove) => () =>
   dom.removeEventListener(btnEl, 'click', onRemove);
-
-/**
- * Creates a function that removes an event listener for value input
- * @param {object} dom - The DOM utilities object
- * @param {HTMLElement} el - The element to remove the listener from
- * @param {Function} handler - The event handler function to remove
- * @returns {Function} A function that removes the event listener
- */
-const createRemoveValueListener = (dom, el, handler) => () =>
-  dom.removeEventListener(el, 'input', handler);
 
 /**
  * Creates a function that removes an event listener for add button clicks

--- a/src/inputHandlers/number.js
+++ b/src/inputHandlers/number.js
@@ -1,9 +1,7 @@
 import { maybeRemoveKV, maybeRemoveDendrite } from './removeElements.js';
 import { NUMBER_INPUT_SELECTOR } from '../constants/selectors.js';
 import { hideAndDisable } from './inputState.js';
-
-const createRemoveValueListener = (dom, el, handler) => () =>
-  dom.removeEventListener(el, 'input', handler);
+import { createRemoveListener } from '../browser/document.js';
 
 const createBaseNumberInput = dom => {
   const input = dom.createElement('input');
@@ -13,7 +11,12 @@ const createBaseNumberInput = dom => {
 
 const setupInputEvents = (input, onChange, dom) => {
   dom.addEventListener(input, 'input', onChange);
-  input._dispose = createRemoveValueListener(dom, input, onChange);
+  input._dispose = createRemoveListener({
+    dom,
+    el: input,
+    event: 'input',
+    handler: onChange,
+  });
 };
 
 export const createNumberInput = (value, onChange, dom) => {


### PR DESCRIPTION
## Summary
- add a generic `createRemoveListener` helper for detaching events
- use the new helper when disposing number input listeners
- reuse the helper in `createValueElement`
- refactor helper to accept an options object

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686925981218832e87e03872002271c5