### PR TITLE
Add permanent data toy

### DIFF
--- a/src/blog.json
+++ b/src/blog.json
@@ -10,6 +10,18 @@
         "functionName": "addDendritePage"
       },
       "tags": ["toy", "story", "dendrite"],
+    "release": "beta"
+  },
+    {
+      "key": "PERM2",
+      "title": "Set Permanent Data",
+      "publicationDate": "2025-07-05",
+      "content": ["Stores input into permanent storage."],
+      "toy": {
+        "modulePath": "/2025-07-05/setPermanentData.js",
+        "functionName": "setPermanentData"
+      },
+      "tags": ["toy"],
       "release": "beta"
     },
     {

--- a/src/toys/2025-07-05/setPermanentData.js
+++ b/src/toys/2025-07-05/setPermanentData.js
@@ -1,0 +1,19 @@
+// Toy: Set Permanent Data
+// (string input, env) -> string
+
+/**
+ * Store permanent data using the environment helper.
+ * @param {string} input - JSON string describing the permanent data.
+ * @param {Map<string, Function>} env - Environment with `setLocalPermanentData`.
+ * @returns {string} JSON string of the updated permanent data or '{}'.
+ */
+export function setPermanentData(input, env) {
+  try {
+    const obj = JSON.parse(input);
+    const setLocalPermanentData = env.get('setLocalPermanentData');
+    const result = setLocalPermanentData(obj);
+    return JSON.stringify(result);
+  } catch {
+    return JSON.stringify({});
+  }
+}

--- a/test/toys/2025-07-05/setPermanentData.test.js
+++ b/test/toys/2025-07-05/setPermanentData.test.js
@@ -1,0 +1,21 @@
+import { setPermanentData } from '../../../src/toys/2025-07-05/setPermanentData.js';
+import { describe, test, expect, jest } from '@jest/globals';
+
+describe('setPermanentData', () => {
+  test('passes parsed object to env and returns the result', () => {
+    const mock = jest.fn(obj => ({ ...obj.permanent, ok: true }));
+    const env = new Map([['setLocalPermanentData', mock]]);
+    const input = JSON.stringify({ permanent: { foo: 'bar' } });
+    const result = JSON.parse(setPermanentData(input, env));
+    expect(result).toEqual({ foo: 'bar', ok: true });
+    expect(mock).toHaveBeenCalledWith({ permanent: { foo: 'bar' } });
+  });
+
+  test('returns empty object on parse failure', () => {
+    const mock = jest.fn();
+    const env = new Map([['setLocalPermanentData', mock]]);
+    const output = setPermanentData('not json', env);
+    expect(output).toBe(JSON.stringify({}));
+    expect(mock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- create a simple toy to forward JSON to `setLocalPermanentData`
- cover new toy with tests
- configure the toy in `blog.json` as beta

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686930d9b55c832eb70579a90d5ad3b8