### PR TITLE
Add submit-new-page cloud function

### DIFF
--- a/infra/cloud-functions/submit-new-page/index.js
+++ b/infra/cloud-functions/submit-new-page/index.js
@@ -1,0 +1,81 @@
+import * as functions from 'firebase-functions';
+import { initializeApp } from 'firebase-admin/app';
+import { getFirestore, FieldValue } from 'firebase-admin/firestore';
+import crypto from 'crypto';
+import express from 'express';
+import cors from 'cors';
+
+initializeApp();
+const db = getFirestore();
+const app = express();
+
+const allowed = ['https://mattheard.net', 'https://dendritestories.co.nz'];
+app.use(
+  cors({
+    origin: (origin, cb) => {
+      if (!origin || allowed.includes(origin)) {
+        cb(null, true);
+      } else {
+        cb(new Error('CORS'));
+      }
+    },
+    methods: ['POST'],
+  })
+);
+
+app.use(express.urlencoded({ extended: false, limit: '20kb' }));
+
+/**
+ * Handle new page submissions.
+ * @param {import('express').Request} req HTTP request object.
+ * @param {import('express').Response} res HTTP response object.
+ * @returns {Promise<void>} Promise resolving when response is sent.
+ */
+async function handleSubmit(req, res) {
+  let {
+    incoming_option: incomingOption,
+    content = '',
+    author = '???',
+  } = req.body;
+  incomingOption = incomingOption?.toString().trim().slice(0, 120) || '';
+  content = content.toString().trim().slice(0, 10_000);
+  author = author.toString().trim().slice(0, 120);
+
+  const options = [];
+  for (let i = 0; i < 4; i += 1) {
+    const raw = req.body[`option${i}`];
+    if (raw === undefined || raw === null) {
+      continue;
+    }
+    const val = raw.toString().trim().slice(0, 120);
+    if (val) {
+      options.push(val);
+    }
+  }
+
+  const id = crypto.randomUUID();
+  await db
+    .collection('pageFormSubmissions')
+    .doc(id)
+    .set({
+      incomingOptionId: incomingOption || null,
+      content,
+      author,
+      options,
+      createdAt: FieldValue.serverTimestamp(),
+    });
+
+  res.status(201).json({
+    id,
+    incomingOptionId: incomingOption || null,
+    content,
+    author,
+    options,
+  });
+}
+
+app.post('/', handleSubmit);
+
+export const submitNewPage = functions
+  .region('europe-west1')
+  .https.onRequest(app);

--- a/infra/cloud-functions/submit-new-page/package.json
+++ b/infra/cloud-functions/submit-new-page/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "submit-new-page",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.js",
+  "dependencies": {
+    "firebase-admin": "^11.10.1",
+    "firebase-functions": "^4.4.1",
+    "express": "^4.19.2",
+    "cors": "^2.8.5"
+  }
+}


### PR DESCRIPTION
## Summary
- add submit-new-page Cloud Function for new page submissions
- upload submit-new-page archive via Terraform configuration
- deploy submit-new-page cloud function and IAM permissions

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687807d36f58832e9473f8ecd0abc534