### PR TITLE
Use single-field index for pages number

### DIFF
--- a/infra/dendrite-firestore.tf
+++ b/infra/dendrite-firestore.tf
@@ -63,14 +63,18 @@ resource "google_firestore_index" "ratings_by_variant" {
   }
 }
 
-resource "google_firestore_index" "pages_number_global" {
-  project     = var.project_id
-  collection  = "pages"
-  query_scope = "COLLECTION_GROUP"
+resource "google_firestore_field" "pages_number_global" {
+  provider   = google-beta
+  project    = var.project_id
+  database   = "(default)"
+  collection = "pages"
+  field      = "number"
 
-  fields {
-    field_path = "number"
-    order      = "ASCENDING"
+  index_config {
+    indexes {
+      order       = "ASCENDING"
+      query_scope = "COLLECTION_GROUP"
+    }
   }
 }
 

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -4,10 +4,19 @@ terraform {
       source  = "hashicorp/google"
       version = "~> 5.0"
     }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 5.0"
+    }
   }
 }
 
 provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+provider "google-beta" {
   project = var.project_id
   region  = var.region
 }


### PR DESCRIPTION
## Summary
- use google-beta provider in Terraform
- switch pages collection group number index to a single field configuration

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687674d33764832ea41727222f54ec26