### PR TITLE
Enable token form submission after Google sign-in

### DIFF
--- a/infra/mod.html
+++ b/infra/mod.html
@@ -18,7 +18,14 @@
     </p>
     <p>Click the "Next page" button to be shown a page to approve or reject.</p>
     <div id="signinButton"></div>
-    <button disabled>Next page</button>
+    <form
+      id="nextPageForm"
+      action="https://europe-west1-irien-465710.cloudfunctions.net/prod-next-page"
+      method="post"
+    >
+      <input type="hidden" name="id_token" id="idTokenField" />
+      <button type="submit" disabled>Next page</button>
+    </form>
 
     <!-- Google Identity Services -->
     <script src="https://accounts.google.com/gsi/client" defer></script>

--- a/infra/moderate.js
+++ b/infra/moderate.js
@@ -3,12 +3,29 @@ import { initGoogleSignIn, getIdToken } from './googleAuth.js';
 initGoogleSignIn({
   onSignIn: () => {
     document.body.classList.add('authed');
-    const button = document.querySelector('button');
+    const button = document.querySelector('form button[type="submit"]');
     if (button) {
       button.disabled = false;
     }
   },
 });
+
+// attach once DOM is parsed
+if (typeof document !== 'undefined' && document.addEventListener) {
+  document.addEventListener('DOMContentLoaded', () => {
+    const form = document.getElementById('nextPageForm');
+    const field = document.getElementById('idTokenField');
+
+    form.addEventListener('submit', () => {
+      const token = getIdToken();
+      if (!token) {
+        alert('Please sign in first');
+        throw new Error('id_token missing');
+      }
+      field.value = token; // 🔑 travels in the POST body
+    });
+  });
+}
 
 export const authedFetch = async (url, opts = {}) => {
   const token = getIdToken();


### PR DESCRIPTION
## Summary
- Replace standalone moderation button with form that posts to server and holds Google ID token
- Enable submit button on Google sign-in and inject token into form on submit

## Testing
- `npm test`
- `npm run lint` (warnings)


------
https://chatgpt.com/codex/tasks/task_e_688e7a441be4832e859d5cb87f208956