### PR TITLE
Add no-store cache-control to pending variant JSON

### DIFF
--- a/infra/cloud-functions/render-variant/index.js
+++ b/infra/cloud-functions/render-variant/index.js
@@ -65,6 +65,7 @@ export const renderVariant = functions
       .file(pendingPath)
       .save(JSON.stringify({ path: filePath }), {
         contentType: 'application/json',
+        metadata: { cacheControl: 'no-store' }, // 🔑 stop both positive *and* negative caching
       });
 
     return null;


### PR DESCRIPTION
## Summary
- prevent caching of pending variant JSON by setting `metadata.cacheControl` to `no-store`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f87573ae4832eb72f280f54397522