### PR TITLE
Migrate get-api-key-credit to Cloud Functions V2

### DIFF
--- a/infra/cloud-functions/get-api-key-credit/index.js
+++ b/infra/cloud-functions/get-api-key-credit/index.js
@@ -8,7 +8,7 @@ const firestore = new Firestore();
  * @param {object} res - Express response object.
  * @returns {Promise<void>} Response with credit value or error code.
  */
-export async function getApiKeyCredit(req, res) {
+export async function handler(req, res) {
   const { uuid } = req.params;
 
   if (!uuid) {

--- a/infra/cloud-functions/get-api-key-credit/variables.tf
+++ b/infra/cloud-functions/get-api-key-credit/variables.tf
@@ -1,0 +1,4 @@
+variable "region" {
+  type    = string
+  default = "europe-west1"
+}


### PR DESCRIPTION
## Summary
- switch get-api-key-credit to `google_cloudfunctions2_function`
- upload a zipped archive for the function code
- export the handler as `handler` to match the entry point
- expose `region` variable for the function
- remove generated zip from the repository

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6873962d2458832e9a7f91d8c59a404d