### PR TITLE
Use apikeys.admin role for Terraform service account

### DIFF
--- a/infra/firebase-api-key.tf
+++ b/infra/firebase-api-key.tf
@@ -7,7 +7,7 @@
 # Allow Terraform to create / update / delete API keys
 resource "google_project_iam_member" "terraform_apikeys_admin" {
   project = var.project_id
-  role    = "roles/serviceusage.apiKeysAdmin"
+  role    = "roles/apikeys.admin"
   member  = "serviceAccount:terraform@${var.project_id}.iam.gserviceaccount.com"
 }
 


### PR DESCRIPTION
### Summary
- allow Terraform service account to fully manage API keys by switching IAM role to `roles/apikeys.admin`

### Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689247aa1a28832e8f7f7be72552e6ef