### PR TITLE
Handle incoming option lookup

### DIFF
--- a/infra/cloud-functions/submit-new-page/helpers.js
+++ b/infra/cloud-functions/submit-new-page/helpers.js
@@ -1,0 +1,67 @@
+/**
+ * Parse a user supplied incoming option reference.
+ * @param {string} str Raw option string.
+ * @returns {{pageNumber: number, variantName: string, optionNumber: number}|null}
+ *   Parsed info or null when invalid.
+ */
+export function parseIncomingOption(str) {
+  if (!str) {
+    return null;
+  }
+  const parts = String(str)
+    .split(/[^0-9a-zA-Z]+/)
+    .filter(Boolean);
+  if (parts.length !== 3) {
+    return null;
+  }
+  const [pageStr, variantName, optionStr] = parts;
+  const pageNumber = Number.parseInt(pageStr, 10);
+  const optionNumber = Number.parseInt(optionStr, 10);
+  if (!Number.isInteger(pageNumber) || !Number.isInteger(optionNumber)) {
+    return null;
+  }
+  if (!variantName) {
+    return null;
+  }
+  return { pageNumber, variantName, optionNumber };
+}
+
+/**
+ * Resolve an option document by page, variant and option indices.
+ * @param {object} db Firestore database instance.
+ * @param {{pageNumber: number, variantName: string, optionNumber: number}} info
+ *   Location details.
+ * @returns {Promise<string|null>} Option identifier or null when not found.
+ */
+export async function findExistingOption(db, info) {
+  if (!db || !info) {
+    return null;
+  }
+  const pageSnap = await db
+    .collectionGroup('pages')
+    .where('number', '==', info.pageNumber)
+    .limit(1)
+    .get();
+  if (pageSnap.empty) {
+    return null;
+  }
+  const pageRef = pageSnap.docs[0].ref;
+  const variantSnap = await pageRef
+    .collection('variants')
+    .where('name', '==', info.variantName)
+    .limit(1)
+    .get();
+  if (variantSnap.empty) {
+    return null;
+  }
+  const variantRef = variantSnap.docs[0].ref;
+  const optionsSnap = await variantRef
+    .collection('options')
+    .orderBy('createdAt')
+    .limit(info.optionNumber + 1)
+    .get();
+  if (optionsSnap.size <= info.optionNumber) {
+    return null;
+  }
+  return optionsSnap.docs[info.optionNumber].id;
+}

--- a/test/cloud-functions/submitNewPageHelpers.test.js
+++ b/test/cloud-functions/submitNewPageHelpers.test.js
@@ -1,0 +1,73 @@
+import { describe, test, expect, jest } from '@jest/globals';
+import {
+  parseIncomingOption,
+  findExistingOption,
+} from '../../infra/cloud-functions/submit-new-page/helpers.js';
+
+describe('parseIncomingOption', () => {
+  test('parses valid string', () => {
+    const result = parseIncomingOption('1.a.0');
+    expect(result).toEqual({
+      pageNumber: 1,
+      variantName: 'a',
+      optionNumber: 0,
+    });
+  });
+
+  test('returns null for invalid', () => {
+    expect(parseIncomingOption('bad')).toBeNull();
+  });
+});
+
+describe('findExistingOption', () => {
+  test('returns option id when found', async () => {
+    const optionId = 'opt1';
+    const variantRef = {
+      collection: jest.fn(() => ({
+        orderBy: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        get: jest.fn().mockResolvedValue({ size: 1, docs: [{ id: optionId }] }),
+      })),
+    };
+    const pageRef = {
+      collection: jest.fn(() => ({
+        where: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        get: jest
+          .fn()
+          .mockResolvedValue({ empty: false, docs: [{ ref: variantRef }] }),
+      })),
+    };
+    const db = {
+      collectionGroup: jest.fn(() => ({
+        where: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        get: jest
+          .fn()
+          .mockResolvedValue({ empty: false, docs: [{ ref: pageRef }] }),
+      })),
+    };
+    const result = await findExistingOption(db, {
+      pageNumber: 1,
+      variantName: 'a',
+      optionNumber: 0,
+    });
+    expect(result).toBe(optionId);
+  });
+
+  test('returns null when option missing', async () => {
+    const db = {
+      collectionGroup: jest.fn(() => ({
+        where: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        get: jest.fn().mockResolvedValue({ empty: true }),
+      })),
+    };
+    const result = await findExistingOption(db, {
+      pageNumber: 1,
+      variantName: 'a',
+      optionNumber: 0,
+    });
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- parse the incoming option into page/variant/option parts
- resolve the option ID and store it with the submission
- add helpers and unit tests for new logic

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687fc2b5d7d4832e876e8d40c2d40214