### PR TITLE
Remove reconfigure option from Terraform init

### DIFF
--- a/.github/workflows/deploy-terraform.yml
+++ b/.github/workflows/deploy-terraform.yml
@@ -36,7 +36,7 @@ jobs:
           terraform_version: 1.6.6
 
       - name: Terraform Init
-        run: terraform init -reconfigure
+        run: terraform init
 
       - name: Terraform Plan
         run: terraform plan -out=tfplan

--- a/infra/README.md
+++ b/infra/README.md
@@ -27,4 +27,4 @@ environments.
 Terraform stores its state in a Google Cloud Storage bucket. The backend is
 defined in `backend.tf` and expects a bucket named `terraform-state-irien-465710` with a
 `terraform/state` prefix. Ensure this bucket exists before running
-`terraform init -reconfigure` so that the remote state can be initialized.
+`terraform init` so that the remote state can be initialized.


### PR DESCRIPTION
## Summary
- remove the `-reconfigure` flag from Terraform initialization
- update docs for initializing remote state

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68763de28f84832e89016f5e90ce3148