### PR TITLE
Update variant render heading link

### DIFF
--- a/infra/cloud-functions/render-variant/index.js
+++ b/infra/cloud-functions/render-variant/index.js
@@ -27,7 +27,7 @@ function escapeHtml(text) {
  */
 function buildHtml(content, options) {
   const items = options.map(opt => `<li>${escapeHtml(opt)}</li>`).join('');
-  return `<!doctype html><html lang="en"><body><h1>Dendrite</h1><p>${escapeHtml(
+  return `<!doctype html><html lang="en"><body><h1><a href="/">Dendrite</a></h1><p>${escapeHtml(
     content
   )}</p><ol>${items}</ol></body></html>`;
 }


### PR DESCRIPTION
## Summary
- make the `<h1>` heading link to `/` when rendering variant pages

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688be2078350832e9c93188440b5b9e0