### PR TITLE
Fix lint warning in API key credit function

### DIFF
--- a/infra/cloud-functions/get-api-key-credit/index.js
+++ b/infra/cloud-functions/get-api-key-credit/index.js
@@ -66,15 +66,22 @@ async function safeFetchCredit(uuid) {
 }
 
 /**
+ * Extract the UUID from the request parameters or query string.
+ * @param {object} req - Express request object.
+ * @returns {string|undefined} The UUID when present.
+ */
+function getUuid(req) {
+  return req.params.uuid || req.query.uuid;
+}
+
+/**
  * HTTP Cloud Function to retrieve credit data associated with an API key.
  * @param {object} req - Express request object.
  * @param {object} res - Express response object.
  * @returns {Promise<void>} Response with credit value or error code.
  */
 export async function handler(req, res) {
-  const { uuid: paramUuid } = req.params || {};
-  const { uuid: queryUuid } = req.query || {};
-  const uuid = paramUuid || queryUuid;
+  const uuid = getUuid(req);
 
   if (!uuid) {
     sendBadRequest(res, 'Missing UUID');


### PR DESCRIPTION
## Summary
- remove param and query destructuring in `get-api-key-credit` handler
- add `getUuid` helper to extract uuid
- ensure lint passes without warnings

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6874ae082cd4832eb8ce62797182fe2d