### PR TITLE
Add Firebase setup for moderation page

### DIFF
--- a/infra/mod.html
+++ b/infra/mod.html
@@ -33,6 +33,31 @@
     <!-- Google Identity Services -->
     <script src="https://accounts.google.com/gsi/client" defer></script>
 
+    <!-- Firebase -->
+    <script type="module">
+      // Import the functions you need from the SDKs you need
+      import { initializeApp } from 'https://www.gstatic.com/firebasejs/12.0.0/firebase-app.js';
+      import { getAnalytics } from 'https://www.gstatic.com/firebasejs/12.0.0/firebase-analytics.js';
+      // TODO: Add SDKs for Firebase products that you want to use
+      // https://firebase.google.com/docs/web/setup#available-libraries
+
+      // Your web app's Firebase configuration
+      // For Firebase JS SDK v7.20.0 and later, measurementId is optional
+      const firebaseConfig = {
+        apiKey: 'AIzaSyBPbRcQ3KwzqTV7WVyPLNgUTZKIkMQ9vlc',
+        authDomain: 'dadeto-b2ab0.firebaseapp.com',
+        projectId: 'dadeto-b2ab0',
+        storageBucket: 'dadeto-b2ab0.firebasestorage.app',
+        messagingSenderId: '321987378807',
+        appId: '1:321987378807:web:8c9b8d0e6fffd3cedf5072',
+        measurementId: 'G-ZLG86K7Q5J',
+      };
+
+      // Initialize Firebase
+      const app = initializeApp(firebaseConfig);
+      const analytics = getAnalytics(app);
+    </script>
+
     <!-- Moderate tools -->
     <script type="module" src="./moderate.js"></script>
   </body>


### PR DESCRIPTION
## Summary
- load and initialize Firebase analytics in `mod.html`

## Testing
- `npm test`
- `npm run lint` *(fails: 16 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688efe4744a0832e83a815240df1c17e