### PR TITLE
feat: add no-store cache control for 404 page

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -62,6 +62,7 @@ resource "google_storage_bucket_object" "dendrite_404" {
   bucket       = google_storage_bucket.dendrite_static.name
   source       = "${path.module}/404.html"
   content_type = "text/html"
+  cache_control = "no-store"
 }
 
 resource "google_storage_bucket_object" "dendrite_new_story" {


### PR DESCRIPTION
## Summary
- disable caching for 404 page by setting cache_control to no-store

## Testing
- `npm test`
- `npm run lint` (warnings: complexity and camelcase)
- `npx prettier --write infra/main.tf` (no parser for Terraform)

------
https://chatgpt.com/codex/tasks/task_e_688fabc0de8c832e83c2006c9e7aa13d