### PR TITLE
Update Firestore ruleset dependencies and import indexes

### DIFF
--- a/infra/dendrite-firestore.tf
+++ b/infra/dendrite-firestore.tf
@@ -12,7 +12,10 @@ resource "google_firebaserules_ruleset" "firestore" {
       content = data.local_file.firestore_rules.content
     }
   }
-  depends_on = [google_project_service.firebaserules]
+  depends_on = [
+    google_project_service.firebaserules,
+    google_project_iam_member.ci_firebaserules_admin,
+  ]
 }
 
 resource "google_firebaserules_release" "firestore" {

--- a/infra/import_targets.json
+++ b/infra/import_targets.json
@@ -42,5 +42,13 @@
   {
     "resource": "google_project_service.firebaserules",
     "id": "projects/irien-465710/services/firebaserules.googleapis.com"
+  },
+  {
+    "resource": "google_firestore_index.variants_author_created",
+    "id": "projects/irien-465710/databases/(default)/collectionGroups/variants/indexes/CICAgJiUpoMK"
+  },
+  {
+    "resource": "google_firestore_index.ratings_by_variant",
+    "id": "projects/irien-465710/databases/(default)/collectionGroups/moderationRatings/indexes/CICAgOjXh4EK"
   }
 ]


### PR DESCRIPTION
## Summary
- ensure Firestore rules wait for IAM binding by adding dependency on `google_project_iam_member.ci_firebaserules_admin`
- list existing Firestore indexes in `import_targets.json` for Terraform import

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687545fb0e64832e8b995ab1e6e9abaa