### PR TITLE
chore: remove redundant Firebase script from mod page

### DIFF
--- a/infra/mod.html
+++ b/infra/mod.html
@@ -33,23 +33,6 @@
     <!-- Google Identity Services -->
     <script src="https://accounts.google.com/gsi/client" defer></script>
 
-    <!-- Firebase -->
-    <script type="module">
-      // Import the functions you need from the SDKs you need
-      import { initializeApp } from 'https://www.gstatic.com/firebasejs/12.0.0/firebase-app.js';
-      import { getAnalytics } from 'https://www.gstatic.com/firebasejs/12.0.0/firebase-analytics.js';
-      // TODO: Add SDKs for Firebase products that you want to use
-      // https://firebase.google.com/docs/web/setup#available-libraries
-
-      // Your web app's Firebase configuration
-      // For Firebase JS SDK v7.20.0 and later, measurementId is optional
-      const firebaseConfig = ${firebase_web_app_config};
-
-      // Initialize Firebase
-      const app = initializeApp(firebaseConfig);
-      const analytics = getAnalytics(app);
-    </script>
-
     <!-- Moderate tools -->
     <script type="module" src="./moderate.js"></script>
   </body>


### PR DESCRIPTION
## Summary
- remove leftover Firebase initialization script from the moderation page

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890baa404f0832eb046e82b525550e5