### PR TITLE
Reduce complexity in DEND2 title gathering

### DIFF
--- a/src/toys/2025-07-05/getDend2Titles.js
+++ b/src/toys/2025-07-05/getDend2Titles.js
@@ -2,19 +2,47 @@
 // (input, env) -> string
 
 /**
- * Safely gather DEND2 story titles using the provided data getter.
+ * Safely access the DEND2 stories list.
+ * @param {Function} getData - Function that retrieves state data.
+ * @returns {object[]} Array of DEND2 story objects.
+ */
+function getStories(getData) {
+  if (typeof getData !== 'function') {
+    return [];
+  }
+  let data;
+  try {
+    data = getData();
+  } catch {
+    return [];
+  }
+  const dend2 = data && data.temporary && data.temporary.DEND2;
+  const stories = dend2 && dend2.stories;
+  if (Array.isArray(stories)) {
+    return stories;
+  }
+  return [];
+}
+
+/**
+ * Extract valid titles from the provided stories array.
+ * @param {object[]} stories - Array of story objects.
+ * @returns {string[]} Array of story titles.
+ */
+function extractTitles(stories) {
+  return stories
+    .map(story => story?.title)
+    .filter(title => typeof title === 'string');
+}
+
+/**
+ * Gather DEND2 story titles using the provided data getter.
  * @param {Function} getData - Function that retrieves state data.
  * @returns {string[]} Array of story titles.
  */
 function gatherTitles(getData) {
-  try {
-    const stories = getData()?.temporary?.DEND2?.stories || [];
-    return stories
-      .map(story => story?.title)
-      .filter(title => typeof title === 'string');
-  } catch {
-    return [];
-  }
+  const stories = getStories(getData);
+  return extractTitles(stories);
 }
 
 /**


### PR DESCRIPTION
## Summary
- extract helper functions from `getDend2Titles` logic
- delegate story retrieval and title extraction to helpers

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6873b78e470c832e8273ab7ced0de922