### PR TITLE
Allow Terraform to manage API keys

### DIFF
--- a/infra/firebase-api-key.tf
+++ b/infra/firebase-api-key.tf
@@ -4,6 +4,13 @@
 #  Restrict the public Firebase Web API key                           (browser)
 ###############################################################################
 
+# Allow Terraform to create / update / delete API keys
+resource "google_project_iam_member" "terraform_apikeys_admin" {
+  project = var.project_id
+  role    = "roles/serviceusage.apiKeysAdmin"
+  member  = "serviceAccount:terraform@${var.project_id}.iam.gserviceaccount.com"
+}
+
 # Existing Firebase Web API key
 resource "google_project_service" "apikeys_api" {
   project = var.project_id


### PR DESCRIPTION
## Summary
- allow Terraform service account to create, update, and delete API keys

## Testing
- `npm test`
- `npm run lint` (29 warnings)

------
https://chatgpt.com/codex/tasks/task_e_68920f198d10832e83f9ba68e7523a0e