### PR TITLE
Use Terraform output for Firebase config in moderation page

### DIFF
--- a/infra/firebase-auth.tf
+++ b/infra/firebase-auth.tf
@@ -34,6 +34,18 @@ data "google_firebase_web_app_config" "frontend" {
   web_app_id = google_firebase_web_app.frontend.app_id
 }
 
+locals {
+  firebase_web_app_config = {
+    apiKey            = data.google_firebase_web_app_config.frontend.api_key
+    authDomain        = data.google_firebase_web_app_config.frontend.auth_domain
+    projectId         = data.google_firebase_web_app_config.frontend.project_id
+    storageBucket     = data.google_firebase_web_app_config.frontend.storage_bucket
+    messagingSenderId = data.google_firebase_web_app_config.frontend.messaging_sender_id
+    appId             = data.google_firebase_web_app_config.frontend.app_id
+    measurementId     = data.google_firebase_web_app_config.frontend.measurement_id
+  }
+}
+
 resource "google_identity_platform_config" "auth" {
   provider                 = google-beta
   project                  = var.project_id

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -82,7 +82,9 @@ resource "google_storage_bucket_object" "dendrite_new_page" {
 resource "google_storage_bucket_object" "dendrite_mod" {
   name         = "mod.html"
   bucket       = google_storage_bucket.dendrite_static.name
-  source       = "${path.module}/mod.html"
+  content      = templatefile("${path.module}/mod.html", {
+    firebase_web_app_config = jsonencode(local.firebase_web_app_config)
+  })
   content_type = "text/html"
 }
 

--- a/infra/mod.html
+++ b/infra/mod.html
@@ -43,15 +43,7 @@
 
       // Your web app's Firebase configuration
       // For Firebase JS SDK v7.20.0 and later, measurementId is optional
-      const firebaseConfig = {
-        apiKey: 'AIzaSyBPbRcQ3KwzqTV7WVyPLNgUTZKIkMQ9vlc',
-        authDomain: 'dadeto-b2ab0.firebaseapp.com',
-        projectId: 'dadeto-b2ab0',
-        storageBucket: 'dadeto-b2ab0.firebasestorage.app',
-        messagingSenderId: '321987378807',
-        appId: '1:321987378807:web:8c9b8d0e6fffd3cedf5072',
-        measurementId: 'G-ZLG86K7Q5J',
-      };
+      const firebaseConfig = ${firebase_web_app_config};
 
       // Initialize Firebase
       const app = initializeApp(firebaseConfig);

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -1,3 +1,3 @@
 output "firebase_web_app_config" {
-  value = data.google_firebase_web_app_config.frontend
+  value = local.firebase_web_app_config
 }


### PR DESCRIPTION
## Summary
- expose Firebase web app config as a Terraform local/output
- template `mod.html` with Terraform to inject the Firebase config
- moderation page now initializes analytics with the correct Firebase project

## Testing
- `npm test`
- `npm run lint` *(warnings: complexity, camelcase)*

------
https://chatgpt.com/codex/tasks/task_e_688fafeeb7d8832e9bc57320bd7e2ab1