### PR TITLE
Handle moderation job assignment in place

### DIFF
--- a/infra/mod.html
+++ b/infra/mod.html
@@ -23,13 +23,9 @@
       <button id="signoutBtn" type="button">Sign out</button>
     </div>
     <div id="actions">
-      <form
-        id="nextPageForm"
-        action="https://europe-west1-irien-465710.cloudfunctions.net/prod-assign-moderation-job"
-        method="post"
-      >
-        <input type="hidden" name="id_token" id="idTokenField" />
-        <button type="submit" disabled>Next page</button>
+      <form id="nextPageForm">
+        <input type="hidden" id="idTokenField" />
+        <button id="nextPageBtn" type="submit" disabled>Next page</button>
       </form>
     </div>
 


### PR DESCRIPTION
## Summary
- Submit "Next page" via JavaScript instead of navigating to the Cloud Function
- Add `assignJob` helper and use it before reloading the moderation variant

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6891ce8d7474832e94a866f1395b38c5