### PR TITLE
Wrap route_rules in path_matcher

### DIFF
--- a/infra/load-balancer.tf
+++ b/infra/load-balancer.tf
@@ -47,22 +47,32 @@ resource "google_compute_managed_ssl_certificate" "dendrite" {
 }
 
 resource "google_compute_url_map" "dendrite" {
-  provider       = google-beta
-  name           = "${var.environment}-dendrite-url-map"
+  provider        = google-beta
+  name            = "${var.environment}-dendrite-url-map"
   default_service = google_compute_backend_bucket.dendrite_static.id
 
-  route_rules {
-    priority = 0
+  host_rule {
+    hosts        = ["*"]
+    path_matcher = "allpaths"
+  }
 
-    match_rules {
-      full_path_match = "/"
+  path_matcher {
+    name            = "allpaths"
+    default_service = google_compute_backend_bucket.dendrite_static.id
+
+    route_rules {
+      priority = 0
+
+      match_rules {
+        full_path_match = "/"
+      }
+
+      url_rewrite {
+        path_prefix_rewrite = "/index.html"
+      }
+
+      service = google_compute_backend_bucket.dendrite_static.id
     }
-
-    url_rewrite {
-      path_prefix_rewrite = "/index.html"
-    }
-
-    service = google_compute_backend_bucket.dendrite_static.id
   }
 
   depends_on = [


### PR DESCRIPTION
## Summary
- refactor load balancer config so `route_rules` live inside a `path_matcher`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688cb68554a0832eae1c1181bbe9a769