### PR TITLE
Restore dendrite bucket name

### DIFF
--- a/infra/cloud-functions/render-contents/index.js
+++ b/infra/cloud-functions/render-contents/index.js
@@ -91,7 +91,7 @@ export const renderContents = functions
     }
     const html = buildHtml(items);
     await storage
-      .bucket('www.dendritestories.co.nz')
+      .bucket('dendrite-static')
       .file('index.html')
       .save(html, { contentType: 'text/html' });
     return null;

--- a/infra/cloud-functions/render-variant/index.js
+++ b/infra/cloud-functions/render-variant/index.js
@@ -54,7 +54,7 @@ export const renderVariant = functions
     const filePath = `p/${page.number}${variant.name}.html`;
 
     await storage
-      .bucket('www.dendritestories.co.nz')
+      .bucket('dendrite-static')
       .file(filePath)
       .save(html, { contentType: 'text/html' });
 

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -54,7 +54,7 @@ resource "google_storage_bucket_iam_member" "public_read_access" {
 }
 
 resource "google_storage_bucket" "dendrite_static" {
-  name     = "www.dendritestories.co.nz"
+  name     = "dendrite-static"
   location = var.region
   force_destroy = true
 }


### PR DESCRIPTION
## Summary
- fix `dendrite_static` bucket naming
- update render functions to use the bucket name

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6877f5fc2864832e8ca311eee7195230