### PR TITLE
fix: revert API key role and add dependency

### DIFF
--- a/infra/firebase-api-key.tf
+++ b/infra/firebase-api-key.tf
@@ -7,8 +7,10 @@
 # Allow Terraform to create / update / delete API keys
 resource "google_project_iam_member" "terraform_apikeys_admin" {
   project = var.project_id
-  role    = "roles/apikeys.admin"
+  role    = "roles/serviceusage.apiKeysAdmin"
   member  = "serviceAccount:terraform@${var.project_id}.iam.gserviceaccount.com"
+
+  depends_on = [google_project_service.apikeys_api]
 }
 
 # Existing Firebase Web API key
@@ -44,5 +46,8 @@ resource "google_apikeys_key" "firebase_web" {
     create_before_destroy = false
   }
 
-  depends_on = [google_project_service.apikeys_api]
+  depends_on = [
+    google_project_iam_member.terraform_apikeys_admin,  # wait for the role
+    google_project_service.apikeys_api                  # and the API itself
+  ]
 }


### PR DESCRIPTION
## Summary
- restore Terraform API keys role to `serviceusage.apiKeysAdmin`
- ensure Firebase API key waits for API enablement and IAM role assignment

## Testing
- `npm test`
- `npm run lint` (29 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68924acb2af0832e830fdfc710277cab