### PR TITLE
Use random UUIDs for option documents

### DIFF
--- a/infra/cloud-functions/process-new-story/index.js
+++ b/infra/cloud-functions/process-new-story/index.js
@@ -60,8 +60,10 @@ export const processNewStory = functions
       createdAt: FieldValue.serverTimestamp(),
     });
 
-    sub.options.forEach((text, i) => {
-      const optionRef = variantRef.collection('options').doc(`o${i + 1}`);
+    sub.options.forEach(text => {
+      const optionRef = variantRef
+        .collection('options')
+        .doc(crypto.randomUUID());
       batch.set(optionRef, {
         content: text,
         targetPageId: null,


### PR DESCRIPTION
## Summary
- update `process-new-story` cloud function to give each new option document a random uuid

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687691a485b8832e9e942cfd407ae66e