### PR TITLE
Add Identity Platform viewer role for Cloud Function runtime

### DIFF
--- a/infra/firebase-auth-iam.tf
+++ b/infra/firebase-auth-iam.tf
@@ -12,3 +12,15 @@ resource "google_project_iam_member" "terraform_serviceusage_admin" {
   member  = "serviceAccount:terraform@${var.project_id}.iam.gserviceaccount.com"
 }
 
+# Allow the Cloud Function runtime SA to read auth users
+resource "google_project_iam_member" "runtime_identityplatform_viewer" {
+  project = var.project_id
+  role    = "roles/identityplatform.viewer"   # just “view” permissions
+  member  = "serviceAccount:${google_service_account.cloud_function_runtime.email}"
+
+  # optional, but makes the dependency explicit
+  depends_on = [
+    google_project_service.identitytoolkit       # turned on in firebase-auth.tf
+  ]
+}
+


### PR DESCRIPTION
## Summary
- allow Cloud Function runtime service account to view Identity Platform users

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6891106557f0832e81fcc0b6e59d9806