### PR TITLE
Add process-new-story function

### DIFF
--- a/.github/workflows/deploy-terraform.yml
+++ b/.github/workflows/deploy-terraform.yml
@@ -76,6 +76,11 @@ jobs:
           zip -r submit-new-story.zip . -x '*.zip'
           cd -
 
+          echo "Zipping process-new-story function..."
+          cd cloud-functions/process-new-story
+          zip -r process-new-story.zip . -x '*.zip'
+          cd -
+
       - name: Terraform Plan
         run: terraform plan -out=tfplan
 

--- a/cloud-functions/process-new-story/index.js
+++ b/cloud-functions/process-new-story/index.js
@@ -1,0 +1,60 @@
+import { initializeApp } from 'firebase-admin/app';
+import { getFirestore, FieldValue } from 'firebase-admin/firestore';
+import * as functions from 'firebase-functions';
+
+initializeApp();
+const db = getFirestore();
+
+export const processNewStory = functions
+  .region('europe-west1')
+  .firestore.document('storyFormSubmissions/{subId}')
+  .onCreate(async (snap, ctx) => {
+    const sub = snap.data();
+    if (sub.processed) {
+      return null;
+    }
+
+    const storyId = ctx.params.subId;
+    const pageId = 'p1';
+    const variantId = 'vA';
+
+    const storyRef = db.doc(`stories/${storyId}`);
+    const pageRef = storyRef.collection('pages').doc(pageId);
+    const variantRef = pageRef.collection('variants').doc(variantId);
+
+    const batch = db.batch();
+    batch.set(storyRef, {
+      title: sub.title,
+      rootPage: pageRef,
+      createdAt: FieldValue.serverTimestamp(),
+    });
+
+    batch.set(pageRef, {
+      pageNumber: 1,
+      incomingOptionId: null,
+      createdAt: FieldValue.serverTimestamp(),
+    });
+
+    batch.set(variantRef, {
+      pageLetter: 'A',
+      content: sub.content,
+      authorId: null,
+      incomingOptionId: null,
+      createdAt: FieldValue.serverTimestamp(),
+    });
+
+    sub.options.forEach((text, i) => {
+      const optionRef = variantRef.collection('options').doc(`o${i + 1}`);
+      batch.set(optionRef, {
+        content: text,
+        targetPageId: null,
+        createdAt: FieldValue.serverTimestamp(),
+      });
+    });
+
+    batch.set(db.doc(`storyStats/${storyId}`), { variantCount: 1 });
+    batch.update(snap.ref, { processed: true });
+
+    await batch.commit();
+    return null;
+  });

--- a/cloud-functions/process-new-story/package.json
+++ b/cloud-functions/process-new-story/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "process-new-story",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.js",
+  "dependencies": {
+    "firebase-admin": "^11.10.1",
+    "firebase-functions": "^4.4.1"
+  }
+}


### PR DESCRIPTION
## Summary
- add a new `process-new-story` Cloud Function under `cloud-functions`
- zip the new function in the deployment workflow

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68760f6f92ec832e9e1b4e174d7d9874