### PR TITLE
Extend import script for parts

### DIFF
--- a/.github/workflows/deploy-terraform.yml
+++ b/.github/workflows/deploy-terraform.yml
@@ -47,10 +47,16 @@ jobs:
 
           jq -c '.[]' import_targets.json | while read row; do
             RESOURCE=$(echo "$row" | jq -r .resource)
-            ID=$(echo "$row" | jq -r .id)
 
-            echo "\U1F30D Importing $RESOURCE → $ID"
-            terraform import "$RESOURCE" "$ID" || echo "\u26A0\uFE0F Failed to import $RESOURCE"
+            if echo "$row" | jq -e 'has("parts")' > /dev/null; then
+              PARTS=$(echo "$row" | jq -r '.parts | [.resource, .role, .member] | @sh' | tr -d "'")
+              echo "\U1F30D Importing $RESOURCE with parts: $PARTS"
+              terraform import "$RESOURCE" $PARTS || echo "\u26A0\uFE0F Failed to import $RESOURCE"
+            else
+              ID=$(echo "$row" | jq -r .id)
+              echo "\U1F30D Importing $RESOURCE → $ID"
+              terraform import "$RESOURCE" "$ID" || echo "\u26A0\uFE0F Failed to import $RESOURCE"
+            fi
           done
 
       - name: Zip Cloud Functions

--- a/infra/README.md
+++ b/infra/README.md
@@ -20,4 +20,6 @@ resources for this function are defined directly in `main.tf`.
 
 The `import_targets.json` file lists any existing resources that should be
 imported into the Terraform state. Each entry specifies the Terraform resource
-address and the corresponding ID of the resource to import.
+address and either an `id` string or a `parts` object. The `parts` variant is
+used for resources that require multiple ID components, providing `resource`,
+`role`, and `member` values separately.

--- a/infra/import_targets.json
+++ b/infra/import_targets.json
@@ -17,6 +17,10 @@
   },
   {
     "resource": "google_cloudfunctions_function_iam_member.invoker",
-    "id": "projects/irien-465710/locations/europe-west1/functions/get-api-key-credit/roles/cloudfunctions.invoker/allUsers"
+    "parts": {
+      "resource": "projects/irien-465710/locations/europe-west1/functions/get-api-key-credit",
+      "role": "roles/cloudfunctions.invoker",
+      "member": "allUsers"
+    }
   }
 ]


### PR DESCRIPTION
## Summary
- update import_targets.json with new `parts` format
- document the `parts` option in infra README
- enhance the Terraform import step to handle partial IDs

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687405f9b1c0832eaf0df613020149b1