### PR TITLE
chore: set default backend bucket

### DIFF
--- a/infra/load-balancer.tf
+++ b/infra/load-balancer.tf
@@ -47,6 +47,9 @@ resource "google_compute_url_map" "dendrite" {
   provider = google-beta
   name     = "${var.environment}-dendrite-url-map"
 
+  # mandatory fallback for any request that dodges all matchers
+  default_service = google_compute_backend_bucket.dendrite_static.id
+
   # --- 1️⃣  Apex host goes through its own matcher -------------
   host_rule {
     hosts        = ["dendritestories.co.nz"]


### PR DESCRIPTION
## Summary
- set backend bucket as the default service for the global URL map

## Testing
- `npx prettier infra/load-balancer.tf --write` *(fails: No parser could be inferred for file)*
- `npm test`
- `npm run lint` *(warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688e30f54a38832ea532b2badbebdef4