### PR TITLE
Add assign moderation job cloud function

### DIFF
--- a/infra/cloud-functions/assign-moderation-job/index.js
+++ b/infra/cloud-functions/assign-moderation-job/index.js
@@ -1,0 +1,69 @@
+import { initializeApp } from 'firebase-admin/app';
+import { getAuth } from 'firebase-admin/auth';
+import { getFirestore, FieldValue } from 'firebase-admin/firestore';
+import * as functions from 'firebase-functions';
+
+initializeApp();
+const db = getFirestore();
+const auth = getAuth();
+
+/**
+ * Assign a random moderation job to the requesting user.
+ * @param {import('express').Request} req HTTP request object.
+ * @param {import('express').Response} res HTTP response object.
+ * @returns {Promise<void>} Promise resolving when the response is sent.
+ */
+async function handleAssignModerationJob(req, res) {
+  if (req.method !== 'POST') {
+    res.status(405).send('POST only');
+    return;
+  }
+
+  const { id_token: idToken } = req.body ?? {};
+  if (!idToken) {
+    res.status(400).send('Missing id_token');
+    return;
+  }
+
+  let userRecord;
+  try {
+    const { uid } = await auth.verifyIdToken(idToken);
+    userRecord = await auth.getUser(uid);
+  } catch {
+    res.status(401).send('Invalid or expired token');
+    return;
+  }
+
+  const total = (await db.collectionGroup('variants').count().get()).data()
+    .count;
+  if (!total) {
+    res.status(404).send('No variants to moderate');
+    return;
+  }
+
+  const randomOffset = Math.floor(Math.random() * total);
+  const variantSnap = await db
+    .collectionGroup('variants')
+    .limit(1)
+    .offset(randomOffset)
+    .get();
+
+  if (variantSnap.empty) {
+    res.status(500).send('Variant fetch failed 🤷');
+    return;
+  }
+
+  const variantDoc = variantSnap.docs[0];
+
+  const ratingsRef = await db.collection('moderationRatings').add({
+    createdAt: FieldValue.serverTimestamp(),
+    firebaseUid: db.doc(`users/${userRecord.uid}`),
+    variant: variantDoc.ref,
+  });
+
+  res.status(201).json({ moderationId: ratingsRef.id });
+}
+
+export const assignModerationJob = functions
+  .region('europe-west1')
+  .https.onRequest(handleAssignModerationJob);

--- a/infra/cloud-functions/assign-moderation-job/package.json
+++ b/infra/cloud-functions/assign-moderation-job/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "assign-moderation-job",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.js",
+  "dependencies": {
+    "firebase-admin": "^11.10.1",
+    "firebase-functions": "^4.4.1"
+  }
+}

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -386,6 +386,56 @@ resource "google_cloudfunctions_function_iam_member" "submit_new_page_invoker" {
   ]
 }
 
+data "archive_file" "assign_moderation_job_src" {
+  type        = "zip"
+  source_dir  = "${path.module}/cloud-functions/assign-moderation-job"
+  output_path = "${path.module}/build/assign-moderation-job.zip"
+}
+
+resource "google_storage_bucket_object" "assign_moderation_job" {
+  name   = "${var.environment}-assign-moderation-job-${data.archive_file.assign_moderation_job_src.output_sha256}.zip"
+  bucket = google_storage_bucket.gcf_source_bucket.name
+  source = data.archive_file.assign_moderation_job_src.output_path
+}
+
+resource "google_cloudfunctions_function" "assign_moderation_job" {
+  name        = "${var.environment}-assign-moderation-job"
+  runtime     = var.cloud_functions_runtime
+  entry_point = "assignModerationJob"
+  source_archive_bucket = google_storage_bucket.gcf_source_bucket.name
+  source_archive_object = google_storage_bucket_object.assign_moderation_job.name
+  trigger_http                 = true
+  https_trigger_security_level = var.https_security_level
+  service_account_email        = google_service_account.cloud_function_runtime.email
+  region                       = var.region
+
+  environment_variables = {
+    GCLOUD_PROJECT       = var.project_id
+    GOOGLE_CLOUD_PROJECT = var.project_id
+    FIREBASE_CONFIG      = jsonencode({ projectId = var.project_id })
+  }
+
+  depends_on = [
+    google_project_service.cloudfunctions,
+    google_project_service.cloudbuild,
+    google_project_iam_member.cloudfunctions_access,
+    google_service_account_iam_member.terraform_can_impersonate_runtime,
+    google_service_account_iam_member.terraform_can_impersonate_default_compute,
+  ]
+}
+
+resource "google_cloudfunctions_function_iam_member" "assign_moderation_job_invoker" {
+  project        = var.project_id
+  region         = var.region
+  cloud_function = google_cloudfunctions_function.assign_moderation_job.name
+  role           = "roles/cloudfunctions.invoker"
+  member         = "allUsers"
+  depends_on = [
+    google_cloudfunctions_function.assign_moderation_job,
+    google_project_iam_member.terraform_cloudfunctions_viewer,
+  ]
+}
+
 data "archive_file" "process_src" {
   type        = "zip"
   source_dir  = "${path.module}/cloud-functions/process-new-story"


### PR DESCRIPTION
## Summary
- implement assignModerationJob HTTP Cloud Function that verifies user tokens, randomly selects a variant, and records a moderation job
- add package configuration for the new function
- add Terraform resources to deploy the assignModerationJob function and allow public invocation

## Testing
- `npm test`
- `npm run lint` (warnings: complexity and camelcase)


------
https://chatgpt.com/codex/tasks/task_e_688e8221baf0832eb9884008d5458c58