### PR TITLE
Remove eslint warning in transformer

### DIFF
--- a/src/toys/2025-07-04/transformDendriteStory.js
+++ b/src/toys/2025-07-04/transformDendriteStory.js
@@ -48,40 +48,49 @@ function createOptions(data, getUuid) {
 }
 
 /**
+ * Safely parse a JSON string.
+ * @param {string} str - String to parse.
+ * @returns {object|null} Parsed object or null when invalid.
+ */
+function safeParse(str) {
+  try {
+    return JSON.parse(str);
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Transform and store a Dendrite story submission.
  * @param {string} input - JSON string of a Dendrite story submission.
  * @param {Map<string, Function>} env - Environment providing getData/setLocalTemporaryData.
  * @returns {string} JSON string of the new objects.
  */
 export function transformDendriteStory(input, env) {
-  try {
-    const parsed = JSON.parse(input);
-    if (!isValidInput(parsed)) {
-      throw new Error('invalid');
-    }
-
-    const getUuid = env.get('getUuid');
-    const getData = env.get('getData');
-    const setLocalTemporaryData = env.get('setLocalTemporaryData');
-    const storyId = getUuid();
-    const pageId = getUuid();
-    const opts = createOptions(parsed, getUuid).map(o => ({
-      ...o,
-      pageId,
-    }));
-    const story = { id: storyId, title: parsed.title };
-    const page = { id: pageId, storyId, content: parsed.content };
-
-    const currentData = getData();
-    const newData = deepClone(currentData);
-    ensureDend2(newData);
-    newData.temporary.DEND2.stories.push(story);
-    newData.temporary.DEND2.pages.push(page);
-    newData.temporary.DEND2.options.push(...opts);
-    setLocalTemporaryData(newData);
-
-    return JSON.stringify({ stories: [story], pages: [page], options: opts });
-  } catch {
+  const parsed = safeParse(input);
+  if (!isValidInput(parsed)) {
     return JSON.stringify({ stories: [], pages: [], options: [] });
   }
+
+  const getUuid = env.get('getUuid');
+  const getData = env.get('getData');
+  const setLocalTemporaryData = env.get('setLocalTemporaryData');
+  const storyId = getUuid();
+  const pageId = getUuid();
+  const opts = createOptions(parsed, getUuid).map(o => ({
+    ...o,
+    pageId,
+  }));
+  const story = { id: storyId, title: parsed.title };
+  const page = { id: pageId, storyId, content: parsed.content };
+
+  const currentData = getData();
+  const newData = deepClone(currentData);
+  ensureDend2(newData);
+  newData.temporary.DEND2.stories.push(story);
+  newData.temporary.DEND2.pages.push(page);
+  newData.temporary.DEND2.options.push(...opts);
+  setLocalTemporaryData(newData);
+
+  return JSON.stringify({ stories: [story], pages: [page], options: opts });
 }


### PR DESCRIPTION
## Summary
- simplify `transformDendriteStory` by using a helper to parse JSON safely
- return early when input is invalid

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686950a1a440832ea65b40a57995d377