### PR TITLE
Update import targets for existing Cloud Function resources

### DIFF
--- a/infra/import_targets.json
+++ b/infra/import_targets.json
@@ -10,5 +10,13 @@
   {
     "resource": "google_service_account.cloud_function_runtime",
     "id": "projects/irien-465710/serviceAccounts/cloud-function-runtime@irien-465710.iam.gserviceaccount.com"
+  },
+  {
+    "resource": "google_cloudfunctions_function.get_api_key_credit",
+    "id": "projects/irien-465710/locations/europe-west1/functions/get-api-key-credit"
+  },
+  {
+    "resource": "google_cloudfunctions_function_iam_member.invoker",
+    "id": "projects/irien-465710/locations/europe-west1/functions/get-api-key-credit/roles/cloudfunctions.invoker/allUsers"
   }
 ]


### PR DESCRIPTION
## Summary
- extend `infra/import_targets.json` with import information for the existing `get-api-key-credit` Cloud Function and its invoker IAM member

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6873fc2e7bf4832ebcb1b23e5f6ca01a