### PR TITLE
Refactor to lower storage save complexity

### DIFF
--- a/src/browser/data.js
+++ b/src/browser/data.js
@@ -420,7 +420,21 @@ function getPermanentRaw(storage) {
 }
 
 /**
- * Persist permanent data to storage.
+ * Write the permanent data object to storage.
+ * @param {Storage} storage - Storage used to persist data.
+ * @param {object} data - Data to save.
+ * @param {Function} logError - Error logger.
+ */
+function writePermanentData(storage, data, logError) {
+  try {
+    storage.setItem('permanentData', JSON.stringify(data));
+  } catch (storageError) {
+    logError('Failed to persist permanent data:', storageError);
+  }
+}
+
+/**
+ * Persist permanent data when storage is available.
  * @param {Storage} storage - Storage used to persist data.
  * @param {object} data - Data to save.
  * @param {Function} logError - Error logger.
@@ -429,11 +443,7 @@ function savePermanentData(storage, data, logError) {
   if (!storage) {
     return;
   }
-  try {
-    storage.setItem('permanentData', JSON.stringify(data));
-  } catch (storageError) {
-    logError('Failed to persist permanent data:', storageError);
-  }
+  writePermanentData(storage, data, logError);
 }
 
 export const setLocalPermanentData = (desired, loggers, storage) => {


### PR DESCRIPTION
## Summary
- extract `writePermanentData` helper from `savePermanentData`
- reduce cyclomatic complexity for saving permanent data

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6873c7148138832ea698520e1b2974cf