### PR TITLE
feat: add moderation variant endpoint and UI

### DIFF
--- a/infra/cloud-functions/get-moderation-variant/index.js
+++ b/infra/cloud-functions/get-moderation-variant/index.js
@@ -1,0 +1,91 @@
+import { initializeApp } from 'firebase-admin/app';
+import { getAuth } from 'firebase-admin/auth';
+import { getFirestore } from 'firebase-admin/firestore';
+import * as functions from 'firebase-functions';
+
+initializeApp();
+const db = getFirestore();
+const auth = getAuth();
+
+/**
+ * Fetch the variant assigned to the authenticated moderator.
+ * @param {import('express').Request} req HTTP request object.
+ * @param {import('express').Response} res HTTP response object.
+ * @returns {Promise<void>} Promise resolving when the response is sent.
+ */
+async function handleGetModerationVariant(req, res) {
+  console.log('[getModerationVariant] method=%s ip=%s', req.method, req.ip);
+  if (req.method !== 'GET') {
+    console.warn('[getModerationVariant] non-GET rejected');
+    res.status(405).send('GET only');
+    return;
+  }
+
+  const authHeader = req.get('Authorization') || '';
+  const match = authHeader.match(/^Bearer (.+)$/);
+  if (!match) {
+    console.warn('[getModerationVariant] missing bearer token');
+    res.status(401).send('Missing or invalid Authorization header');
+    return;
+  }
+
+  let uid;
+  try {
+    const decoded = await auth.verifyIdToken(match[1]);
+    uid = decoded.uid;
+    console.log('[getModerationVariant] token ok uid=%s', uid);
+  } catch (err) {
+    console.error(
+      '[getModerationVariant] verifyIdToken failed',
+      err.code,
+      err.message,
+      err.stack
+    );
+    res.status(401).send(err.message || 'Invalid or expired token');
+    return;
+  }
+
+  const moderatorSnap = await db.collection('moderators').doc(uid).get();
+  if (!moderatorSnap.exists) {
+    res.status(404).send('No moderation job');
+    return;
+  }
+  const data = moderatorSnap.data();
+  if (!data.variant) {
+    res.status(404).send('No moderation job');
+    return;
+  }
+
+  const variantRef = data.variant;
+  const variantSnap = await variantRef.get();
+  if (!variantSnap.exists) {
+    res.status(404).send('Variant not found');
+    return;
+  }
+  const variantData = variantSnap.data();
+
+  const pageSnap = await variantRef.parent.parent.get();
+  const storySnap = await pageSnap.ref.parent.parent.get();
+  const storyTitle = storySnap.exists ? storySnap.data().title || '' : '';
+
+  const optionsSnap = await variantRef.collection('options').get();
+  const options = optionsSnap.docs.map(doc => {
+    const { content = '', targetPageNumber } = doc.data();
+    return targetPageNumber !== undefined
+      ? { content, targetPageNumber }
+      : { content };
+  });
+
+  res.status(200).json({
+    title: storyTitle,
+    content: variantData.content || '',
+    author: variantData.author || '',
+    options,
+  });
+}
+
+export const getModerationVariant = functions
+  .region('europe-west1')
+  .https.onRequest(handleGetModerationVariant);
+
+export { handleGetModerationVariant };

--- a/infra/cloud-functions/get-moderation-variant/package.json
+++ b/infra/cloud-functions/get-moderation-variant/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "get-moderation-variant",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.js",
+  "dependencies": {
+    "firebase-admin": "^11.10.1",
+    "firebase-functions": "^4.4.1"
+  }
+}

--- a/infra/mod.html
+++ b/infra/mod.html
@@ -17,18 +17,21 @@
       write.
     </p>
     <p>Click the "Next page" button to be shown a page to approve or reject.</p>
+    <div id="pageContent"></div>
     <div id="signinButton"></div>
     <div id="signoutWrap" style="display: none">
       <button id="signoutBtn" type="button">Sign out</button>
     </div>
-    <form
-      id="nextPageForm"
-      action="https://europe-west1-irien-465710.cloudfunctions.net/prod-assign-moderation-job"
-      method="post"
-    >
-      <input type="hidden" name="id_token" id="idTokenField" />
-      <button type="submit" disabled>Next page</button>
-    </form>
+    <div id="actions">
+      <form
+        id="nextPageForm"
+        action="https://europe-west1-irien-465710.cloudfunctions.net/prod-assign-moderation-job"
+        method="post"
+      >
+        <input type="hidden" name="id_token" id="idTokenField" />
+        <button type="submit" disabled>Next page</button>
+      </form>
+    </div>
 
     <!-- Google Identity Services -->
     <script src="https://accounts.google.com/gsi/client" defer></script>

--- a/infra/moderate.js
+++ b/infra/moderate.js
@@ -1,5 +1,55 @@
 import { initGoogleSignIn, getIdToken, signOut } from './googleAuth.js';
 
+const GET_VARIANT_URL =
+  'https://europe-west1-irien-465710.cloudfunctions.net/prod-get-moderation-variant';
+
+/**
+ * Load the current moderation variant and render it.
+ * @returns {Promise<void>} Promise resolving when rendering is complete.
+ */
+async function loadVariant() {
+  try {
+    const data = await authedFetch(GET_VARIANT_URL);
+    const container = document.getElementById('pageContent');
+    container.innerHTML = '';
+    const title = document.createElement('h3');
+    title.textContent = data.title || '';
+    const author = document.createElement('p');
+    author.textContent = data.author ? `By ${data.author}` : '';
+    const content = document.createElement('p');
+    content.textContent = data.content || '';
+    container.appendChild(title);
+    container.appendChild(author);
+    container.appendChild(content);
+    if (Array.isArray(data.options) && data.options.length) {
+      const list = document.createElement('ol');
+      data.options.forEach(opt => {
+        const li = document.createElement('li');
+        li.textContent =
+          opt.targetPageNumber !== undefined
+            ? `${opt.content} (${opt.targetPageNumber})`
+            : opt.content;
+        list.appendChild(li);
+      });
+      container.appendChild(list);
+    }
+    const actions = document.getElementById('actions');
+    actions.innerHTML = '';
+    const approve = document.createElement('button');
+    approve.type = 'button';
+    approve.textContent = 'Approve';
+    approve.disabled = true;
+    const reject = document.createElement('button');
+    reject.type = 'button';
+    reject.textContent = 'Reject';
+    reject.disabled = true;
+    actions.appendChild(approve);
+    actions.appendChild(reject);
+  } catch (err) {
+    console.error(err);
+  }
+}
+
 initGoogleSignIn({
   onSignIn: () => {
     document.body.classList.add('authed');
@@ -20,6 +70,7 @@ initGoogleSignIn({
       }
       document.body.classList.remove('authed');
     };
+    loadVariant();
   },
 });
 
@@ -64,4 +115,5 @@ if (getIdToken()) {
   if (button) {
     button.disabled = false;
   }
+  loadVariant();
 }


### PR DESCRIPTION
## Summary
- add Cloud Function to return assigned moderation variant for logged-in user
- fetch and display moderation variant in mod page with approve/reject placeholders

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68912a85d888832ea694261b3c015405