### PR TITLE
Fix Firebase Web-App Config argument

### DIFF
--- a/infra/firebase-auth.tf
+++ b/infra/firebase-auth.tf
@@ -29,9 +29,9 @@ resource "google_firebase_web_app" "frontend" {
 
 # Expose the JS SDK config
 data "google_firebase_web_app_config" "frontend" {
-  provider = google-beta
-  project  = var.project_id
-  app_id   = google_firebase_web_app.frontend.app_id
+  provider   = google-beta
+  project    = var.project_id
+  web_app_id = google_firebase_web_app.frontend.app_id
 }
 
 resource "google_identity_platform_config" "auth" {


### PR DESCRIPTION
## Summary
- use `web_app_id` when fetching Firebase Web App config

## Testing
- `npm test`
- `npm run lint` (warnings only)


------
https://chatgpt.com/codex/tasks/task_e_688f864dfdc8832e84f1f3cb8c7bf973