### PR TITLE
Add runtime service account import

### DIFF
--- a/infra/import_targets.json
+++ b/infra/import_targets.json
@@ -6,5 +6,9 @@
   {
     "resource": "google_firestore_database.default",
     "id": "projects/irien-465710/databases/(default)"
+  },
+  {
+    "resource": "google_service_account.cloud_function_runtime",
+    "id": "projects/irien-465710/serviceAccounts/cloud-function-runtime@irien-465710.iam.gserviceaccount.com"
   }
 ]


### PR DESCRIPTION
## Summary
- add the Cloud Functions runtime service account to Terraform import_targets.json

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6873c8f85274832ead1337db76cc8584