### PR TITLE
chore: grant Firebase and Service Usage roles to Terraform

### DIFF
--- a/infra/firebase-auth-iam.tf
+++ b/infra/firebase-auth-iam.tf
@@ -1,0 +1,14 @@
+# Firebase Authentication IAM roles for Terraform
+
+resource "google_project_iam_member" "terraform_firebase_admin" {
+  project = var.project_id
+  role    = "roles/firebase.admin"             # can add Firebase to a project & manage web-apps
+  member  = "serviceAccount:terraform@${var.project_id}.iam.gserviceaccount.com"
+}
+
+resource "google_project_iam_member" "terraform_serviceusage_admin" {
+  project = var.project_id
+  role    = "roles/serviceusage.serviceUsageAdmin"  # turns APIs on/off programmatically
+  member  = "serviceAccount:terraform@${var.project_id}.iam.gserviceaccount.com"
+}
+


### PR DESCRIPTION
## Summary
- allow Terraform service account to manage Firebase configuration
- permit Terraform to enable and disable APIs programmatically

## Testing
- `npm test`
- `npm run lint` (16 warnings, 0 errors)


------
https://chatgpt.com/codex/tasks/task_e_688f88349d38832ea51b6b1aeb149b7a