### PR TITLE
Add option position metadata

### DIFF
--- a/infra/cloud-functions/process-new-page/index.js
+++ b/infra/cloud-functions/process-new-page/index.js
@@ -72,7 +72,7 @@ export const processNewPage = functions
       createdAt: FieldValue.serverTimestamp(),
     });
 
-    (sub.options || []).forEach(text => {
+    (sub.options || []).forEach((text, position) => {
       const optRef = newVariantRef
         .collection('options')
         .doc(crypto.randomUUID());
@@ -80,6 +80,7 @@ export const processNewPage = functions
         content: text,
         targetPageId: null,
         createdAt: FieldValue.serverTimestamp(),
+        position,
       });
     });
 

--- a/infra/cloud-functions/process-new-story/index.js
+++ b/infra/cloud-functions/process-new-story/index.js
@@ -60,7 +60,7 @@ export const processNewStory = functions
       createdAt: FieldValue.serverTimestamp(),
     });
 
-    sub.options.forEach(text => {
+    sub.options.forEach((text, position) => {
       const optionRef = variantRef
         .collection('options')
         .doc(crypto.randomUUID());
@@ -68,6 +68,7 @@ export const processNewStory = functions
         content: text,
         targetPageId: null,
         createdAt: FieldValue.serverTimestamp(),
+        position,
       });
     });
 


### PR DESCRIPTION
## Summary
- include `position` field when storing new options for stories and pages

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68861fda7540832eb5aa6344f9478330