### PR TITLE
Fix variant page heading link

### DIFF
--- a/infra/cloud-functions/render-variant/index.js
+++ b/infra/cloud-functions/render-variant/index.js
@@ -28,7 +28,7 @@ function escapeHtml(text) {
  */
 function buildHtml(pageNumber, content, options) {
   const items = options.map(opt => `<li>${escapeHtml(opt)}</li>`).join('');
-  return `<!doctype html><html lang="en"><head><meta charset="UTF-8" /><meta name="viewport" content="width=device-width, initial-scale=1" /><title>Dendrite</title><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.fluid.classless.min.css" /></head><body><h1>Dendrite</h1><p>${escapeHtml(
+  return `<!doctype html><html lang="en"><head><meta charset="UTF-8" /><meta name="viewport" content="width=device-width, initial-scale=1" /><title>Dendrite</title><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.fluid.classless.min.css" /></head><body><h1><a href="/">Dendrite</a></h1><p>${escapeHtml(
     content
   )}</p><ol>${items}</ol><p><a href="./${pageNumber}-alts.html">More options</a></p></body></html>`;
 }


### PR DESCRIPTION
## Summary
- link Dendrite heading on variant pages back to the homepage

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688be548bf64832ebcb4ec8bf9bbcc0e