### PR TITLE
Switch moderator sign-in to redirect auth

### DIFF
--- a/infra/googleAuth.js
+++ b/infra/googleAuth.js
@@ -11,6 +11,7 @@ export const initGoogleSignIn = ({ onSignIn } = {}) => {
       sessionStorage.setItem('id_token', credential);
       onSignIn?.(credential);
     },
+    ux_mode: 'redirect',
   });
 
   google.accounts.id.renderButton(document.getElementById('signinButton'), {


### PR DESCRIPTION
## Summary
- switch Google sign-in initialization to `ux_mode: 'redirect'` so moderators authenticate via full-page redirect instead of a popup

## Testing
- `npm test`
- `npm run lint` (warnings remain)


------
https://chatgpt.com/codex/tasks/task_e_688df2c45efc832e99c67f05e759b52a