### PR TITLE
Fix BigInt stringification in prettyFloat

### DIFF
--- a/src/toys/2025-03-26/prettyFloat.js
+++ b/src/toys/2025-03-26/prettyFloat.js
@@ -54,8 +54,8 @@ function getIEEEDecomposition(num) {
  * @returns {string} Formatted output string.
  */
 function formatFloatDecomposition(decimal, { B, C }) {
-  const significand = String(B);
-  const exponent = String(C);
+  const significand = B.toString();
+  const exponent = C.toString();
   return `${decimal} (${significand} × 2^${exponent})`;
 }
 


### PR DESCRIPTION
## Summary
- use `toString()` when converting BigInts in `formatFloatDecomposition`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68753c0a01b8832eb4ff8c7ca6785094