### PR TITLE
Reduce complexity in Dend2Titles

### DIFF
--- a/src/toys/2025-07-05/getDend2Titles.js
+++ b/src/toys/2025-07-05/getDend2Titles.js
@@ -52,13 +52,19 @@ function collectTitles(stories) {
  */
 export function getDend2Titles(input, env) {
   try {
-    const getData = env.get('getData');
-    if (typeof getData !== 'function') {
-      return JSON.stringify([]);
-    }
-    const stories = getStories(getData());
-    return JSON.stringify(collectTitles(stories));
+    return JSON.stringify(gatherTitles(env));
   } catch {
     return JSON.stringify([]);
   }
+}
+
+/**
+ * Retrieve story titles from the environment.
+ * @param {Map<string, Function>} env - Environment with a `getData` accessor.
+ * @returns {string[]} List of story titles.
+ */
+function gatherTitles(env) {
+  const getData = env.get('getData');
+  const stories = getStories(getData());
+  return collectTitles(stories);
 }


### PR DESCRIPTION
## Summary
- extract `gatherTitles` helper to simplify `getDend2Titles`
- remove unused check for `getData` in `gatherTitles`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68740609c9c4832eb73525952300457d