### PR TITLE
Show story title on root variants

### DIFF
--- a/infra/cloud-functions/render-variant/buildHtml.js
+++ b/infra/cloud-functions/render-variant/buildHtml.js
@@ -1,0 +1,15 @@
+import { escapeHtml } from './buildAltsHtml.js';
+
+/**
+ * Build HTML page for the variant.
+ * @param {number} pageNumber Page number.
+ * @param {string} content Variant content.
+ * @param {Array<string>} options Option texts.
+ * @param {string} [storyTitle] Story title.
+ * @returns {string} HTML page.
+ */
+export function buildHtml(pageNumber, content, options, storyTitle = '') {
+  const items = options.map(opt => `<li>${escapeHtml(opt)}</li>`).join('');
+  const title = storyTitle ? `<h1>${escapeHtml(storyTitle)}</h1>` : '';
+  return `<!doctype html><html lang="en"><head><meta charset="UTF-8" /><meta name="viewport" content="width=device-width, initial-scale=1" /><title>Dendrite</title><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.fluid.classless.min.css" /></head><body><h1><a href="/">Dendrite</a></h1>${title}<p>${escapeHtml(content)}</p><ol>${items}</ol><p><a href="./${pageNumber}-alts.html">More options</a></p></body></html>`;
+}

--- a/infra/cloud-functions/render-variant/index.js
+++ b/infra/cloud-functions/render-variant/index.js
@@ -1,24 +1,11 @@
 import { initializeApp } from 'firebase-admin/app';
 import { Storage } from '@google-cloud/storage';
 import * as functions from 'firebase-functions';
-import { buildAltsHtml, escapeHtml } from './buildAltsHtml.js';
+import { buildAltsHtml } from './buildAltsHtml.js';
+import { buildHtml } from './buildHtml.js';
 
 initializeApp();
 const storage = new Storage();
-
-/**
- * Build HTML page for the variant.
- * @param {number} pageNumber Page number.
- * @param {string} content Variant content.
- * @param {Array<string>} options Option texts.
- * @returns {string} HTML page.
- */
-function buildHtml(pageNumber, content, options) {
-  const items = options.map(opt => `<li>${escapeHtml(opt)}</li>`).join('');
-  return `<!doctype html><html lang="en"><head><meta charset="UTF-8" /><meta name="viewport" content="width=device-width, initial-scale=1" /><title>Dendrite</title><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.fluid.classless.min.css" /></head><body><h1><a href="/">Dendrite</a></h1><p>${escapeHtml(
-    content
-  )}</p><ol>${items}</ol><p><a href="./${pageNumber}-alts.html">More options</a></p></body></html>`;
-}
 
 /**
  * Cloud Function triggered when a new variant is created.
@@ -37,8 +24,15 @@ export const renderVariant = functions
 
     const optionsSnap = await snap.ref.collection('options').get();
     const options = optionsSnap.docs.map(doc => doc.data().content || '');
+    let storyTitle = '';
+    if (!page.incomingOptionId) {
+      const storySnap = await pageSnap.ref.parent.parent.get();
+      if (storySnap.exists) {
+        storyTitle = storySnap.data().title || '';
+      }
+    }
 
-    const html = buildHtml(page.number, variant.content, options);
+    const html = buildHtml(page.number, variant.content, options, storyTitle);
     const filePath = `p/${page.number}${variant.name}.html`;
 
     await storage
@@ -71,4 +65,4 @@ export const renderVariant = functions
     return null;
   });
 
-export { buildAltsHtml };
+export { buildAltsHtml, buildHtml };

--- a/test/cloud-functions/buildHtml.test.js
+++ b/test/cloud-functions/buildHtml.test.js
@@ -1,0 +1,17 @@
+import { describe, test, expect } from '@jest/globals';
+import { buildHtml } from '../../infra/cloud-functions/render-variant/buildHtml.js';
+
+describe('buildHtml', () => {
+  test('omits story title when not provided', () => {
+    const html = buildHtml(1, 'hello', []);
+    expect(html).not.toContain('<h1>My Story</h1>');
+  });
+
+  test('includes story title before content when provided', () => {
+    const html = buildHtml(1, 'hello', [], 'My Story');
+    const titleIndex = html.indexOf('<h1>My Story</h1>');
+    const contentIndex = html.indexOf('<p>hello</p>');
+    expect(titleIndex).toBeGreaterThan(-1);
+    expect(titleIndex).toBeLessThan(contentIndex);
+  });
+});


### PR DESCRIPTION
## Summary
- Display the parent story title when a variant has no incoming option
- Extract HTML generation into a dedicated `buildHtml` helper with tests

## Testing
- `npm test`
- `npm run lint` *(fails: complexity warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6890f0d47374832e9dd97e0c17f6e85c