### PR TITLE
chore: use google-beta provider for firebase resources

### DIFF
--- a/infra/dendrite-firestore.tf
+++ b/infra/dendrite-firestore.tf
@@ -5,7 +5,8 @@ data "local_file" "firestore_rules" {
 }
 
 resource "google_firebaserules_ruleset" "firestore" {
-  project = var.project_id
+  provider = google-beta
+  project  = var.project_id
   source {
     files {
       name    = "firestore.rules"
@@ -19,6 +20,7 @@ resource "google_firebaserules_ruleset" "firestore" {
 }
 
 resource "google_firebaserules_release" "firestore" {
+  provider     = google-beta
   project      = var.project_id
   name         = "firestore.rules"
   ruleset_name = google_firebaserules_ruleset.firestore.name

--- a/infra/firebase-auth.tf
+++ b/infra/firebase-auth.tf
@@ -13,6 +13,7 @@ resource "google_project_service" "firebase_api" {
 }
 
 resource "google_firebase_project" "core" {
+  provider   = google-beta
   project    = var.project_id
   depends_on = [
     google_project_service.firebase_api,
@@ -21,18 +22,21 @@ resource "google_firebase_project" "core" {
 }
 
 resource "google_firebase_web_app" "frontend" {
+  provider     = google-beta
   project      = var.project_id
   display_name = "Dadeto Frontend"
 }
 
 # Expose the JS SDK config
 resource "google_firebase_web_app_config" "frontend" {
-  project = var.project_id
-  app_id  = google_firebase_web_app.frontend.app_id
+  provider = google-beta
+  project  = var.project_id
+  app_id   = google_firebase_web_app.frontend.app_id
 }
 
 resource "google_identity_platform_config" "auth" {
-  project                   = var.project_id
+  provider                 = google-beta
+  project                  = var.project_id
   autodelete_anonymous_users = true
 
   authorized_domains = [
@@ -44,17 +48,17 @@ resource "google_identity_platform_config" "auth" {
 }
 
 resource "google_identity_platform_default_supported_idp_config" "google" {
-  project      = var.project_id
-  provider     = "google"
+  provider      = google-beta
+  project       = var.project_id
   client_id     = var.google_oauth_client_id
   client_secret = var.google_oauth_client_secret
   enabled       = true
 }
 
 resource "google_identity_platform_oauth_idp_config" "gis_allowlist" {
+  provider = google-beta
   count       = var.gis_one_tap_client_id == "" ? 0 : 1
   project      = var.project_id
-  provider     = "google"
   display_name = "GIS One-Tap"
   client_id    = var.gis_one_tap_client_id
   enabled      = true


### PR DESCRIPTION
## Summary
- use google-beta provider for Firebase and Identity Platform resources
- apply google-beta provider to Firestore rules resources

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f6fbce0a8832eb892ed1319542b1d