### PR TITLE
Add lifecycle block for Firebase web API key

### DIFF
--- a/infra/firebase-api-key.tf
+++ b/infra/firebase-api-key.tf
@@ -39,5 +39,10 @@ resource "google_apikeys_key" "firebase_web" {
     }
   }
 
+  lifecycle {
+    # 🔑 make Terraform destroy the old key first – and only then create the replacement
+    create_before_destroy = false
+  }
+
   depends_on = [google_project_service.apikeys_api]
 }


### PR DESCRIPTION
## Summary
- add lifecycle configuration for Firebase web API key so Terraform destroys old key before creating a replacement

## Testing
- `npm test`
- `npm run lint` (fails: 29 warnings, 0 errors)


------
https://chatgpt.com/codex/tasks/task_e_68923d791c40832e848d55be322ae085