### PR TITLE
Use popup OAuth mode for Google sign-in

### DIFF
--- a/infra/googleAuth.js
+++ b/infra/googleAuth.js
@@ -11,7 +11,7 @@ export const initGoogleSignIn = ({ onSignIn } = {}) => {
       sessionStorage.setItem('id_token', credential);
       onSignIn?.(credential);
     },
-    ux_mode: 'redirect',
+    ux_mode: 'popup',
   });
 
   google.accounts.id.renderButton(document.getElementById('signinButton'), {

--- a/test/browser/googleAuth.test.js
+++ b/test/browser/googleAuth.test.js
@@ -48,6 +48,7 @@ describe('googleAuth', () => {
     const credential = 'tok';
     initGoogleSignIn({ onSignIn: jest.fn() });
     const args = initialize.mock.calls[0][0];
+    expect(args.ux_mode).toBe('popup');
     args.callback({ credential });
     expect(sessionStorage.getItem('id_token')).toBe(credential);
     expect(getIdToken()).toBe(credential);


### PR DESCRIPTION
## Summary
- use popup UX mode for Google sign-in instead of redirect
- add test coverage confirming popup initialization

## Testing
- `npm test` (pass, branch coverage 99.26%)
- `npm run lint` (warnings)


------
https://chatgpt.com/codex/tasks/task_e_688e3549ceec832e9395dc1966aa2e84