### PR TITLE
Refactor render-contents HTML strings

### DIFF
--- a/infra/cloud-functions/render-contents/htmlSnippets.js
+++ b/infra/cloud-functions/render-contents/htmlSnippets.js
@@ -1,0 +1,5 @@
+export const LIST_ITEM_HTML = (pageNumber, title) =>
+  `<li><a href="./p/${pageNumber}a.html">${title}</a></li>`;
+
+export const PAGE_HTML = list =>
+  `<!doctype html><html lang="en"><head><meta charset="UTF-8" /><meta name="viewport" content="width=device-width, initial-scale=1" /><title>Dendrite</title></head><body><h1><a href="/">Dendrite</a></h1><h2>Contents</h2><ol>${list}</ol></body></html>`;

--- a/infra/cloud-functions/render-contents/index.js
+++ b/infra/cloud-functions/render-contents/index.js
@@ -2,6 +2,7 @@ import { initializeApp } from 'firebase-admin/app';
 import { getFirestore } from 'firebase-admin/firestore';
 import { Storage } from '@google-cloud/storage';
 import * as functions from 'firebase-functions';
+import { LIST_ITEM_HTML, PAGE_HTML } from './htmlSnippets.js';
 
 initializeApp();
 const db = getFirestore();
@@ -28,14 +29,9 @@ function escapeHtml(text) {
  */
 function buildHtml(items) {
   const list = items
-    .map(
-      item =>
-        `<li><a href="./p/${item.pageNumber}a.html">${escapeHtml(
-          item.title
-        )}</a></li>`
-    )
+    .map(item => LIST_ITEM_HTML(item.pageNumber, escapeHtml(item.title)))
     .join('');
-  return `<!doctype html><html lang="en"><head><meta charset="UTF-8" /><meta name="viewport" content="width=device-width, initial-scale=1" /><title>Dendrite</title></head><body><h1><a href="/">Dendrite</a></h1><h2>Contents</h2><ol>${list}</ol></body></html>`;
+  return PAGE_HTML(list);
 }
 
 /**


### PR DESCRIPTION
## Summary
- extract HTML snippets into a new constants module
- use the new constants when generating the contents page

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688a757dce90832e8975826f6f3c43fa