### PR TITLE
Update Terraform imports and dependencies

### DIFF
--- a/infra/dendrite-firestore.tf
+++ b/infra/dendrite-firestore.tf
@@ -22,6 +22,10 @@ resource "google_firebaserules_release" "firestore" {
   project      = var.project_id
   name         = "firestore.rules"
   ruleset_name = google_firebaserules_ruleset.firestore.name
+
+  depends_on = [
+    google_project_iam_member.ci_firebaserules_admin   # ensure role is live
+  ]
 }
 
 resource "google_firestore_index" "variants_author_created" {

--- a/infra/import_targets.json
+++ b/infra/import_targets.json
@@ -34,7 +34,7 @@
   {
     "resource": "google_storage_bucket_iam_member.dendrite_public_read_access",
     "parts": {
-      "bucket": "dendrite-static",
+      "resource": "dendrite-static",
       "role": "roles/storage.objectViewer",
       "member": "allUsers"
     }


### PR DESCRIPTION
## Summary
- use `resource` instead of `bucket` in `import_targets.json`
- ensure firestore rules release waits for admin role

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68754889b0bc832eb619132d13d4b061