### PR TITLE
Update import targets for firestore rules

### DIFF
--- a/infra/import_targets.json
+++ b/infra/import_targets.json
@@ -56,6 +56,10 @@
     "id": "projects/irien-465710/services/firebaserules.googleapis.com"
   },
   {
+    "resource": "google_firebaserules_release.firestore",
+    "id": "projects/irien-465710/releases/firestore.rules"
+  },
+  {
     "resource": "google_firestore_index.variants_author_created",
     "id": "projects/irien-465710/databases/(default)/collectionGroups/variants/indexes/CICAgJiUpoMK"
   },


### PR DESCRIPTION
## Summary
- prevent duplicate creation of Firestore rules by importing the existing release

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6875fbc62540832eaa16c7a65a7d9c2d