### PR TITLE
Fix duplication by sharing dendrite helpers

### DIFF
--- a/src/toys/2025-07-04/transformDendriteStory.js
+++ b/src/toys/2025-07-04/transformDendriteStory.js
@@ -1,6 +1,6 @@
 import { deepClone } from '../../utils/objectUtils.js';
-import { DENDRITE_OPTION_KEYS } from '../../constants/dendrite.js';
 import { isValidString } from '../../utils/validation.js';
+import { ensureDend2, createOptions } from '../utils/dendriteHelpers.js';
 
 /**
  * Determine if a value is a non-null object.
@@ -30,18 +30,6 @@ const hasValidDend2 = temp => {
 const isValidTemporary = temp => isObject(temp) && hasValidDend2(temp);
 
 /**
- * Ensure the data object has a valid temporary.DEND2 structure.
- * @param {object} data - Data object to check.
- */
-function ensureDend2(data) {
-  const empty = { stories: [], pages: [], options: [] };
-
-  if (!isValidTemporary(data.temporary)) {
-    data.temporary = { DEND2: empty };
-  }
-}
-
-/**
  * Validate the parsed story input.
  * @param {object} [obj] - Parsed object.
  * @param {string} obj.title - Story title.
@@ -50,19 +38,6 @@ function ensureDend2(data) {
  */
 function isValidInput(obj) {
   return Boolean(obj) && [obj.title, obj.content].every(isValidString);
-}
-
-/**
- * Create option objects for values present in the input data.
- * @param {object} data - Source data that may contain option values.
- * @param {Function} getUuid - Function that generates unique IDs.
- * @returns {Array<{id: string, content: string}>} Array of option objects.
- */
-function createOptions(data, getUuid) {
-  return DENDRITE_OPTION_KEYS.filter(key => data[key]).map(key => ({
-    id: getUuid(),
-    content: data[key],
-  }));
 }
 
 /**

--- a/src/toys/2025-07-05/addDendritePage.js
+++ b/src/toys/2025-07-05/addDendritePage.js
@@ -1,28 +1,6 @@
 import { deepClone } from '../../utils/objectUtils.js';
-import { DENDRITE_OPTION_KEYS } from '../../constants/dendrite.js';
 import { isValidString } from '../../utils/validation.js';
-
-/**
- * Ensure the data object has a valid temporary.DEND2 structure.
- * @param {object} data - Data object to check.
- */
-// eslint-disable-next-line complexity
-function ensureDend2(data) {
-  if (typeof data.temporary !== 'object' || data.temporary === null) {
-    data.temporary = { DEND2: { stories: [], pages: [], options: [] } };
-    return;
-  }
-  const t = data.temporary;
-  if (
-    typeof t.DEND2 !== 'object' ||
-    t.DEND2 === null ||
-    !Array.isArray(t.DEND2.stories) ||
-    !Array.isArray(t.DEND2.pages) ||
-    !Array.isArray(t.DEND2.options)
-  ) {
-    t.DEND2 = { stories: [], pages: [], options: [] };
-  }
-}
+import { ensureDend2, createOptions } from '../utils/dendriteHelpers.js';
 
 /**
  * Validate the parsed page input.
@@ -37,21 +15,6 @@ function isValidInput(obj) {
     return false;
   }
   return isValidString(obj.optionId) && isValidString(obj.content);
-}
-
-/**
- * Create option objects for values present in the input data.
- * @param {object} data - Source data that may contain option values.
- * @param {string} pageId - Identifier for the new page.
- * @param {Function} getUuid - Function that generates unique IDs.
- * @returns {Array<{id: string, pageId: string, content: string}>} Option list.
- */
-function createOptions(data, pageId, getUuid) {
-  return DENDRITE_OPTION_KEYS.filter(key => data[key]).map(key => ({
-    id: getUuid(),
-    pageId,
-    content: data[key],
-  }));
 }
 
 /**
@@ -72,7 +35,7 @@ export function addDendritePage(input, env) {
     const getData = env.get('getData');
     const setLocalTemporaryData = env.get('setLocalTemporaryData');
     const pageId = getUuid();
-    const opts = createOptions(parsed, pageId, getUuid);
+    const opts = createOptions(parsed, getUuid, pageId);
     const page = {
       id: pageId,
       optionId: parsed.optionId,

--- a/src/toys/utils/dendriteHelpers.js
+++ b/src/toys/utils/dendriteHelpers.js
@@ -1,0 +1,40 @@
+export { ensureDend2, createOptions };
+
+import { DENDRITE_OPTION_KEYS } from '../../constants/dendrite.js';
+
+/**
+ * Ensure the data object has a valid temporary.DEND2 structure.
+ * @param {object} data - Data object to check.
+ * @returns {void}
+ */
+function ensureDend2(data) {
+  if (typeof data.temporary !== 'object' || data.temporary === null) {
+    data.temporary = { DEND2: { stories: [], pages: [], options: [] } };
+    return;
+  }
+  const t = data.temporary;
+  if (
+    typeof t.DEND2 !== 'object' ||
+    t.DEND2 === null ||
+    !Array.isArray(t.DEND2.stories) ||
+    !Array.isArray(t.DEND2.pages) ||
+    !Array.isArray(t.DEND2.options)
+  ) {
+    t.DEND2 = { stories: [], pages: [], options: [] };
+  }
+}
+
+/**
+ * Create option objects for values present in the input data.
+ * @param {object} data - Source data that may contain option values.
+ * @param {Function} getUuid - Function that generates unique IDs.
+ * @param {string} [pageId] - Optional page identifier to include on each option.
+ * @returns {Array<object>} Option list.
+ */
+function createOptions(data, getUuid, pageId) {
+  return DENDRITE_OPTION_KEYS.filter(key => data[key]).map(key => ({
+    id: getUuid(),
+    ...(pageId ? { pageId } : {}),
+    content: data[key],
+  }));
+}


### PR DESCRIPTION
## Summary
- extract `ensureDend2` and `createOptions` into a shared helper
- use the new helper in `addDendritePage` and `transformDendriteStory`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6873bfe38530832ea1bcd1329fe45762