### PR TITLE
Enable Eventarc for Cloud Function

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -59,6 +59,11 @@ resource "google_project_service" "cloudbuild" {
   service = "cloudbuild.googleapis.com"
 }
 
+resource "google_project_service" "eventarc" {
+  project = var.project_id
+  service = "eventarc.googleapis.com"
+}
+
 resource "google_firestore_database" "default" {
   project     = var.project_id
   name        = "(default)"
@@ -139,6 +144,7 @@ resource "google_cloudfunctions2_function" "get_api_key_credit" {
   depends_on = [
     google_project_service.cloudfunctions,
     google_project_service.cloudbuild,
+    google_project_service.eventarc,
     google_project_iam_member.cloudfunctions_access,
     google_service_account_iam_member.terraform_can_impersonate_runtime,
     google_service_account_iam_member.terraform_can_impersonate_default_compute,


### PR DESCRIPTION
## Summary
- enable the Eventarc API via `google_project_service`
- ensure Cloud Function depends on the Eventarc service

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6873cc90d7f4832eb9c7daad50600d81