### PR TITLE
Fix Cloud Function packaging and Firestore rules

### DIFF
--- a/infra/cloud-functions/submit-new-story/index.js
+++ b/infra/cloud-functions/submit-new-story/index.js
@@ -1,11 +1,12 @@
 import * as functions from 'firebase-functions';
-import * as admin from 'firebase-admin';
+import { initializeApp } from 'firebase-admin/app';
+import { getFirestore, FieldValue } from 'firebase-admin/firestore';
 import crypto from 'crypto';
 import express from 'express';
 import cors from 'cors';
 
-admin.initializeApp();
-const db = admin.firestore();
+initializeApp();
+const db = getFirestore();
 const app = express();
 
 const allowed = ['https://mattheard.net', 'https://dendritestories.co.nz'];
@@ -50,7 +51,7 @@ async function handleSubmit(req, res) {
     content,
     options,
     processed: false,
-    createdAt: admin.firestore.FieldValue.serverTimestamp(),
+    createdAt: FieldValue.serverTimestamp(),
   });
 
   res.status(201).json({ id, title, content, options });

--- a/infra/dendrite-firestore.tf
+++ b/infra/dendrite-firestore.tf
@@ -23,6 +23,10 @@ resource "google_firebaserules_release" "firestore" {
   name         = "firestore.rules"
   ruleset_name = google_firebaserules_ruleset.firestore.name
 
+  lifecycle {
+    ignore_changes = [ ruleset_name ]
+  }
+
   depends_on = [
     google_project_iam_member.ci_firebaserules_admin   # ensure role is live
   ]

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -218,7 +218,7 @@ resource "google_cloudfunctions_function" "submit_new_story" {
   trigger_http                 = true
   https_trigger_security_level = "SECURE_ALWAYS"
   service_account_email = google_service_account.cloud_function_runtime.email
-  region = var.region
+  region = "europe-west3"
 
   depends_on = [
     google_project_service.cloudfunctions,
@@ -231,7 +231,7 @@ resource "google_cloudfunctions_function" "submit_new_story" {
 
 resource "google_cloudfunctions_function_iam_member" "submit_new_story_invoker" {
   project        = var.project_id
-  region         = var.region
+  region         = "europe-west3"
   cloud_function = google_cloudfunctions_function.submit_new_story.name
   role           = "roles/cloudfunctions.invoker"
   member         = "allUsers"


### PR DESCRIPTION
## Summary
- use modular Firebase Admin imports
- deploy submit-new-story function in europe-west3
- ignore Firestore release changes in Terraform

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6875f8caf040832e985eba4beb60f676