### PR TITLE
refactor: load firebase from cdn

### DIFF
--- a/infra/firebaseDeps.js
+++ b/infra/firebaseDeps.js
@@ -1,6 +1,0 @@
-export { initializeApp } from 'firebase/app';
-export {
-  getAuth,
-  GoogleAuthProvider,
-  signInWithCredential,
-} from 'firebase/auth';

--- a/infra/googleAuth.js
+++ b/infra/googleAuth.js
@@ -1,9 +1,9 @@
+import { initializeApp } from 'https://www.gstatic.com/firebasejs/12.0.0/firebase-app.js';
 import {
-  initializeApp,
   getAuth,
   GoogleAuthProvider,
   signInWithCredential,
-} from './firebaseDeps.js';
+} from 'https://www.gstatic.com/firebasejs/12.0.0/firebase-auth.js';
 
 initializeApp({
   apiKey: '<API_KEY>',

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -4,6 +4,8 @@ const config = {
   },
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
+    '^https://www\\.gstatic\\.com/firebasejs/12\\.0\\.0/(.*)$':
+      '<rootDir>/test/mocks/$1',
   },
   // Use node environment by default, but allow override for browser testing
   testEnvironment: 'node',

--- a/test/mocks/firebase-app.js
+++ b/test/mocks/firebase-app.js
@@ -1,0 +1,1 @@
+export const initializeApp = () => {};

--- a/test/mocks/firebase-auth.js
+++ b/test/mocks/firebase-auth.js
@@ -1,0 +1,6 @@
+export const getAuth = () => ({
+  signOut: async () => {},
+  currentUser: { getIdToken: async () => '' },
+});
+export const GoogleAuthProvider = { credential: () => ({}) };
+export const signInWithCredential = async () => {};


### PR DESCRIPTION
## Summary
- load Firebase auth modules from the official CDN
- drop the unused `firebaseDeps.js`
- stub Firebase CDN modules in Jest using moduleNameMapper

## Testing
- `npm test`
- `npm run lint` *(fails: 16 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688fafb19720832e9e3758c4f0d1e73b