### PR TITLE
Add Pico CSS stylesheet link to Dendrite HTML

### DIFF
--- a/infra/404.html
+++ b/infra/404.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <title>Page Not Found</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.fluid.classless.min.css" />
   </head>
   <body>
     <h1>404 - Page Not Found</h1>

--- a/infra/cloud-functions/render-contents/htmlSnippets.js
+++ b/infra/cloud-functions/render-contents/htmlSnippets.js
@@ -2,4 +2,4 @@ export const LIST_ITEM_HTML = (pageNumber, title) =>
   `<li><a href="./p/${pageNumber}a.html">${title}</a></li>`;
 
 export const PAGE_HTML = list =>
-  `<!doctype html><html lang="en"><head><meta charset="UTF-8" /><meta name="viewport" content="width=device-width, initial-scale=1" /><title>Dendrite</title></head><body><h1><a href="/">Dendrite</a></h1><h2>Contents</h2><ol>${list}</ol></body></html>`;
+  `<!doctype html><html lang="en"><head><meta charset="UTF-8" /><meta name="viewport" content="width=device-width, initial-scale=1" /><title>Dendrite</title><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.fluid.classless.min.css" /></head><body><h1><a href="/">Dendrite</a></h1><h2>Contents</h2><ol>${list}</ol></body></html>`;

--- a/infra/cloud-functions/render-variant/index.js
+++ b/infra/cloud-functions/render-variant/index.js
@@ -27,7 +27,7 @@ function escapeHtml(text) {
  */
 function buildHtml(content, options) {
   const items = options.map(opt => `<li>${escapeHtml(opt)}</li>`).join('');
-  return `<!doctype html><html lang="en"><body><h1>Dendrite</h1><p>${escapeHtml(
+  return `<!doctype html><html lang="en"><head><meta charset="UTF-8" /><title>Dendrite</title><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.fluid.classless.min.css" /></head><body><h1>Dendrite</h1><p>${escapeHtml(
     content
   )}</p><ol>${items}</ol></body></html>`;
 }
@@ -50,7 +50,7 @@ function buildAltsHtml(pageNumber, variants) {
       )}</a></li>`;
     })
     .join('');
-  return `<!doctype html><html lang="en"><body><h1><a href="/">Dendrite</a></h1><ol>${items}</ol></body></html>`;
+  return `<!doctype html><html lang="en"><head><meta charset="UTF-8" /><title>Dendrite</title><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.fluid.classless.min.css" /></head><body><h1><a href="/">Dendrite</a></h1><ol>${items}</ol></body></html>`;
 }
 
 /**

--- a/infra/index.html
+++ b/infra/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <title>Dendrite</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.fluid.classless.min.css" />
   </head>
   <body>
     <h1><a href="./index.html">Dendrite</a></h1>

--- a/infra/mod.html
+++ b/infra/mod.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Dendrite - Moderate a story page</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.fluid.classless.min.css">
 </head>
 <body>
     <h1><a href="/">Dendrite</a></h1>

--- a/infra/new-story.html
+++ b/infra/new-story.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <title>New Story</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.fluid.classless.min.css" />
   </head>
   <body>
     <h1><a href="/">Dendrite</a></h1>


### PR DESCRIPTION
## Summary
- add Pico.css link to static HTML files under `infra`
- add the same stylesheet link in HTML generated by the Dendrite cloud functions

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688bdfadc934832eaf8e18afad26fbe3