### PR TITLE
Add load balancer role for terraform

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -188,6 +188,12 @@ resource "google_project_iam_member" "build_loadbalancer_admin" {
   member  = "serviceAccount:${data.google_project.project.number}@cloudbuild.gserviceaccount.com"
 }
 
+resource "google_project_iam_member" "terraform_loadbalancer_admin" {
+  project = var.project_id
+  role    = "roles/compute.loadBalancerAdmin"
+  member  = "serviceAccount:terraform@${var.project_id}.iam.gserviceaccount.com"
+}
+
 resource "google_service_account" "cloud_function_runtime" {
   account_id   = "${var.environment}-cloud-function-runtime"
   display_name = "Cloud Function Runtime Service Account"


### PR DESCRIPTION
## Summary
- allow the terraform service account to administer load balancer resources

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688c624cc1c8832e9265561db9b18512