### PR TITLE
chore: ensure idp config waits for auth

### DIFF
--- a/infra/firebase-auth.tf
+++ b/infra/firebase-auth.tf
@@ -54,6 +54,9 @@ resource "google_identity_platform_default_supported_idp_config" "google" {
   client_id     = var.google_oauth_client_id
   client_secret = var.google_oauth_client_secret
   enabled       = true
+
+  # ensure API has finished provisioning before this runs
+  depends_on = [google_identity_platform_config.auth]
 }
 
 resource "google_identity_platform_oauth_idp_config" "gis_allowlist" {


### PR DESCRIPTION
## Summary
- make default supported IDP config wait for Identity Platform auth provisioning

## Testing
- `npm test`
- `npm run lint` (16 warnings)


------
https://chatgpt.com/codex/tasks/task_e_688f8fdb1a94832ea83eb3ff65db01f4