### PR TITLE
Configure runtime service account

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -6,7 +6,9 @@ The configuration provisions a Google Cloud Storage bucket and creates a
 Firestore database. The Terraform service account is granted the
 `roles/datastore.user` role so it can manage Firestore resources, and the
 `roles/cloudfunctions.developer` role so it can create and manage Cloud
-Functions. The `cloud-functions/get-api-key-credit` directory contains the code
+Functions. A separate compute service account is created for running
+Cloud Functions, and the Terraform service account is allowed to
+impersonate this runtime account. The `cloud-functions/get-api-key-credit` directory contains the code
 for a Google Cloud Function that returns the credit associated with a given API
 key. The
 Cloud Functions API is enabled via a `google_project_service` resource, and the

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -75,6 +75,18 @@ resource "google_project_iam_member" "cloudfunctions_access" {
   member  = "serviceAccount:terraform@${var.project_id}.iam.gserviceaccount.com"
 }
 
+resource "google_service_account" "default_runtime" {
+  account_id   = "${var.project_id}-compute"
+  project      = var.project_id
+  display_name = "Default Compute Service Account"
+}
+
+resource "google_service_account_iam_member" "allow_terraform_to_impersonate_runtime" {
+  service_account_id = google_service_account.default_runtime.name
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:terraform@${var.project_id}.iam.gserviceaccount.com"
+}
+
 resource "google_storage_bucket_object" "get_api_key_credit" {
   name   = "get-api-key-credit.zip"
   bucket = google_storage_bucket.irien_bucket.name
@@ -100,6 +112,7 @@ resource "google_cloudfunctions2_function" "get_api_key_credit" {
     available_memory   = "128Mi"
     timeout_seconds    = 60
     min_instance_count = 0
+    service_account_email = google_service_account.default_runtime.email
   }
 
   event_trigger {
@@ -110,6 +123,7 @@ resource "google_cloudfunctions2_function" "get_api_key_credit" {
   depends_on = [
     google_project_service.cloudfunctions,
     google_project_service.cloudbuild,
-    google_project_iam_member.cloudfunctions_access
+    google_project_iam_member.cloudfunctions_access,
+    google_service_account_iam_member.allow_terraform_to_impersonate_runtime
   ]
 }


### PR DESCRIPTION
## Summary
- create a compute service account for Cloud Functions
- allow the Terraform service account to impersonate it
- configure the Cloud Function to use the new runtime account
- document the runtime service account in the infrastructure README

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6873b9d2a350832e96c341f63d106b0e