### PR TITLE
Use vars for Firebase project and app IDs

### DIFF
--- a/infra/firebase-auth.tf
+++ b/infra/firebase-auth.tf
@@ -38,10 +38,10 @@ locals {
   firebase_web_app_config = {
     apiKey            = data.google_firebase_web_app_config.frontend.api_key
     authDomain        = data.google_firebase_web_app_config.frontend.auth_domain
-    projectId         = data.google_firebase_web_app_config.frontend.project_id
+    projectId         = var.project_id
     storageBucket     = data.google_firebase_web_app_config.frontend.storage_bucket
     messagingSenderId = data.google_firebase_web_app_config.frontend.messaging_sender_id
-    appId             = data.google_firebase_web_app_config.frontend.app_id
+    appId             = google_firebase_web_app.frontend.app_id
     measurementId     = data.google_firebase_web_app_config.frontend.measurement_id
   }
 }


### PR DESCRIPTION
## Summary
- reference project and app IDs directly in Firebase locals block

## Testing
- `npx prettier -w infra/firebase-auth.tf` *(fails: No parser could be inferred for file)*
- `terraform fmt infra/firebase-auth.tf` *(fails: command not found: terraform)*
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68905a0ceeac832ea5a8b3f4e78acc11