### PR TITLE
Add author name to new story variants

### DIFF
--- a/infra/cloud-functions/process-new-story/index.js
+++ b/infra/cloud-functions/process-new-story/index.js
@@ -56,6 +56,7 @@ export const processNewStory = functions
       name: 'a',
       content: sub.content,
       authorId: null,
+      authorName: sub.author,
       incomingOptionId: null,
       createdAt: FieldValue.serverTimestamp(),
     });


### PR DESCRIPTION
## Summary
- include `authorName` when creating the initial variant in the `processNewStory` Cloud Function

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688bbc88cabc832eba0ccf8128d1cd93