### PR TITLE
Update Terraform to manage Cloud Functions

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -4,9 +4,11 @@ This directory houses Terraform configurations and related resources for deployi
 
 The configuration provisions a Google Cloud Storage bucket and creates a
 Firestore database. The Terraform service account is granted the
-`roles/datastore.user` role so it can manage Firestore resources. The
-`cloud-functions/get-api-key-credit` directory contains the code for a Google
-Cloud Function that returns the credit associated with a given API key. The
+`roles/datastore.user` role so it can manage Firestore resources, and the
+`roles/cloudfunctions.developer` role so it can create and manage Cloud
+Functions. The `cloud-functions/get-api-key-credit` directory contains the code
+for a Google Cloud Function that returns the credit associated with a given API
+key. The
 Cloud Functions API is enabled via a `google_project_service` resource and the
 resources for this function are defined directly in `main.tf`.
 

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -64,6 +64,12 @@ resource "google_project_iam_member" "firestore_access" {
   member  = "serviceAccount:terraform@${var.project_id}.iam.gserviceaccount.com"
 }
 
+resource "google_project_iam_member" "cloudfunctions_access" {
+  project = var.project_id
+  role    = "roles/cloudfunctions.developer"
+  member  = "serviceAccount:terraform@${var.project_id}.iam.gserviceaccount.com"
+}
+
 resource "google_storage_bucket_object" "get_api_key_credit" {
   name   = "get-api-key-credit.zip"
   bucket = google_storage_bucket.irien_bucket.name


### PR DESCRIPTION
## Summary
- give terraform service account permission to develop Cloud Functions
- mention new permission in infrastructure docs

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6873b0df67e0832ea3d40d1d69068b22