### PR TITLE
Fix alt page link generation

### DIFF
--- a/infra/cloud-functions/render-variant/buildAltsHtml.js
+++ b/infra/cloud-functions/render-variant/buildAltsHtml.js
@@ -1,0 +1,32 @@
+/**
+ * Escape HTML special characters.
+ * @param {string} text Text to escape.
+ * @returns {string} Escaped text.
+ */
+export function escapeHtml(text) {
+  return String(text ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+/**
+ * Build HTML page listing all variants of a page.
+ * @param {number} pageNumber Page number.
+ * @param {Array<{name: string, content: string}>} variants Variant info.
+ * @returns {string} HTML page.
+ */
+export function buildAltsHtml(pageNumber, variants) {
+  const items = variants
+    .map(v => {
+      const words = String(v.content || '')
+        .split(/\s+/)
+        .slice(0, 5)
+        .join(' ');
+      return `<li><a href="/p/${pageNumber}${v.name}.html">${escapeHtml(words)}</a></li>`;
+    })
+    .join('');
+  return `<!doctype html><html lang="en"><head><meta charset="UTF-8" /><meta name="viewport" content="width=device-width, initial-scale=1" /><title>Dendrite</title><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.fluid.classless.min.css" /></head><body><h1><a href="/">Dendrite</a></h1><ol>${items}</ol></body></html>`;
+}

--- a/infra/cloud-functions/render-variant/index.js
+++ b/infra/cloud-functions/render-variant/index.js
@@ -1,23 +1,10 @@
 import { initializeApp } from 'firebase-admin/app';
 import { Storage } from '@google-cloud/storage';
 import * as functions from 'firebase-functions';
+import { buildAltsHtml, escapeHtml } from './buildAltsHtml.js';
 
 initializeApp();
 const storage = new Storage();
-
-/**
- * Escape HTML special characters.
- * @param {string} text Text to escape.
- * @returns {string} Escaped text.
- */
-function escapeHtml(text) {
-  return String(text ?? '')
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#039;');
-}
 
 /**
  * Build HTML page for the variant.
@@ -31,27 +18,6 @@ function buildHtml(pageNumber, content, options) {
   return `<!doctype html><html lang="en"><head><meta charset="UTF-8" /><meta name="viewport" content="width=device-width, initial-scale=1" /><title>Dendrite</title><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.fluid.classless.min.css" /></head><body><h1><a href="/">Dendrite</a></h1><p>${escapeHtml(
     content
   )}</p><ol>${items}</ol><p><a href="./${pageNumber}-alts.html">More options</a></p></body></html>`;
-}
-
-/**
- * Build HTML page listing all variants of a page.
- * @param {number} pageNumber Page number.
- * @param {Array<{name: string, content: string}>} variants Variant info.
- * @returns {string} HTML page.
- */
-function buildAltsHtml(pageNumber, variants) {
-  const items = variants
-    .map(v => {
-      const words = String(v.content || '')
-        .split(/\s+/)
-        .slice(0, 5)
-        .join(' ');
-      return `<li><a href="./p/${pageNumber}${v.name}.html">${escapeHtml(
-        words
-      )}</a></li>`;
-    })
-    .join('');
-  return `<!doctype html><html lang="en"><head><meta charset="UTF-8" /><meta name="viewport" content="width=device-width, initial-scale=1" /><title>Dendrite</title><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.fluid.classless.min.css" /></head><body><h1><a href="/">Dendrite</a></h1><ol>${items}</ol></body></html>`;
 }
 
 /**
@@ -103,3 +69,5 @@ export const renderVariant = functions
 
     return null;
   });
+
+export { buildAltsHtml };

--- a/test/cloud-functions/buildAltsHtml.test.js
+++ b/test/cloud-functions/buildAltsHtml.test.js
@@ -1,0 +1,9 @@
+import { describe, test, expect } from '@jest/globals';
+import { buildAltsHtml } from '../../infra/cloud-functions/render-variant/buildAltsHtml.js';
+
+describe('buildAltsHtml', () => {
+  test('links to variant pages in /p path', () => {
+    const html = buildAltsHtml(1, [{ name: 'a', content: 'hello world' }]);
+    expect(html).toContain('<a href="/p/1a.html">');
+  });
+});


### PR DESCRIPTION
## Summary
- generate alt variant links that point to `/p/1a.html`
- export `buildAltsHtml` from a new helper module
- test alt page link generation

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688c52a328fc832e8d5573cd61b8e0c2