### PR TITLE
Enable manual Terraform deploy

### DIFF
--- a/.github/workflows/deploy-terraform.yml
+++ b/.github/workflows/deploy-terraform.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - main
 
+  workflow_dispatch:
 jobs:
   terraform:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add `workflow_dispatch` trigger to deploy Terraform workflow

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6873aaeaa864832eb8bcbc5c6ad833f6