### PR TITLE
Fix lint eqeqeq warning

### DIFF
--- a/infra/cloud-functions/submit-new-story/index.js
+++ b/infra/cloud-functions/submit-new-story/index.js
@@ -36,7 +36,7 @@ async function handleSubmit(req, res) {
   const options = [];
   for (let i = 0; i < 4; i += 1) {
     const raw = req.body[`option${i}`];
-    if (raw == null) {
+    if (raw === undefined || raw === null) {
       continue;
     }
     const val = raw.toString().trim().slice(0, 120);


### PR DESCRIPTION
## Summary
- remove loose equality comparison in submit-new-story Cloud Function

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687603ad11c8832ea54bf29cf675d2c4