### PR TITLE
Update google Terraform providers

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 5.0"
+      version = "~> 5.6"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 5.0"
+      version = "~> 5.6"
     }
   }
 }


### PR DESCRIPTION
## Summary
- bump google and google-beta provider versions to 5.6

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688cb33768e4832e8d6feae309839b8f