### PR TITLE
Use dedicated bucket for function sources

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -2,7 +2,8 @@
 
 This directory houses Terraform configurations and related resources for deploying cloud infrastructure.
 
-The configuration provisions a Google Cloud Storage bucket and creates a
+The configuration provisions two Google Cloud Storage buckets, one for static
+files and another for Cloud Functions source archives, and creates a
 Firestore database. The Terraform service account is granted the
 `roles/datastore.user` role so it can manage Firestore resources, the
 `roles/cloudfunctions.developer` role so it can create and manage Cloud

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -44,6 +44,14 @@ resource "google_storage_bucket_iam_member" "public_read_access" {
   member = "allUsers"
 }
 
+resource "google_storage_bucket" "gcf_source_bucket" {
+  name     = "gcf-source-${var.project_id}-${var.region}"
+  location = var.region
+
+  uniform_bucket_level_access = true
+  force_destroy               = true
+}
+
 resource "google_project_service" "firestore" {
   project = var.project_id
   service = "firestore.googleapis.com"
@@ -118,7 +126,7 @@ resource "google_service_account_iam_member" "terraform_can_impersonate_default_
 
 resource "google_storage_bucket_object" "get_api_key_credit" {
   name   = "get-api-key-credit.zip"
-  bucket = google_storage_bucket.irien_bucket.name
+  bucket = google_storage_bucket.gcf_source_bucket.name
   source = "${path.module}/cloud-functions/get-api-key-credit/get-api-key-credit.zip"
 }
 
@@ -127,7 +135,7 @@ resource "google_cloudfunctions_function" "get_api_key_credit" {
   description = "Returns credit for an API key"
   runtime     = "nodejs20"
   available_memory_mb   = 128
-  source_archive_bucket = google_storage_bucket.irien_bucket.name
+  source_archive_bucket = google_storage_bucket.gcf_source_bucket.name
   source_archive_object = google_storage_bucket_object.get_api_key_credit.name
   entry_point = "handler"
   trigger_http = true


### PR DESCRIPTION
## Summary
- add a bucket specifically for Google Cloud Function archives
- reference the new bucket when uploading the function zip
- document the extra bucket in infrastructure README

## Testing
- `npm run lint`
- `npm test` *(fails to keep branch coverage at 100%)*

------
https://chatgpt.com/codex/tasks/task_e_6874ac9befb0832e87b6f67631ef451f