### PR TITLE
relax permanent data validation

### DIFF
--- a/public/browser/data.js
+++ b/public/browser/data.js
@@ -247,21 +247,12 @@ function validateIncomingState(incomingState, errorFn) {
 }
 
 /**
- * Determine if an object includes its own `permanent` property.
- * @param {object} obj - Object to inspect.
- * @returns {boolean} True when the property exists.
- */
-function hasPermanentProperty(obj) {
-  return Object.hasOwn(obj, 'permanent');
-}
-
-/**
- * Determine whether a permanent state object has required properties.
+ * Determine whether a permanent state object is invalid.
  * @param {object} value - Candidate state object.
- * @returns {boolean} True if the state is missing required fields.
+ * @returns {boolean} True when the value is not a non-null object.
  */
 function isInvalidPermanentState(value) {
-  return !isNonNullObject(value) || !hasPermanentProperty(value);
+  return !isNonNullObject(value);
 }
 
 /**
@@ -276,9 +267,7 @@ function validateIncomingPermanentState(incomingState, errorFn) {
       'setLocalPermanentData received invalid data structure:',
       incomingState
     );
-    throw new Error(
-      "setLocalPermanentData requires an object with at least a 'permanent' property."
-    );
+    throw new Error('setLocalPermanentData requires an object.');
   }
 }
 
@@ -386,10 +375,10 @@ export const setLocalTemporaryData = (state, loggers) => {
 /**
  * Updates persistent data stored in localStorage.
  * Reads existing data, merges with the incoming object and persists the result.
- * @param {object} desired - The new state object (must have 'permanent').
+ * @param {object} desired - The new state object.
  * @param {object} loggers - Logging functions.
  * @param {Function} loggers.logError - Error logger.
- * @param storage
+ * @param {Storage} [storage] - Storage used to persist data.
  * @returns {object} The merged permanent state.
  */
 export const setLocalPermanentData = (desired, loggers, storage) => {
@@ -406,7 +395,7 @@ export const setLocalPermanentData = (desired, loggers, storage) => {
     logError('Failed to read permanent data:', readError);
   }
 
-  const updated = { ...storedData, ...desired.permanent };
+  const updated = { ...storedData, ...desired };
 
   try {
     if (storage) {

--- a/src/browser/data.js
+++ b/src/browser/data.js
@@ -247,21 +247,12 @@ function validateIncomingState(incomingState, errorFn) {
 }
 
 /**
- * Determine if an object includes its own `permanent` property.
- * @param {object} obj - Object to inspect.
- * @returns {boolean} True when the property exists.
- */
-function hasPermanentProperty(obj) {
-  return Object.hasOwn(obj, 'permanent');
-}
-
-/**
- * Determine whether a permanent state object has required properties.
+ * Determine whether a permanent state object is invalid.
  * @param {object} value - Candidate state object.
- * @returns {boolean} True if the state is missing required fields.
+ * @returns {boolean} True when the value is not a non-null object.
  */
 function isInvalidPermanentState(value) {
-  return !isNonNullObject(value) || !hasPermanentProperty(value);
+  return !isNonNullObject(value);
 }
 
 /**
@@ -276,9 +267,7 @@ function validateIncomingPermanentState(incomingState, errorFn) {
       'setLocalPermanentData received invalid data structure:',
       incomingState
     );
-    throw new Error(
-      "setLocalPermanentData requires an object with at least a 'permanent' property."
-    );
+    throw new Error('setLocalPermanentData requires an object.');
   }
 }
 
@@ -386,10 +375,10 @@ export const setLocalTemporaryData = (state, loggers) => {
 /**
  * Updates persistent data stored in localStorage.
  * Reads existing data, merges with the incoming object and persists the result.
- * @param {object} desired - The new state object (must have 'permanent').
+ * @param {object} desired - The new state object.
  * @param {object} loggers - Logging functions.
  * @param {Function} loggers.logError - Error logger.
- * @param storage
+ * @param {Storage} [storage] - Storage used to persist data.
  * @returns {object} The merged permanent state.
  */
 export const setLocalPermanentData = (desired, loggers, storage) => {
@@ -406,7 +395,7 @@ export const setLocalPermanentData = (desired, loggers, storage) => {
     logError('Failed to read permanent data:', readError);
   }
 
-  const updated = { ...storedData, ...desired.permanent };
+  const updated = { ...storedData, ...desired };
 
   try {
     if (storage) {

--- a/test/browser/setLocalPermanentData.test.js
+++ b/test/browser/setLocalPermanentData.test.js
@@ -6,7 +6,7 @@ describe('setLocalPermanentData', () => {
     const storage = { getItem: jest.fn(), setItem: jest.fn() };
     storage.getItem.mockReturnValueOnce(JSON.stringify({ existing: true }));
     const logError = jest.fn();
-    const incoming = { permanent: { foo: 'bar' } };
+    const incoming = { foo: 'bar' };
     const result = setLocalPermanentData(incoming, { logError }, storage);
     expect(result).toEqual({ existing: true, foo: 'bar' });
     expect(storage.setItem).toHaveBeenCalledWith(
@@ -18,12 +18,12 @@ describe('setLocalPermanentData', () => {
   it('throws and logs when state is invalid', () => {
     const storage = { getItem: jest.fn(), setItem: jest.fn() };
     const logError = jest.fn();
-    expect(() => setLocalPermanentData({}, { logError }, storage)).toThrow(
-      "setLocalPermanentData requires an object with at least a 'permanent' property."
+    expect(() => setLocalPermanentData(null, { logError }, storage)).toThrow(
+      'setLocalPermanentData requires an object.'
     );
     expect(logError).toHaveBeenCalledWith(
       'setLocalPermanentData received invalid data structure:',
-      {}
+      null
     );
     expect(storage.setItem).not.toHaveBeenCalled();
   });

--- a/test/toys/2025-07-05/setPermanentData.test.js
+++ b/test/toys/2025-07-05/setPermanentData.test.js
@@ -3,12 +3,12 @@ import { describe, test, expect, jest } from '@jest/globals';
 
 describe('setPermanentData', () => {
   test('passes parsed object to env and returns the result', () => {
-    const mock = jest.fn(obj => ({ ...obj.permanent, ok: true }));
+    const mock = jest.fn(obj => ({ ...obj, ok: true }));
     const env = new Map([['setLocalPermanentData', mock]]);
-    const input = JSON.stringify({ permanent: { foo: 'bar' } });
+    const input = JSON.stringify({ foo: 'bar' });
     const result = JSON.parse(setPermanentData(input, env));
     expect(result).toEqual({ foo: 'bar', ok: true });
-    expect(mock).toHaveBeenCalledWith({ permanent: { foo: 'bar' } });
+    expect(mock).toHaveBeenCalledWith({ foo: 'bar' });
   });
 
   test('returns empty object on parse failure', () => {


### PR DESCRIPTION
## Summary
- loosen validation in `setLocalPermanentData`
- merge incoming data directly
- update browser build file
- adjust tests for new API
- document storage parameter and simplify validation comments

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68694576a51c832e8a9da794d767e168