### PR TITLE
Restrict Firebase web API key

### DIFF
--- a/.github/workflows/deploy-terraform.yml
+++ b/.github/workflows/deploy-terraform.yml
@@ -43,6 +43,13 @@ jobs:
       - name: Terraform Init
         run: terraform init
 
+      - name: Import existing Firebase API key
+        run: |
+          terraform import \
+            google_apikeys_key.firebase_web \
+            projects/$(gcloud config get-value project)/locations/global/keys/e1d641f2-a5f5-4ab1-8fac-3bab75f15cb9 \
+            || true
+
       - name: Terraform Plan
         run: terraform plan -input=false -out=tfplan
 

--- a/infra/firebase-api-key.tf
+++ b/infra/firebase-api-key.tf
@@ -1,0 +1,36 @@
+###############################################################################
+#  firebase-api-key.tf
+#
+#  Restrict the public Firebase Web API key                           (browser)
+###############################################################################
+
+# Existing Firebase Web API key
+resource "google_project_service" "apikeys_api" {
+  project = var.project_id
+  service = "apikeys.googleapis.com"
+}
+
+resource "google_apikeys_key" "firebase_web" {
+  name         = "projects/${var.project_id}/locations/global/keys/e1d641f2-a5f5-4ab1-8fac-3bab75f15cb9"
+  display_name = "Firebase Web key (browser)"
+
+  restrictions {
+    api_targets {
+      service = "identitytoolkit.googleapis.com"
+    }
+    api_targets {
+      service = "securetoken.googleapis.com"
+    }
+
+    browser_key_restrictions {
+      allowed_referrers = [
+        "https://www.dendritestories.co.nz/*",
+        "https://dendritestories.co.nz/*",
+        "http://localhost:5173/*",
+        "http://localhost:3000/*",
+      ]
+    }
+  }
+
+  depends_on = [google_project_service.apikeys_api]
+}


### PR DESCRIPTION
## Summary
- enable Google API Keys API and lock down existing Firebase Web key to allowed referrers and Firebase auth services
- auto-import the existing Firebase API key during Terraform workflow

## Testing
- `npm test`
- `npm run lint` *(warnings only)*

------
https://chatgpt.com/codex/tasks/task_e_6891d4b7a9f8832eab2029fc96704a2a