### PR TITLE
Update getApiKeyCredit handler

### DIFF
--- a/infra/cloud-functions/get-api-key-credit/index.js
+++ b/infra/cloud-functions/get-api-key-credit/index.js
@@ -72,7 +72,10 @@ async function safeFetchCredit(uuid) {
  * @returns {Promise<void>} Response with credit value or error code.
  */
 export async function handler(req, res) {
-  const { uuid } = req.params;
+  const { uuid: paramUuid } = req.params || {};
+  const { uuid: queryUuid } = req.query || {};
+  const uuid = paramUuid || queryUuid;
+
   if (!uuid) {
     sendBadRequest(res, 'Missing UUID');
     return;


### PR DESCRIPTION
## Summary
- allow `get-api-key-credit` cloud function to accept `uuid` via query string

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68740d4b7e40832e94fe89c0c0feea5e