### PR TITLE
Replace Firebase API key resource

### DIFF
--- a/infra/firebase-api-key.tf
+++ b/infra/firebase-api-key.tf
@@ -20,6 +20,7 @@ resource "google_project_service" "apikeys_api" {
 }
 
 resource "google_apikeys_key" "public_web" {
+  name         = "projects/${var.project_id}/locations/global/keys/e1d641f2-a5f5-4ab1-8fac-3bab75f15cb9"
   display_name = "Dadeto Public Web key (browser)"
 
   restrictions {


### PR DESCRIPTION
## Summary
- replace deprecated `google_apikeys_key` "firebase_web" with new `public_web` key and display name

## Testing
- `npm test`
- `npm run lint` (fails: 29 warnings, no errors)


------
https://chatgpt.com/codex/tasks/task_e_6893605b1e2c832eab05fcdf9c63ccf4