### PR TITLE
Fix sonar issue with startsWith

### DIFF
--- a/src/browser/tags.js
+++ b/src/browser/tags.js
@@ -5,7 +5,7 @@
  * @returns {boolean} True when `str` starts with `prefix`.
  */
 export function startsWith(str, prefix) {
-  return str.indexOf(prefix) === 0;
+  return str.startsWith(prefix);
 }
 
 /**


### PR DESCRIPTION
## Summary
- replace manual prefix check with `String.startsWith`
- `npm test` and `npm run lint` pass

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6873ba446fbc832eb0fe10e08ccfafce