### PR TITLE
Add Terraform module for Cloud Function

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -6,6 +6,7 @@ The configuration provisions a Google Cloud Storage bucket and now also creates
 a Firestore database. The Terraform service account is granted the
 `roles/datastore.user` role so it can manage Firestore resources.
 Additionally, the `cloud-functions/get-api-key-credit` directory contains a Google Cloud Function that returns the credit associated with a given API key.
+This function is applied through a module declaration in `main.tf`.
 
 ## Import Targets
 

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -53,3 +53,7 @@ resource "google_project_iam_member" "firestore_access" {
   role    = "roles/datastore.user"
   member  = "serviceAccount:terraform@${var.project_id}.iam.gserviceaccount.com"
 }
+
+module "get_api_key_credit" {
+  source = "${path.module}/cloud-functions/get-api-key-credit"
+}


### PR DESCRIPTION
## Summary
- add module invocation for `get-api-key-credit` Cloud Function
- document module usage in infra README

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6873734cb008832eb6343167dfe03f1f