### PR TITLE
Enable Firebase Rules API and import static bucket

### DIFF
--- a/infra/dendrite-firestore.tf
+++ b/infra/dendrite-firestore.tf
@@ -12,6 +12,7 @@ resource "google_firebaserules_ruleset" "firestore" {
       content = data.local_file.firestore_rules.content
     }
   }
+  depends_on = [google_project_service.firebaserules]
 }
 
 resource "google_firebaserules_release" "firestore" {

--- a/infra/import_targets.json
+++ b/infra/import_targets.json
@@ -26,5 +26,21 @@
       "role": "roles/cloudfunctions.invoker",
       "member": "allUsers"
     }
+  },
+  {
+    "resource": "google_storage_bucket.dendrite_static",
+    "id": "dendrite-static"
+  },
+  {
+    "resource": "google_storage_bucket_iam_member.dendrite_public_read_access",
+    "parts": {
+      "bucket": "dendrite-static",
+      "role": "roles/storage.objectViewer",
+      "member": "allUsers"
+    }
+  },
+  {
+    "resource": "google_project_service.firebaserules",
+    "id": "projects/irien-465710/services/firebaserules.googleapis.com"
   }
 ]

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -84,6 +84,11 @@ resource "google_project_service" "cloudbuild" {
   service = "cloudbuild.googleapis.com"
 }
 
+resource "google_project_service" "firebaserules" {
+  project = var.project_id
+  service = "firebaserules.googleapis.com"
+}
+
 
 resource "google_firestore_database" "default" {
   project     = var.project_id
@@ -120,6 +125,12 @@ resource "google_project_iam_member" "terraform_set_iam_policy" {
 resource "google_project_iam_member" "terraform_create_sa" {
   project = var.project_id
   role    = "roles/iam.serviceAccountAdmin"
+  member  = "serviceAccount:terraform@${var.project_id}.iam.gserviceaccount.com"
+}
+
+resource "google_project_iam_member" "ci_firebaserules_admin" {
+  project = var.project_id
+  role    = "roles/firebaserules.admin"
   member  = "serviceAccount:terraform@${var.project_id}.iam.gserviceaccount.com"
 }
 


### PR DESCRIPTION
## Summary
- import existing dendrite static bucket
- import public IAM binding for the bucket
- enable the Firebase Rules API
- grant Firebaserules admin permissions to the CI service account
- ensure ruleset depends on the API

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68753b5aba44832e91ac75dbf6b773e1