### PR TITLE
Remove unsupported import target

### DIFF
--- a/infra/import_targets.json
+++ b/infra/import_targets.json
@@ -4,10 +4,6 @@
     "id": "irien-hello-world-irien-465710"
   },
   {
-    "resource": "google_storage_bucket_object.hello_world",
-    "id": "irien-hello-world-irien-465710/hello-world.txt"
-  },
-  {
     "resource": "google_firestore_database.default",
     "id": "projects/irien-465710/databases/(default)"
   }


### PR DESCRIPTION
## Summary
- remove `google_storage_bucket_object` from Terraform import targets

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68736e88d4c8832ebc7348142ded9c74