### PR TITLE
Add Cloud Functions admin role

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -4,9 +4,10 @@ This directory houses Terraform configurations and related resources for deployi
 
 The configuration provisions a Google Cloud Storage bucket and creates a
 Firestore database. The Terraform service account is granted the
-`roles/datastore.user` role so it can manage Firestore resources, and the
+`roles/datastore.user` role so it can manage Firestore resources, the
 `roles/cloudfunctions.developer` role so it can create and manage Cloud
-Functions. A separate compute service account is created for running
+Functions, and the `roles/cloudfunctions.admin` role so it can set Cloud
+Functions IAM policy. A separate compute service account is created for running
 Cloud Functions, and the Terraform service account is allowed to
 impersonate this runtime account. The `cloud-functions/get-api-key-credit` directory contains the code
 for a Google Cloud Function that returns the credit associated with a given API

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -86,6 +86,12 @@ resource "google_project_iam_member" "terraform_cloudfunctions_viewer" {
   member  = "serviceAccount:terraform@${var.project_id}.iam.gserviceaccount.com"
 }
 
+resource "google_project_iam_member" "terraform_set_iam_policy" {
+  project = var.project_id
+  role    = "roles/cloudfunctions.admin"
+  member  = "serviceAccount:terraform@${var.project_id}.iam.gserviceaccount.com"
+}
+
 resource "google_project_iam_member" "terraform_create_sa" {
   project = var.project_id
   role    = "roles/iam.serviceAccountAdmin"


### PR DESCRIPTION
## Summary
- assign roles/cloudfunctions.admin to terraform service account
- mention new IAM role in infra docs

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6873ffafdbfc832e82d5dd9f8ff63078