### PR TITLE
Update page & variant fields

### DIFF
--- a/infra/cloud-functions/process-new-story/index.js
+++ b/infra/cloud-functions/process-new-story/index.js
@@ -30,13 +30,13 @@ export const processNewStory = functions
     });
 
     batch.set(pageRef, {
-      pageNumber: 1,
+      number: 1,
       incomingOptionId: null,
       createdAt: FieldValue.serverTimestamp(),
     });
 
     batch.set(variantRef, {
-      pageLetter: 'A',
+      name: 'a',
       content: sub.content,
       authorId: null,
       incomingOptionId: null,


### PR DESCRIPTION
## Summary
- use `number` for page documents
- use `name` for variant documents
- change initial variant name to lowercase `a`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68766e5c79fc832e897881a1158f1b29