### PR TITLE
Fix lint warning in dendrite helpers

### DIFF
--- a/reports/lint/lint.txt
+++ b/reports/lint/lint.txt
@@ -1,8 +1,5 @@
 
-/workspace/dadeto/src/toys/2025-07-04/transformDendriteStory.js
-  17:7  warning  'hasValidDend2' is assigned a value but never used  no-unused-vars
+/workspace/dadeto/infra/cloud-functions/get-api-key-credit/index.js
+  74:8  warning  Async function 'handler' has a complexity of 5. Maximum allowed is 2  complexity
 
-/workspace/dadeto/src/toys/utils/dendriteHelpers.js
-  74:9  warning  Ternary operator used  no-ternary
-
-✖ 2 problems (0 errors, 2 warnings)
+✖ 1 problem (0 errors, 1 warning)

--- a/src/toys/utils/dendriteHelpers.js
+++ b/src/toys/utils/dendriteHelpers.js
@@ -69,9 +69,11 @@ function ensureDend2(data) {
  * @returns {Array<object>} Option list.
  */
 function createOptions(data, getUuid, pageId) {
-  return DENDRITE_OPTION_KEYS.filter(key => data[key]).map(key => ({
-    id: getUuid(),
-    ...(pageId ? { pageId } : {}),
-    content: data[key],
-  }));
+  return DENDRITE_OPTION_KEYS.filter(key => data[key]).map(key => {
+    const option = { id: getUuid(), content: data[key] };
+    if (pageId) {
+      option.pageId = pageId;
+    }
+    return option;
+  });
 }


### PR DESCRIPTION
## Summary
- fix lint warning about ternary usage in `createOptions`
- update lint report

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6874acd54d50832e9aa8ebe38992b78c