### PR TITLE
Add zip archive restriction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ tmp/
 # Miscellaneous
 debug/
 *.lock
+*.zip
 
 # stryker temp files
 .stryker-tmp

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,3 +44,8 @@ Write clear commit messages that summarize the change.
 
 Include a Summary and Testing section in the PR body describing the changes and
 any test results or failures.
+
+## File Restrictions
+
+- Do not commit zip archives (`*.zip`). These files are ignored via `.gitignore`
+  and should not be added to pull requests.


### PR DESCRIPTION
## Summary
- ignore zip files in `.gitignore`
- instruct agents not to commit `.zip` archives

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68739b5f359c832e9ddb6b25a3345950