### PR TITLE
Add submit-new-story Cloud Function

### DIFF
--- a/.github/workflows/deploy-terraform.yml
+++ b/.github/workflows/deploy-terraform.yml
@@ -71,6 +71,11 @@ jobs:
           zip -r get-api-key-credit.zip . -x '*.zip'
           cd -
 
+          echo "Zipping submit-new-story function..."
+          cd cloud-functions/submit-new-story
+          zip -r submit-new-story.zip . -x '*.zip'
+          cd -
+
       - name: Terraform Plan
         run: terraform plan -out=tfplan
 

--- a/infra/cloud-functions/submit-new-story/package.json
+++ b/infra/cloud-functions/submit-new-story/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "submit-new-story",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.js",
+  "dependencies": {
+    "firebase-admin": "^11.10.1",
+    "firebase-functions": "^4.4.1",
+    "express": "^4.19.2",
+    "cors": "^2.8.5"
+  }
+}

--- a/infra/import_targets.json
+++ b/infra/import_targets.json
@@ -28,6 +28,18 @@
     }
   },
   {
+    "resource": "google_cloudfunctions_function.submit_new_story",
+    "id": "projects/irien-465710/locations/europe-west3/functions/submit-new-story"
+  },
+  {
+    "resource": "google_cloudfunctions_function_iam_member.submit_new_story_invoker",
+    "parts": {
+      "resource": "projects/irien-465710/locations/europe-west3/functions/submit-new-story",
+      "role": "roles/cloudfunctions.invoker",
+      "member": "allUsers"
+    }
+  },
+  {
     "resource": "google_storage_bucket.dendrite_static",
     "id": "dendrite-static"
   },


### PR DESCRIPTION
## Summary
- implement `submit-new-story` Cloud Function
- add Terraform deployment resources
- zip new function in deploy workflow
- reference region variable in Terraform resources

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687561f70a18832ead8123fa1485f337