### PR TITLE
feat: store moderator assignments by user

### DIFF
--- a/infra/cloud-functions/assign-moderation-job/index.js
+++ b/infra/cloud-functions/assign-moderation-job/index.js
@@ -72,13 +72,13 @@ async function handleAssignModerationJob(req, res) {
 
   const variantDoc = variantSnap.docs[0];
 
-  const ratingsRef = await db.collection('moderationRatings').add({
-    createdAt: FieldValue.serverTimestamp(),
-    firebaseUid: db.doc(`users/${userRecord.uid}`),
+  const moderatorRef = db.collection('moderators').doc(userRecord.uid);
+  await moderatorRef.set({
     variant: variantDoc.ref,
+    createdAt: FieldValue.serverTimestamp(),
   });
 
-  res.status(201).json({ moderationId: ratingsRef.id });
+  res.status(201).json({});
 }
 
 export const assignModerationJob = functions


### PR DESCRIPTION
## Summary
- save moderation assignments in a `moderators` document keyed by Firebase uid
- return an empty payload when acknowledging a moderation assignment

## Testing
- `npm test`
- `npm run lint` (warnings only)


------
https://chatgpt.com/codex/tasks/task_e_689122b2e118832e8ccb730ee7c24848