### PR TITLE
Add Firestore config

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -17,6 +17,11 @@ Cloud Functions API is enabled via a `google_project_service` resource, and the
 Cloud Build API is also enabled so that functions can be built from source. The
 resources for this function are defined directly in `main.tf`.
 
+Firestore security rules and composite indexes for the Dendrite collections are
+defined in `dendrite-firestore.tf`. The rules file lives in `rules/firestore.rules`
+and is released through Terraform to ensure consistent access control across
+environments.
+
 ## Import Targets
 
 The `import_targets.json` file lists any existing resources that should be

--- a/infra/dendrite-firestore.tf
+++ b/infra/dendrite-firestore.tf
@@ -1,0 +1,73 @@
+# Firestore security rules and indexes for Dendrite
+
+data "local_file" "firestore_rules" {
+  filename = "${path.module}/rules/firestore.rules"
+}
+
+resource "google_firebaserules_ruleset" "firestore" {
+  project = var.project_id
+  source {
+    files {
+      name    = "firestore.rules"
+      content = data.local_file.firestore_rules.content
+    }
+  }
+}
+
+resource "google_firebaserules_release" "firestore" {
+  name    = "firestore.rules"
+  project = var.project_id
+  ruleset = google_firebaserules_ruleset.firestore.id
+}
+
+resource "google_firestore_index" "variants_author_created" {
+  project     = var.project_id
+  collection  = "variants"
+  query_scope = "COLLECTION"
+
+  fields {
+    field_path = "authorId"
+    order      = "ASCENDING"
+  }
+  fields {
+    field_path = "createdAt"
+    order      = "DESCENDING"
+  }
+}
+
+resource "google_firestore_index" "options_by_source" {
+  project     = var.project_id
+  collection  = "options"
+  query_scope = "COLLECTION"
+
+  fields {
+    field_path = "sourceVariantId"
+    order      = "ASCENDING"
+  }
+}
+
+resource "google_firestore_index" "ratings_by_variant" {
+  project     = var.project_id
+  collection  = "moderationRatings"
+  query_scope = "COLLECTION"
+
+  fields {
+    field_path = "variantId"
+    order      = "ASCENDING"
+  }
+  fields {
+    field_path = "ratedAt"
+    order      = "DESCENDING"
+  }
+}
+
+resource "google_firestore_index" "story_stats_variantcount" {
+  project     = var.project_id
+  collection  = "storyStats"
+  query_scope = "COLLECTION"
+
+  fields {
+    field_path = "variantCount"
+    order      = "DESCENDING"
+  }
+}

--- a/infra/rules/firestore.rules
+++ b/infra/rules/firestore.rules
@@ -1,0 +1,101 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{db}/documents {
+
+    /*──────────────────────────────
+      PUBLIC LEADERBOARD STATS
+      • Written exclusively by back-end code (Admin SDK bypasses rules)
+      • Everyone may read
+    ──────────────────────────────*/
+    match /storyStats/{storyId} {
+      allow read:   if true;
+      allow write:  if false;   // locked to clients
+      allow delete: if false;
+    }
+
+    /*──────────────────────────────
+      USER PROFILES
+      • Anyone can read
+      • A signed-in user may create their own doc once
+      • Immutable thereafter
+    ──────────────────────────────*/
+    match /users/{userId} {
+      allow read:   if true;
+      allow create: if request.auth != null && request.auth.uid == userId;
+      allow update, delete: if false;
+    }
+
+    /*──────────────────────────────
+      STORY → PAGE → VARIANT GRAPH
+    ──────────────────────────────*/
+    match /stories/{storyId} {
+      /*  STORIES  */
+      allow read, create:  if true;  // open platform
+      allow update, delete: if false; // stories are immutable
+
+      match /pages/{pageId} {
+        /*  PAGES  */
+        allow read, create: if true;
+
+        /*  Exactly-once update: set incomingOptionId
+            - incomingOptionId must currently be null
+            - it’s the ONLY field that may change
+            - new value must be a string
+        */
+        allow update: if
+          resource.data.incomingOptionId == null &&
+          request.resource.data.diff(resource.data).changedKeys()
+                .hasOnly(['incomingOptionId']) &&
+          request.resource.data.incomingOptionId is string;
+
+        allow delete: if false;
+
+        match /variants/{variantId} {
+          /*  VARIANTS  */
+          allow read, create: if true;      // anyone can branch
+          allow update, delete: if false;   // immutable snapshots
+
+          match /options/{optionId} {
+            /*  OPTIONS  */
+            allow read, create: if true;
+
+            /*  Exactly-once update: stitch option to a target page
+                - targetPageId must currently be null
+                - it’s the ONLY field that may change
+                - new value must be a string
+            */
+            allow update: if
+              resource.data.targetPageId == null &&
+              request.resource.data.diff(resource.data).changedKeys()
+                    .hasOnly(['targetPageId']) &&
+              request.resource.data.targetPageId is string;
+
+            allow delete: if false;
+          }
+
+          match /moderationRatings/{moderatorId} {
+            /*  MODERATION  */
+            allow read: if true;
+
+            /*  Create blank rating (rating == null) — must be signed-in user */
+            allow create: if
+              request.auth != null &&
+              request.auth.uid == moderatorId &&
+              request.resource.data.rating == null;
+
+            /*  Exactly-once update: write final rating  */
+            allow update: if
+              request.auth != null &&
+              request.auth.uid == moderatorId &&
+              resource.data.rating == null &&
+              request.resource.data.diff(resource.data).changedKeys()
+                    .hasOnly(['rating']) &&
+              request.resource.data.rating in ['approved', 'rejected'];
+
+            allow delete: if false;
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- define Firestore rules and release through Terraform
- add composite indexes for Dendrite collections
- document Firestore setup in infra README

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687525529f70832e866d76b9569dc921