### PR TITLE
Add API key credit cloud function

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -5,6 +5,7 @@ This directory houses Terraform configurations and related resources for deployi
 The configuration provisions a Google Cloud Storage bucket and now also creates
 a Firestore database. The Terraform service account is granted the
 `roles/datastore.user` role so it can manage Firestore resources.
+Additionally, the `cloud-functions/get-api-key-credit` directory contains a Google Cloud Function that returns the credit associated with a given API key.
 
 ## Import Targets
 

--- a/infra/cloud-functions/get-api-key-credit/function.tf
+++ b/infra/cloud-functions/get-api-key-credit/function.tf
@@ -1,0 +1,17 @@
+resource "google_cloudfunctions_function" "get_api_key_credit" {
+  name        = "get-api-key-credit"
+  description = "Returns credit associated with API key"
+  runtime     = "nodejs18"
+  region      = "europe-west1"
+  entry_point = "getApiKeyCredit"
+  source_directory = path.module
+
+  trigger_http = true
+
+  available_memory_mb   = 128
+  timeout               = 60
+
+  environment_variables = {
+    NODE_ENV = "production"
+  }
+}

--- a/infra/cloud-functions/get-api-key-credit/index.js
+++ b/infra/cloud-functions/get-api-key-credit/index.js
@@ -1,0 +1,33 @@
+import { Firestore } from '@google-cloud/firestore';
+
+const firestore = new Firestore();
+
+/**
+ * HTTP Cloud Function to retrieve credit data associated with an API key.
+ * @param {object} req - Express request object.
+ * @param {object} res - Express response object.
+ * @returns {Promise<void>} Response with credit value or error code.
+ */
+export async function getApiKeyCredit(req, res) {
+  const { uuid } = req.params;
+
+  if (!uuid) {
+    res.status(400).send('Missing UUID');
+    return;
+  }
+
+  try {
+    const doc = await firestore.collection('api-key-credit').doc(uuid).get();
+
+    if (!doc.exists) {
+      res.status(404).send('Not found');
+      return;
+    }
+
+    const data = doc.data();
+    res.status(200).json({ credit: data.credit });
+  } catch (error) {
+    console.error(error);
+    res.status(500).send('Internal error');
+  }
+}

--- a/infra/cloud-functions/get-api-key-credit/package.json
+++ b/infra/cloud-functions/get-api-key-credit/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "get-api-key-credit",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.js",
+  "dependencies": {
+    "@google-cloud/firestore": "^7.6.0"
+  }
+}


### PR DESCRIPTION
## Summary
- add a Google Cloud Function for retrieving credit by API key
- document new function in infrastructure README

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6872d0d5412c832e8959f3316d899742