### PR TITLE
Fix new-story form and allow www CORS

### DIFF
--- a/infra/cloud-functions/submit-new-story/index.js
+++ b/infra/cloud-functions/submit-new-story/index.js
@@ -9,7 +9,11 @@ initializeApp();
 const db = getFirestore();
 const app = express();
 
-const allowed = ['https://mattheard.net', 'https://dendritestories.co.nz'];
+const allowed = [
+  'https://mattheard.net',
+  'https://dendritestories.co.nz',
+  'https://www.dendritestories.co.nz', // new: static-site domain
+];
 app.use(
   cors({
     origin: (origin, cb) => {

--- a/infra/new-story.html
+++ b/infra/new-story.html
@@ -6,7 +6,11 @@
   </head>
   <body>
     <h1>Submit a New Story</h1>
-    <form action="/submit-new-story" method="post" enctype="multipart/form-data">
+    <form
+      action="https://europe-west1-irien-465710.cloudfunctions.net/prod-submit-new-story"
+      method="post"
+      enctype="multipart/form-data"
+    >
       <div>
         <label>Title <input type="text" name="title" /></label>
       </div>


### PR DESCRIPTION
## Summary
- submit new-story form directly to the Cloud Function
- allow `https://www.dendritestories.co.nz` in submit-new-story CORS list

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688bc36722e8832eba1e1581cffa9013