### PR TITLE
Remove ternary warning

### DIFF
--- a/reports/lint/lint.txt
+++ b/reports/lint/lint.txt
@@ -2,11 +2,7 @@
 /workspace/dadeto/src/toys/2025-07-04/transformDendriteStory.js
   30:7  warning  'isValidTemporary' is assigned a value but never used  no-unused-vars
 
-/workspace/dadeto/src/toys/2025-07-05/getDend2Titles.js
-  35:10  warning  Ternary operator used                                              no-ternary
-  43:1   warning  Function 'getStories' has a complexity of 4. Maximum allowed is 2  complexity
-
 /workspace/dadeto/src/toys/utils/dendriteHelpers.js
   74:9  warning  Ternary operator used  no-ternary
 
-✖ 4 problems (0 errors, 4 warnings)
+✖ 2 problems (0 errors, 2 warnings)

--- a/src/toys/2025-07-05/getDend2Titles.js
+++ b/src/toys/2025-07-05/getDend2Titles.js
@@ -30,7 +30,10 @@ function extractDend2Stories(data) {
  */
 function getStories(data) {
   const stories = extractDend2Stories(data);
-  return isStoryArray(stories) ? stories : [];
+  if (isStoryArray(stories)) {
+    return stories;
+  }
+  return [];
 }
 
 /**


### PR DESCRIPTION
## Summary
- rewrite `getStories` in `getDend2Titles.js` to avoid a ternary
- update `reports/lint/lint.txt` after running ESLint

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6874098c0448832e9354e021486e84cb