### PR TITLE
Add Firestore index for pages number

### DIFF
--- a/infra/dendrite-firestore.tf
+++ b/infra/dendrite-firestore.tf
@@ -63,3 +63,14 @@ resource "google_firestore_index" "ratings_by_variant" {
   }
 }
 
+resource "google_firestore_index" "pages_number_global" {
+  project     = var.project_id
+  collection  = "pages"
+  query_scope = "COLLECTION_GROUP"
+
+  fields {
+    field_path = "number"
+    order      = "ASCENDING"
+  }
+}
+


### PR DESCRIPTION
## Summary
- create collection group index on the `pages` collection by page number

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68766fc40b98832e94028d2f173a7850