### PR TITLE
Enable async new story submission

### DIFF
--- a/infra/cloud-functions/render-variant/index.js
+++ b/infra/cloud-functions/render-variant/index.js
@@ -59,7 +59,7 @@ function buildAltsHtml(pageNumber, variants) {
 export const renderVariant = functions
   .region('europe-west1')
   .firestore.document('stories/{storyId}/pages/{pageId}/variants/{variantId}')
-  .onCreate(async snap => {
+  .onCreate(async (snap, ctx) => {
     const variant = snap.data();
 
     const pageSnap = await snap.ref.parent.parent.get();
@@ -91,6 +91,14 @@ export const renderVariant = functions
       .bucket('www.dendritestories.co.nz')
       .file(altsPath)
       .save(altsHtml, { contentType: 'text/html' });
+
+    const pendingPath = `pending/${ctx.params.storyId}.json`;
+    await storage
+      .bucket('www.dendritestories.co.nz')
+      .file(pendingPath)
+      .save(JSON.stringify({ path: filePath }), {
+        contentType: 'application/json',
+      });
 
     return null;
   });

--- a/infra/new-story.html
+++ b/infra/new-story.html
@@ -36,6 +36,54 @@
       <div>
         <button type="submit">Submit</button>
       </div>
+      <p id="saving" style="display: none;">Saving...</p>
     </form>
+    <script>
+      document.addEventListener("DOMContentLoaded", () => {
+        const form = document.querySelector("form");
+        const button = form.querySelector("button[type='submit']");
+        const saving = document.getElementById("saving");
+
+        form.addEventListener("submit", async event => {
+          event.preventDefault();
+          button.disabled = true;
+          saving.style.display = "block";
+          let dots = 1;
+          saving.textContent = "Saving.";
+          const intervalId = setInterval(() => {
+            dots = (dots % 3) + 1;
+            saving.textContent = `Saving${".".repeat(dots)}`;
+          }, 500);
+
+          try {
+            const formData = new FormData(form);
+            const response = await fetch(form.action, {
+              method: form.method,
+              body: formData,
+            });
+            if (!response.ok) {
+              throw new Error("Submission failed");
+            }
+            const { id } = await response.json();
+            let delay = 500;
+            while (true) {
+              await new Promise(resolve => setTimeout(resolve, delay));
+              const pendingRes = await fetch(`/pending/${id}.json`);
+              if (pendingRes.ok) {
+                const data = await pendingRes.json();
+                clearInterval(intervalId);
+                window.location.href = data.path;
+                return;
+              }
+              delay = Math.min(delay * 2, 8000);
+            }
+          } catch (err) {
+            clearInterval(intervalId);
+            saving.textContent = "Failed to save.";
+            button.disabled = false;
+          }
+        });
+      });
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- automate new-story.html form submission with fetch
- poll for pending story variant creation
- write pending page path in render-variant cloud function

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688bdd4d79e4832eba5268d8bf9f2f82