### PR TITLE
Enable Cloud Build in Terraform

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -9,7 +9,8 @@ Firestore database. The Terraform service account is granted the
 Functions. The `cloud-functions/get-api-key-credit` directory contains the code
 for a Google Cloud Function that returns the credit associated with a given API
 key. The
-Cloud Functions API is enabled via a `google_project_service` resource and the
+Cloud Functions API is enabled via a `google_project_service` resource, and the
+Cloud Build API is also enabled so that functions can be built from source. The
 resources for this function are defined directly in `main.tf`.
 
 ## Import Targets

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -50,6 +50,11 @@ resource "google_project_service" "cloudfunctions" {
   service = "cloudfunctions.googleapis.com"
 }
 
+resource "google_project_service" "cloudbuild" {
+  project = var.project_id
+  service = "cloudbuild.googleapis.com"
+}
+
 resource "google_firestore_database" "default" {
   project     = var.project_id
   name        = "(default)"
@@ -104,6 +109,7 @@ resource "google_cloudfunctions2_function" "get_api_key_credit" {
 
   depends_on = [
     google_project_service.cloudfunctions,
+    google_project_service.cloudbuild,
     google_project_iam_member.cloudfunctions_access
   ]
 }


### PR DESCRIPTION
## Summary
- add `google_project_service.cloudbuild` to enable Cloud Build
- depend on the Cloud Build service for Cloud Functions
- document the Cloud Build API requirement

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6873b7534da4832e8075fa9e8518667a