### PR TITLE
chore: add google oauth vars to terraform workflow

### DIFF
--- a/.github/workflows/deploy-terraform.yml
+++ b/.github/workflows/deploy-terraform.yml
@@ -17,6 +17,8 @@ jobs:
     env:
       REGION: europe-west1
       ENVIRONMENT: prod
+      TF_VAR_google_oauth_client_id: ${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}
+      TF_VAR_google_oauth_client_secret: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
 
     steps:
       - name: Checkout repo


### PR DESCRIPTION
## Summary
- expose Google OAuth client id and secret to Terraform via TF_VAR variables

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688f68354d40832eb390e893baa6334b