### PR TITLE
Add Cross-Origin header to load balancer backend

### DIFF
--- a/infra/load-balancer.tf
+++ b/infra/load-balancer.tf
@@ -21,6 +21,11 @@ resource "google_compute_backend_bucket" "dendrite_static" {
   bucket_name = google_storage_bucket.dendrite_static.name
   enable_cdn  = true
 
+  # Add custom response header for Google Sign-In compatibility
+  custom_response_headers = [
+    "Cross-Origin-Opener-Policy: same-origin-allow-popups"
+  ]
+
   depends_on = [
     google_project_service.compute,
     google_project_iam_member.terraform_loadbalancer_admin,


### PR DESCRIPTION
## Summary
- add `Cross-Origin-Opener-Policy` header to backend bucket so Google Sign-In works

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688caa5a7aa0832e83b217b69c11cb7b