### PR TITLE
Add new story link to contents page

### DIFF
--- a/infra/cloud-functions/render-contents/htmlSnippets.js
+++ b/infra/cloud-functions/render-contents/htmlSnippets.js
@@ -2,4 +2,4 @@ export const LIST_ITEM_HTML = (pageNumber, title) =>
   `<li><a href="./p/${pageNumber}a.html">${title}</a></li>`;
 
 export const PAGE_HTML = list =>
-  `<!doctype html><html lang="en"><head><meta charset="UTF-8" /><meta name="viewport" content="width=device-width, initial-scale=1" /><title>Dendrite</title></head><body><h1><a href="/">Dendrite</a></h1><h2>Contents</h2><ol>${list}</ol></body></html>`;
+  `<!doctype html><html lang="en"><head><meta charset="UTF-8" /><meta name="viewport" content="width=device-width, initial-scale=1" /><title>Dendrite</title></head><body><h1><a href="/">Dendrite</a></h1><h2>Contents</h2><ol>${list}</ol><p><a href="new-story.html">New story</a></p></body></html>`;


### PR DESCRIPTION
## Summary
- update HTML snippet to include a `New story` link after the ordered list

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688bde863c2c832ebc84ef414bed3e1d