### PR TITLE
refactor: remove firebase web api key name

### DIFF
--- a/infra/firebase-api-key.tf
+++ b/infra/firebase-api-key.tf
@@ -20,7 +20,6 @@ resource "google_project_service" "apikeys_api" {
 }
 
 resource "google_apikeys_key" "firebase_web" {
-  name         = "projects/${var.project_id}/locations/global/keys/e1d641f2-a5f5-4ab1-8fac-3bab75f15cb9"
   display_name = "Firebase Web key (browser) v2"
 
   restrictions {


### PR DESCRIPTION
## Summary
- remove explicit name field from firebase_web api key to let Terraform manage naming

## Testing
- `npx prettier infra/firebase-api-key.tf -w` *(fails: No parser could be inferred for file)*
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68925f97cd04832eae349e6a222bd1f2