### PR TITLE
Remove custom header from load balancer backend

### DIFF
--- a/infra/load-balancer.tf
+++ b/infra/load-balancer.tf
@@ -21,10 +21,7 @@ resource "google_compute_backend_bucket" "dendrite_static" {
   bucket_name = google_storage_bucket.dendrite_static.name
   enable_cdn  = true
 
-  # Add custom response header for Google Sign-In compatibility
-  custom_response_headers = [
-    "Cross-Origin-Opener-Policy: same-origin-allow-popups"
-  ]
+  # No COOP header → default 'unsafe-none'
 
   depends_on = [
     google_project_service.compute,


### PR DESCRIPTION
## Summary
- clean up Terraform config for the load balancer
- remove the custom COOP header and document default

## Testing
- `npm test`
- `npm run lint` *(fails: 14 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688cd235a72c832ea1d2bd91c0e9238a