### PR TITLE
Allow HTTP origin for dendritestories

### DIFF
--- a/infra/cloud-functions/submit-new-page/index.js
+++ b/infra/cloud-functions/submit-new-page/index.js
@@ -10,7 +10,11 @@ initializeApp();
 const db = getFirestore();
 const app = express();
 
-const allowed = ['https://mattheard.net', 'https://dendritestories.co.nz'];
+const allowed = [
+  'https://mattheard.net',
+  'https://dendritestories.co.nz',
+  'http://www.dendritestories.co.nz',
+];
 app.use(
   cors({
     origin: (origin, cb) => {

--- a/infra/cloud-functions/submit-new-story/index.js
+++ b/infra/cloud-functions/submit-new-story/index.js
@@ -13,6 +13,7 @@ const allowed = [
   'https://mattheard.net',
   'https://dendritestories.co.nz',
   'https://www.dendritestories.co.nz', // new: static-site domain
+  'http://www.dendritestories.co.nz',
 ];
 app.use(
   cors({


### PR DESCRIPTION
## Summary
- add `http://www.dendritestories.co.nz` to allowed origins for submit functions

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688bd892cebc832ea40fd5378fff9c80