### PR TITLE
Allow CORS on get moderation variant

### DIFF
--- a/infra/cloud-functions/get-moderation-variant/package.json
+++ b/infra/cloud-functions/get-moderation-variant/package.json
@@ -5,6 +5,8 @@
   "main": "index.js",
   "dependencies": {
     "firebase-admin": "^11.10.1",
-    "firebase-functions": "^4.4.1"
+    "firebase-functions": "^4.4.1",
+    "express": "^4.19.2",
+    "cors": "^2.8.5"
   }
 }


### PR DESCRIPTION
## Summary
- Add Express + CORS middleware to `get-moderation-variant` cloud function and allow requests from approved origins
- Declare Express and CORS dependencies for the cloud function package

## Testing
- `npm test`
- `npm run lint` (warnings only)


------
https://chatgpt.com/codex/tasks/task_e_6893ade0f00c832e8d33a796e5450281