### PR TITLE
Fix dendrite index lifecycle

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -75,11 +75,7 @@ resource "google_storage_bucket_object" "dendrite_index" {
 
   lifecycle {
     ignore_changes = [
-      content,
-      md5hash,
-      crc32c,
-      generation,
-      metageneration,
+      content
     ]
   }
 }


### PR DESCRIPTION
## Summary
- simplify `ignore_changes` for dendrite index bucket object to avoid plan failures

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687a5997ad20832e88f75fb2593fb077