### PR TITLE
Remove Firebase API key import from Terraform workflow

### DIFF
--- a/.github/workflows/deploy-terraform.yml
+++ b/.github/workflows/deploy-terraform.yml
@@ -43,13 +43,6 @@ jobs:
       - name: Terraform Init
         run: terraform init
 
-      - name: Import existing Firebase API key
-        run: |
-          set -euo pipefail
-          terraform import \
-            google_apikeys_key.firebase_web \
-            projects/$(gcloud config get-value project)/locations/global/keys/e1d641f2-a5f5-4ab1-8fac-3bab75f15cb9
-
       - name: Terraform Plan
         run: terraform plan -input=false -out=tfplan
 


### PR DESCRIPTION
### Summary
- remove existing Firebase API key import step from Terraform deployment workflow

### Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689216e301ec832e93588524bfd059a2