### PR TITLE
Remove unsupported content_md5 field

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -27,7 +27,4 @@ resource "google_storage_bucket_object" "hello_world" {
   name   = "hello-world.txt"
   bucket = google_storage_bucket.irien_bucket.name
   source = "${path.module}/hello-world.txt"
-
-  # ensures new versions get uploaded if the file changes
-  content_md5 = filemd5("${path.module}/hello-world.txt")
 }


### PR DESCRIPTION
## Summary
- remove the deprecated `content_md5` field from `google_storage_bucket_object`
- tidy up Terraform formatting

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68724552e9f4832eb12b4ff25243a366