### PR TITLE
Update url map to use google-beta

### DIFF
--- a/infra/load-balancer.tf
+++ b/infra/load-balancer.tf
@@ -47,7 +47,8 @@ resource "google_compute_managed_ssl_certificate" "dendrite" {
 }
 
 resource "google_compute_url_map" "dendrite" {
-  name            = "${var.environment}-dendrite-url-map"
+  provider       = google-beta
+  name           = "${var.environment}-dendrite-url-map"
   default_service = google_compute_backend_bucket.dendrite_static.id
 
   route_rules {


### PR DESCRIPTION
## Summary
- use google-beta provider for the `google_compute_url_map` resource

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688cb0114990832ebec481fde0a6b83c