### PR TITLE
Remove incomingOptionId from new story variant document

### DIFF
--- a/infra/cloud-functions/process-new-story/index.js
+++ b/infra/cloud-functions/process-new-story/index.js
@@ -57,7 +57,6 @@ export const processNewStory = functions
       content: sub.content,
       authorId: null,
       authorName: sub.author,
-      incomingOptionId: null,
       createdAt: FieldValue.serverTimestamp(),
     });
 


### PR DESCRIPTION
## Summary
- avoid setting `incomingOptionId` on a new story's variant document

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688cc85f088c832ea6d51b21682ae2e0