### PR TITLE
Add load balancer role for build SA

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -182,6 +182,12 @@ resource "google_project_iam_member" "ci_firebaserules_admin" {
   member  = "serviceAccount:terraform@${var.project_id}.iam.gserviceaccount.com"
 }
 
+resource "google_project_iam_member" "build_loadbalancer_admin" {
+  project = var.project_id
+  role    = "roles/compute.loadBalancerAdmin"
+  member  = "serviceAccount:${data.google_project.project.number}@cloudbuild.gserviceaccount.com"
+}
+
 resource "google_service_account" "cloud_function_runtime" {
   account_id   = "${var.environment}-cloud-function-runtime"
   display_name = "Cloud Function Runtime Service Account"


### PR DESCRIPTION
## Summary
- give the Cloud Build service account the `roles/compute.loadBalancerAdmin` role

## Testing
- `npm test`
- `npm run lint` *(warnings only)*

------
https://chatgpt.com/codex/tasks/task_e_688c596b5b10832e85621a8cbaf784c6