### PR TITLE
Update Cloud Function runtime to Node.js 20

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -125,7 +125,7 @@ resource "google_storage_bucket_object" "get_api_key_credit" {
 resource "google_cloudfunctions_function" "get_api_key_credit" {
   name        = "get-api-key-credit"
   description = "Returns credit for an API key"
-  runtime     = "nodejs18"
+  runtime     = "nodejs20"
   available_memory_mb   = 128
   source_archive_bucket = google_storage_bucket.irien_bucket.name
   source_archive_object = google_storage_bucket_object.get_api_key_credit.name


### PR DESCRIPTION
## Summary
- update the runtime for `get_api_key_credit` cloud function to `nodejs20`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68740a65a604832e8222dd9807f322dd