### PR TITLE
Fix escapeHtml handling of undefined

### DIFF
--- a/src/generator/html.js
+++ b/src/generator/html.js
@@ -219,7 +219,11 @@ export function applyAllHtmlEscapeReplacements(text, replacements) {
  * @returns {string} - HTML-escaped text
  */
 export function escapeHtml(text) {
-  return applyAllHtmlEscapeReplacements(text, htmlEscapeReplacements());
+  const safeText = text ?? '';
+  return applyAllHtmlEscapeReplacements(
+    String(safeText),
+    htmlEscapeReplacements()
+  );
 }
 
 /**

--- a/test/generator/html.escapeHtml.undefined.test.js
+++ b/test/generator/html.escapeHtml.undefined.test.js
@@ -1,0 +1,6 @@
+import { test, expect } from '@jest/globals';
+import { escapeHtml } from '../../src/generator/html.js';
+
+test('escapeHtml returns empty string for undefined input', () => {
+  expect(escapeHtml(undefined)).toBe('');
+});


### PR DESCRIPTION
## Summary
- prevent errors when escaping undefined values
- test escapeHtml with undefined input

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6873b3fbb568832eac2e9d7a2997a85e