### PR TITLE
Reduce complexity in getDend2Titles helper

### DIFF
--- a/src/toys/2025-07-05/getDend2Titles.js
+++ b/src/toys/2025-07-05/getDend2Titles.js
@@ -18,14 +18,23 @@ function safeGetData(getData) {
 }
 
 /**
+ * Normalize a potential stories array.
+ * @param {*} stories - Value that may be an array of stories.
+ * @returns {object[]} Valid stories array or empty array.
+ */
+function normalizeStories(stories) {
+  return Array.isArray(stories) ? stories : [];
+}
+
+/**
  * Safely access the DEND2 stories list.
  * @param {Function} getData - Retrieves state data.
  * @returns {object[]} Array of DEND2 story objects.
  */
 function getStories(getData) {
   const data = safeGetData(getData);
-  const stories = data?.temporary?.DEND2?.stories;
-  return Array.isArray(stories) ? stories : [];
+  const dend2 = data?.temporary?.DEND2;
+  return normalizeStories(dend2?.stories);
 }
 
 /**


### PR DESCRIPTION
## Summary
- extract `normalizeStories` helper from `getStories`
- use the new helper to simplify `getStories`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6873bcc1d66c832e9eac90f43c47a160