### PR TITLE
Fail Firebase API key import on errors

### DIFF
--- a/.github/workflows/deploy-terraform.yml
+++ b/.github/workflows/deploy-terraform.yml
@@ -45,10 +45,10 @@ jobs:
 
       - name: Import existing Firebase API key
         run: |
+          set -euo pipefail
           terraform import \
             google_apikeys_key.firebase_web \
-            projects/$(gcloud config get-value project)/locations/global/keys/e1d641f2-a5f5-4ab1-8fac-3bab75f15cb9 \
-            || true
+            projects/$(gcloud config get-value project)/locations/global/keys/e1d641f2-a5f5-4ab1-8fac-3bab75f15cb9
 
       - name: Terraform Plan
         run: terraform plan -input=false -out=tfplan


### PR DESCRIPTION
## Summary
- Ensure Firebase API key import step fails on errors by enabling `set -euo pipefail`
- Remove silent failure fallback so Terraform import errors stop the workflow

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891f344add8832e931955ac42078eb9