### PR TITLE
Refactor getDend2Titles to lower complexity

### DIFF
--- a/src/toys/2025-07-05/getDend2Titles.js
+++ b/src/toys/2025-07-05/getDend2Titles.js
@@ -2,6 +2,22 @@
 // (input, env) -> string
 
 /**
+ * Safely gather DEND2 story titles using the provided data getter.
+ * @param {Function} getData - Function that retrieves state data.
+ * @returns {string[]} Array of story titles.
+ */
+function gatherTitles(getData) {
+  try {
+    const stories = getData()?.temporary?.DEND2?.stories || [];
+    return stories
+      .map(story => story?.title)
+      .filter(title => typeof title === 'string');
+  } catch {
+    return [];
+  }
+}
+
+/**
  * Gather all DEND2 story titles from temporary storage.
  * @param {*} input - Unused value.
  * @param {Map<string, Function>} env - Environment with a `getData` accessor.
@@ -12,13 +28,6 @@ export function getDend2Titles(input, env) {
   if (typeof getData !== 'function') {
     return JSON.stringify([]);
   }
-  try {
-    const stories = getData()?.temporary?.DEND2?.stories || [];
-    const titles = stories
-      .map(story => story?.title)
-      .filter(title => typeof title === 'string');
-    return JSON.stringify(titles);
-  } catch {
-    return JSON.stringify([]);
-  }
+  const titles = gatherTitles(getData);
+  return JSON.stringify(titles);
 }


### PR DESCRIPTION
## Summary
- extract `gatherTitles` helper from `getDend2Titles`
- simplify the main function and keep documentation

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6873b05ae410832e82942d04b446d130