### PR TITLE
Enable Cloud Functions API

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -2,12 +2,13 @@
 
 This directory houses Terraform configurations and related resources for deploying cloud infrastructure.
 
-The configuration provisions a Google Cloud Storage bucket and now also creates
-a Firestore database. The Terraform service account is granted the
-`roles/datastore.user` role so it can manage Firestore resources. Additionally,
-the `cloud-functions/get-api-key-credit` directory contains the code for a
-Google Cloud Function that returns the credit associated with a given API key.
-The resources for this function are defined directly in `main.tf`.
+The configuration provisions a Google Cloud Storage bucket and creates a
+Firestore database. The Terraform service account is granted the
+`roles/datastore.user` role so it can manage Firestore resources. The
+`cloud-functions/get-api-key-credit` directory contains the code for a Google
+Cloud Function that returns the credit associated with a given API key. The
+Cloud Functions API is enabled via a `google_project_service` resource and the
+resources for this function are defined directly in `main.tf`.
 
 ## Import Targets
 

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -45,6 +45,11 @@ resource "google_project_service" "firestore" {
   service = "firestore.googleapis.com"
 }
 
+resource "google_project_service" "cloudfunctions" {
+  project = var.project_id
+  service = "cloudfunctions.googleapis.com"
+}
+
 resource "google_firestore_database" "default" {
   project     = var.project_id
   name        = "(default)"
@@ -90,4 +95,6 @@ resource "google_cloudfunctions2_function" "get_api_key_credit" {
     event_type     = "google.cloud.functions.v2.eventTypes.http.request"
     trigger_region = var.region
   }
+
+  depends_on = [google_project_service.cloudfunctions]
 }


### PR DESCRIPTION
## Summary
- enable Google Cloud Functions API in Terraform
- ensure the cloud function depends on the API
- document the Cloud Functions API requirement

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6873adbeda64832eb61a2111dd33e077