### PR TITLE
Add setLocalPermanentData env function

### DIFF
--- a/src/browser/main.js
+++ b/src/browser/main.js
@@ -4,6 +4,7 @@ import {
   fetchAndCacheBlogData,
   getData,
   setLocalTemporaryData,
+  setLocalPermanentData,
   getEncodeBase64,
 } from './data.js';
 import {
@@ -66,6 +67,10 @@ function createEnv() {
           { desired: newData, current: globalState },
           loggers
         ),
+    ],
+    [
+      'setLocalPermanentData',
+      newData => setLocalPermanentData(newData, loggers, localStorage),
     ],
     ['encodeBase64', getEncodeBase64(btoa, encodeURIComponent)],
   ]);

--- a/test/browser/setLocalPermanentData.test.js
+++ b/test/browser/setLocalPermanentData.test.js
@@ -1,0 +1,30 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { setLocalPermanentData } from '../../src/browser/data.js';
+
+describe('setLocalPermanentData', () => {
+  it('merges with stored data and persists', () => {
+    const storage = { getItem: jest.fn(), setItem: jest.fn() };
+    storage.getItem.mockReturnValueOnce(JSON.stringify({ existing: true }));
+    const logError = jest.fn();
+    const incoming = { permanent: { foo: 'bar' } };
+    const result = setLocalPermanentData(incoming, { logError }, storage);
+    expect(result).toEqual({ existing: true, foo: 'bar' });
+    expect(storage.setItem).toHaveBeenCalledWith(
+      'permanentData',
+      JSON.stringify({ existing: true, foo: 'bar' })
+    );
+  });
+
+  it('throws and logs when state is invalid', () => {
+    const storage = { getItem: jest.fn(), setItem: jest.fn() };
+    const logError = jest.fn();
+    expect(() => setLocalPermanentData({}, { logError }, storage)).toThrow(
+      "setLocalPermanentData requires an object with at least a 'permanent' property."
+    );
+    expect(logError).toHaveBeenCalledWith(
+      'setLocalPermanentData received invalid data structure:',
+      {}
+    );
+    expect(storage.setItem).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- support permanent local storage
- expose `setLocalPermanentData` through the browser environment
- test new behavior
- persist permanent data to localStorage
- inject localStorage into permanent state setter
- adjust test to stub out localStorage instead of using the global

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686924e60e38832e86d6c8a2bf79f29b