### PR TITLE
Toggle sign out after Google auth

### DIFF
--- a/infra/mod.html
+++ b/infra/mod.html
@@ -18,6 +18,9 @@
     </p>
     <p>Click the "Next page" button to be shown a page to approve or reject.</p>
     <div id="signinButton"></div>
+    <div id="signoutWrap" style="display: none">
+      <button id="signoutBtn" type="button">Sign out</button>
+    </div>
     <form
       id="nextPageForm"
       action="https://europe-west1-irien-465710.cloudfunctions.net/prod-next-page"

--- a/infra/moderate.js
+++ b/infra/moderate.js
@@ -1,4 +1,4 @@
-import { initGoogleSignIn, getIdToken } from './googleAuth.js';
+import { initGoogleSignIn, getIdToken, signOut } from './googleAuth.js';
 
 initGoogleSignIn({
   onSignIn: () => {
@@ -7,6 +7,19 @@ initGoogleSignIn({
     if (button) {
       button.disabled = false;
     }
+    const signin = document.getElementById('signinButton');
+    const wrap = document.getElementById('signoutWrap');
+    signin.style.display = 'none';
+    wrap.style.display = '';
+    wrap.querySelector('#signoutBtn').onclick = () => {
+      signOut();
+      wrap.style.display = 'none';
+      signin.style.display = '';
+      if (button) {
+        button.disabled = true;
+      }
+      document.body.classList.remove('authed');
+    };
   },
 });
 
@@ -42,3 +55,13 @@ export const authedFetch = async (url, opts = {}) => {
   if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
   return resp.json();
 };
+
+if (getIdToken()) {
+  document.body.classList.add('authed');
+  document.getElementById('signinButton').style.display = 'none';
+  document.getElementById('signoutWrap').style.display = '';
+  const button = document.querySelector('form button[type="submit"]');
+  if (button) {
+    button.disabled = false;
+  }
+}


### PR DESCRIPTION
## Summary
- show a Sign out button after Google sign in and hide it again on sign out
- auto-show the Sign out button on page load when an ID token is present

## Testing
- `npm test`
- `npm run lint` *(warnings: complexity, camelcase)*

------
https://chatgpt.com/codex/tasks/task_e_688e80eb2e24832e9714386873572bbf