### PR TITLE
Add JSON body parsing for submission Cloud Functions

### DIFF
--- a/infra/cloud-functions/submit-new-page/index.js
+++ b/infra/cloud-functions/submit-new-page/index.js
@@ -23,6 +23,7 @@ app.use(
   })
 );
 
+app.use(express.json({ limit: '20kb' }));
 app.use(express.urlencoded({ extended: false, limit: '20kb' }));
 
 /**

--- a/infra/cloud-functions/submit-new-story/index.js
+++ b/infra/cloud-functions/submit-new-story/index.js
@@ -23,6 +23,7 @@ app.use(
   })
 );
 
+app.use(express.json({ limit: '20kb' }));
 app.use(express.urlencoded({ extended: false, limit: '20kb' }));
 
 /**


### PR DESCRIPTION
## Summary
- parse JSON payloads alongside form data in submission functions

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687f853506f8832ebf02cb117622ffea