### PR TITLE
Update terraform backend bucket

### DIFF
--- a/.github/workflows/deploy-terraform.yml
+++ b/.github/workflows/deploy-terraform.yml
@@ -36,7 +36,7 @@ jobs:
           terraform_version: 1.6.6
 
       - name: Terraform Init
-        run: terraform init
+        run: terraform init -reconfigure
 
       - name: Import resources
         working-directory: infra

--- a/infra/README.md
+++ b/infra/README.md
@@ -33,6 +33,6 @@ used for resources that require multiple ID components, providing `resource`,
 ## Remote State
 
 Terraform stores its state in a Google Cloud Storage bucket. The backend is
-defined in `backend.tf` and expects a bucket named `tfstate-irien-465710` with a
+defined in `backend.tf` and expects a bucket named `terraform-state-irien-465710` with a
 `terraform/state` prefix. Ensure this bucket exists before running
-`terraform init` so that the remote state can be initialized.
+`terraform init -reconfigure` so that the remote state can be initialized.

--- a/infra/backend.tf
+++ b/infra/backend.tf
@@ -1,6 +1,6 @@
 terraform {
   backend "gcs" {
-    bucket = "tfstate-irien-465710"
+    bucket = "terraform-state-irien-465710"
     prefix = "terraform/state"
   }
 }


### PR DESCRIPTION
## Summary
- point terraform state backend to the new GCS bucket
- document how to reconfigure the backend
- use `terraform init -reconfigure` in the deploy workflow

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68761a2a0f9c832e832e453a5e376c9b