### PR TITLE
Refactor getter utility to lower complexity

### DIFF
--- a/src/toys/2025-07-05/getDend2Titles.js
+++ b/src/toys/2025-07-05/getDend2Titles.js
@@ -6,13 +6,22 @@
  * @param {Function} getData - Retrieves state data.
  * @returns {object|undefined} Retrieved data or undefined on failure.
  */
+function invokeGetter(getData) {
+  try {
+    return getData();
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Safely invoke the provided getter when it is a function.
+ * @param {Function} getData - Retrieves state data.
+ * @returns {object|undefined} Retrieved data or undefined on failure.
+ */
 function safeGetData(getData) {
   if (typeof getData === 'function') {
-    try {
-      return getData();
-    } catch {
-      // ignore
-    }
+    return invokeGetter(getData);
   }
   return undefined;
 }


### PR DESCRIPTION
## Summary
- extract `invokeGetter` helper for `getDend2Titles`
- use the helper in `safeGetData`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6873cd7c0cc8832e955cf7beba7a1520