### PR TITLE
Fix Firestore rules import id

### DIFF
--- a/infra/import_targets.json
+++ b/infra/import_targets.json
@@ -53,7 +53,7 @@
   },
   {
     "resource": "google_project_service.firebaserules",
-    "id": "projects/irien-465710/services/firebaserules.googleapis.com"
+    "id": "irien-465710/firebaserules.googleapis.com"
   },
   {
     "resource": "google_firebaserules_release.firestore",


### PR DESCRIPTION
## Summary
- fix the ID for the `google_project_service.firebaserules` resource in `infra/import_targets.json`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687601be7f08832eb23a5b85dc6e1002