### PR TITLE
Remove processed flag on new submissions

### DIFF
--- a/infra/cloud-functions/submit-new-story/index.js
+++ b/infra/cloud-functions/submit-new-story/index.js
@@ -52,7 +52,6 @@ async function handleSubmit(req, res) {
     content,
     author,
     options,
-    processed: false,
     createdAt: FieldValue.serverTimestamp(),
   });
 


### PR DESCRIPTION
## Summary
- stop adding a `processed` field when creating `storyFormSubmissions`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687615a28850832ea4d150ab20cbed0b