### PR TITLE
Add Google sign-in button for moderation

### DIFF
--- a/infra/googleAuth.js
+++ b/infra/googleAuth.js
@@ -1,0 +1,28 @@
+export const initGoogleSignIn = ({ onSignIn } = {}) => {
+  if (!window.google || !google.accounts?.id) {
+    console.error('Google Identity script missing');
+    return;
+  }
+
+  google.accounts.id.initialize({
+    client_id:
+      '848377461162-7je7r4pg7mnaj85gq558cf4gt0mk8j9b.apps.googleusercontent.com',
+    callback: ({ credential }) => {
+      sessionStorage.setItem('id_token', credential);
+      onSignIn?.(credential);
+    },
+  });
+
+  google.accounts.id.renderButton(document.getElementById('signinButton'), {
+    theme: 'outline',
+    size: 'large',
+    text: 'signin_with',
+  });
+};
+
+export const getIdToken = () => sessionStorage.getItem('id_token');
+
+export const signOut = () => {
+  sessionStorage.removeItem('id_token');
+  google.accounts.id.disableAutoSelect();
+};

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -97,6 +97,20 @@ resource "google_storage_bucket_object" "dendrite_mod" {
   content_type = "text/html"
 }
 
+resource "google_storage_bucket_object" "dendrite_google_auth_js" {
+  name         = "googleAuth.js"
+  bucket       = google_storage_bucket.dendrite_static.name
+  source       = "${path.module}/googleAuth.js"
+  content_type = "application/javascript"
+}
+
+resource "google_storage_bucket_object" "dendrite_moderate_js" {
+  name         = "moderate.js"
+  bucket       = google_storage_bucket.dendrite_static.name
+  source       = "${path.module}/moderate.js"
+  content_type = "application/javascript"
+}
+
 resource "google_storage_bucket_iam_member" "dendrite_public_read_access" {
   bucket = google_storage_bucket.dendrite_static.name
   role   = "roles/storage.objectViewer"

--- a/infra/mod.html
+++ b/infra/mod.html
@@ -11,6 +11,13 @@
     <h2>Moderate a story page</h2>
     <p>Please contribute to keeping Dendrite an excellent place to read and write.</p>
     <p>Click the "Next page" button to be shown a page to approve or reject.</p>
+    <div id="signinButton"></div>
     <button disabled>Next page</button>
+
+    <!-- Google Identity Services -->
+    <script src="https://accounts.google.com/gsi/client" async defer></script>
+
+    <!-- Moderate tools -->
+    <script type="module" src="./moderate.js"></script>
 </body>
 </html>

--- a/infra/moderate.js
+++ b/infra/moderate.js
@@ -1,0 +1,27 @@
+import { initGoogleSignIn, getIdToken } from './googleAuth.js';
+
+initGoogleSignIn({
+  onSignIn: () => {
+    document.body.classList.add('authed');
+    const button = document.querySelector('button');
+    if (button) {
+      button.disabled = false;
+    }
+  },
+});
+
+export const authedFetch = async (url, opts = {}) => {
+  const token = getIdToken();
+  if (!token) throw new Error('not signed in');
+
+  const resp = await fetch(url, {
+    ...opts,
+    headers: {
+      ...(opts.headers || {}),
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+  });
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+  return resp.json();
+};

--- a/reports/lint/lint.txt
+++ b/reports/lint/lint.txt
@@ -1,27 +1,34 @@
 
-/Users/matthew.heard/Code/Matt/dadeto/infra/cloud-functions/process-new-page/index.js
+/workspace/dadeto/infra/cloud-functions/process-new-page/index.js
   12:13  warning  Async arrow function has a complexity of 7. Maximum allowed is 2  complexity
 
-/Users/matthew.heard/Code/Matt/dadeto/infra/cloud-functions/process-new-story/index.js
+/workspace/dadeto/infra/cloud-functions/process-new-story/index.js
   12:13  warning  Async arrow function has a complexity of 4. Maximum allowed is 2  complexity
 
-/Users/matthew.heard/Code/Matt/dadeto/infra/cloud-functions/render-contents/index.js
+/workspace/dadeto/infra/cloud-functions/render-contents/index.js
   55:1   warning  Async function 'fetchStoryInfo' has a complexity of 5. Maximum allowed is 2  complexity
   79:13  warning  Async arrow function has a complexity of 3. Maximum allowed is 2             complexity
 
-/Users/matthew.heard/Code/Matt/dadeto/infra/cloud-functions/render-variant/index.js
-  83:44  warning  Arrow function has a complexity of 3. Maximum allowed is 2  complexity
+/workspace/dadeto/infra/cloud-functions/render-variant/index.js
+  50:44  warning  Arrow function has a complexity of 3. Maximum allowed is 2  complexity
 
-/Users/matthew.heard/Code/Matt/dadeto/infra/cloud-functions/submit-new-page/helpers.js
+/workspace/dadeto/infra/cloud-functions/submit-new-page/helpers.js
    7:8  warning  Function 'parseIncomingOption' has a complexity of 6. Maximum allowed is 2       complexity
   36:8  warning  Async function 'findExistingOption' has a complexity of 6. Maximum allowed is 2  complexity
 
-/Users/matthew.heard/Code/Matt/dadeto/infra/cloud-functions/submit-new-page/index.js
-  16:13  warning  Method 'origin' has a complexity of 3. Maximum allowed is 2                 complexity
-  36:1   warning  Async function 'handleSubmit' has a complexity of 12. Maximum allowed is 2  complexity
+/workspace/dadeto/infra/cloud-functions/submit-new-page/index.js
+  20:13  warning  Method 'origin' has a complexity of 3. Maximum allowed is 2                 complexity
+  40:1   warning  Async function 'handleSubmit' has a complexity of 12. Maximum allowed is 2  complexity
 
-/Users/matthew.heard/Code/Matt/dadeto/infra/cloud-functions/submit-new-story/index.js
-  19:13  warning  Method 'origin' has a complexity of 3. Maximum allowed is 2                complexity
-  39:1   warning  Async function 'handleSubmit' has a complexity of 8. Maximum allowed is 2  complexity
+/workspace/dadeto/infra/cloud-functions/submit-new-story/index.js
+  20:13  warning  Method 'origin' has a complexity of 3. Maximum allowed is 2                complexity
+  40:1   warning  Async function 'handleSubmit' has a complexity of 8. Maximum allowed is 2  complexity
 
-✖ 11 problems (0 errors, 11 warnings)
+/workspace/dadeto/infra/googleAuth.js
+  1:33  warning  Arrow function has a complexity of 5. Maximum allowed is 2  complexity
+  8:5   warning  Identifier 'client_id' is not in camel case                 camelcase
+
+/workspace/dadeto/infra/moderate.js
+  13:28  warning  Async arrow function has a complexity of 5. Maximum allowed is 2  complexity
+
+✖ 14 problems (0 errors, 14 warnings)

--- a/test/browser/googleAuth.test.js
+++ b/test/browser/googleAuth.test.js
@@ -1,0 +1,65 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import {
+  initGoogleSignIn,
+  getIdToken,
+  signOut,
+} from '../../infra/googleAuth.js';
+
+describe('googleAuth', () => {
+  beforeEach(() => {
+    global.sessionStorage = {
+      store: {},
+      getItem(key) {
+        return this.store[key] || null;
+      },
+      setItem(key, value) {
+        this.store[key] = value;
+      },
+      removeItem(key) {
+        delete this.store[key];
+      },
+      clear() {
+        this.store = {};
+      },
+    };
+    sessionStorage.clear();
+    global.window = { google: undefined };
+    global.google = undefined;
+    global.document = { getElementById: jest.fn() };
+  });
+
+  it('logs an error when google object is missing', () => {
+    console.error = jest.fn();
+    initGoogleSignIn();
+    expect(console.error).toHaveBeenCalledWith(
+      'Google Identity script missing'
+    );
+  });
+
+  it('initializes and stores token', () => {
+    const initialize = jest.fn();
+    const renderButton = jest.fn();
+    global.window.google = {
+      accounts: {
+        id: { initialize, renderButton, disableAutoSelect: jest.fn() },
+      },
+    };
+    global.google = global.window.google;
+    const credential = 'tok';
+    initGoogleSignIn({ onSignIn: jest.fn() });
+    const args = initialize.mock.calls[0][0];
+    args.callback({ credential });
+    expect(sessionStorage.getItem('id_token')).toBe(credential);
+    expect(getIdToken()).toBe(credential);
+  });
+
+  it('signOut clears token and disables auto select', () => {
+    const disableAutoSelect = jest.fn();
+    global.window.google = { accounts: { id: { disableAutoSelect } } };
+    global.google = global.window.google;
+    sessionStorage.setItem('id_token', 'tok');
+    signOut();
+    expect(sessionStorage.getItem('id_token')).toBeNull();
+    expect(disableAutoSelect).toHaveBeenCalled();
+  });
+});

--- a/test/browser/moderate.test.js
+++ b/test/browser/moderate.test.js
@@ -1,0 +1,65 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+let authedFetch;
+
+describe('authedFetch', () => {
+  beforeEach(async () => {
+    global.sessionStorage = {
+      store: {},
+      getItem(key) {
+        return this.store[key] || null;
+      },
+      setItem(key, value) {
+        this.store[key] = value;
+      },
+      removeItem(key) {
+        delete this.store[key];
+      },
+      clear() {
+        this.store = {};
+      },
+    };
+    sessionStorage.clear();
+    global.window = {
+      google: {
+        accounts: {
+          id: {
+            initialize: jest.fn(),
+            renderButton: jest.fn(),
+            disableAutoSelect: jest.fn(),
+          },
+        },
+      },
+    };
+    global.google = global.window.google;
+    global.document = { getElementById: jest.fn() };
+    global.fetch = jest.fn();
+    ({ authedFetch } = await import('../../infra/moderate.js'));
+  });
+
+  it('throws when not signed in', async () => {
+    await expect(authedFetch('/api')).rejects.toThrow('not signed in');
+  });
+
+  it('sends token and returns json', async () => {
+    sessionStorage.setItem('id_token', 'abc');
+    global.fetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ ok: true }),
+    });
+    const result = await authedFetch('/api', { method: 'POST' });
+    expect(global.fetch).toHaveBeenCalledWith('/api', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer abc',
+        'Content-Type': 'application/json',
+      },
+    });
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('throws on HTTP errors', async () => {
+    sessionStorage.setItem('id_token', 'abc');
+    global.fetch.mockResolvedValue({ ok: false, status: 500 });
+    await expect(authedFetch('/api')).rejects.toThrow('HTTP 500');
+  });
+});


### PR DESCRIPTION
## Summary
- add Google Identity initialization utilities
- create moderation helper module with authenticated fetch
- expose sign-in button on mod.html
- add unit tests and coverage data
- add js assets to terraform bucket configuration

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688c9338c650832ebd47658fd296b733