### PR TITLE
chore: rename Firebase API key

### DIFF
--- a/infra/firebase-api-key.tf
+++ b/infra/firebase-api-key.tf
@@ -21,7 +21,7 @@ resource "google_project_service" "apikeys_api" {
 
 resource "google_apikeys_key" "firebase_web" {
   name         = "projects/${var.project_id}/locations/global/keys/e1d641f2-a5f5-4ab1-8fac-3bab75f15cb9"
-  display_name = "Firebase Web key (browser)"
+  display_name = "Firebase Web key (browser) v2"
 
   restrictions {
     api_targets {


### PR DESCRIPTION
## Summary
- rename Firebase Web API key to "Firebase Web key (browser) v2"

## Testing
- `npm test`
- `npm run lint` *(fails: 29 warnings, 0 errors)*
- `npx prettier infra/firebase-api-key.tf -w` *(fails: No parser could be inferred for file)*

------
https://chatgpt.com/codex/tasks/task_e_68925126110c832ea382ec0a929be749