### PR TITLE
Remove force_destroy from dendrite bucket

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -56,7 +56,10 @@ resource "google_storage_bucket_iam_member" "public_read_access" {
 resource "google_storage_bucket" "dendrite_static" {
   name     = "www.dendritestories.co.nz"
   location = var.region
-  force_destroy = true
+
+  lifecycle {
+    prevent_destroy = true     # prod safety belt
+  }
 }
 
 resource "google_storage_bucket_object" "dendrite_index" {


### PR DESCRIPTION
## Summary
- remove the `force_destroy` flag from the dendrite static bucket to avoid accidental deletion

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687805466504832e84f8f5a2abf3f4a7