### PR TITLE
Add force_destroy to dendrite static bucket

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -56,6 +56,7 @@ resource "google_storage_bucket_iam_member" "public_read_access" {
 resource "google_storage_bucket" "dendrite_static" {
   name     = "www.dendritestories.co.nz"
   location = var.region
+  force_destroy = true
 }
 
 resource "google_storage_bucket_object" "dendrite_index" {


### PR DESCRIPTION
## Summary
- allow destroying the dendrite_static bucket without manual cleanup

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687752e6f9d8832eab7c118c20776135