### PR TITLE
feat: add moderation rating submission

### DIFF
--- a/infra/cloud-functions/submit-moderation-rating/index.js
+++ b/infra/cloud-functions/submit-moderation-rating/index.js
@@ -1,0 +1,111 @@
+import { initializeApp } from 'firebase-admin/app';
+import { getAuth } from 'firebase-admin/auth';
+import { getFirestore, FieldValue } from 'firebase-admin/firestore';
+import * as functions from 'firebase-functions';
+import express from 'express';
+import cors from 'cors';
+
+initializeApp();
+const db = getFirestore();
+const auth = getAuth();
+const app = express();
+
+const allowed = [
+  'https://mattheard.net',
+  'https://dendritestories.co.nz',
+  'https://www.dendritestories.co.nz',
+];
+app.use(
+  cors({
+    origin: (origin, cb) => {
+      if (!origin || allowed.includes(origin)) {
+        cb(null, true);
+      } else {
+        cb(new Error('CORS'));
+      }
+    },
+    methods: ['POST'],
+  })
+);
+
+app.use(express.json());
+
+/**
+ * Record a moderator's rating for their assigned variant.
+ * @param {import('express').Request} req HTTP request object.
+ * @param {import('express').Response} res HTTP response object.
+ * @returns {Promise<void>} Promise resolving when the response is sent.
+ */
+async function handleSubmitModerationRating(req, res) {
+  console.log('[submitModerationRating] method=%s ip=%s', req.method, req.ip);
+  if (req.method !== 'POST') {
+    console.warn('[submitModerationRating] non-POST rejected');
+    res.status(405).send('POST only');
+    return;
+  }
+
+  const { isApproved } = req.body || {};
+  if (typeof isApproved !== 'boolean') {
+    console.warn('[submitModerationRating] isApproved missing or invalid');
+    res.status(400).send('Missing or invalid isApproved');
+    return;
+  }
+
+  const authHeader = req.get('Authorization') || '';
+  const match = authHeader.match(/^Bearer (.+)$/);
+  if (!match) {
+    console.warn('[submitModerationRating] missing bearer token');
+    res.status(401).send('Missing or invalid Authorization header');
+    return;
+  }
+
+  let uid;
+  try {
+    const decoded = await auth.verifyIdToken(match[1]);
+    uid = decoded.uid;
+    console.log('[submitModerationRating] token ok uid=%s', uid);
+  } catch (err) {
+    console.error(
+      '[submitModerationRating] verifyIdToken failed',
+      err.code,
+      err.message,
+      err.stack
+    );
+    res.status(401).send(err.message || 'Invalid or expired token');
+    return;
+  }
+
+  const moderatorRef = db.collection('moderators').doc(uid);
+  const moderatorSnap = await moderatorRef.get();
+  if (!moderatorSnap.exists) {
+    res.status(404).send('No moderation job');
+    return;
+  }
+  const moderatorData = moderatorSnap.data();
+  if (!moderatorData.variant) {
+    res.status(404).send('No moderation job');
+    return;
+  }
+
+  const variantRef = moderatorData.variant;
+  const variantId = variantRef.id;
+
+  await db.collection('moderationRatings').add({
+    moderatorId: uid,
+    variantId,
+    isApproved,
+    ratedAt: FieldValue.serverTimestamp(),
+  });
+
+  await moderatorRef.update({ variant: FieldValue.delete() });
+
+  res.status(201).json({});
+}
+
+app.post('/', handleSubmitModerationRating);
+
+export const submitModerationRating = functions
+  .region('europe-west1')
+  .https.onRequest(app);
+
+export { handleSubmitModerationRating };

--- a/infra/cloud-functions/submit-moderation-rating/package.json
+++ b/infra/cloud-functions/submit-moderation-rating/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "submit-moderation-rating",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.js",
+  "dependencies": {
+    "firebase-admin": "^11.10.1",
+    "firebase-functions": "^4.4.1",
+    "express": "^4.19.2",
+    "cors": "^2.8.5"
+  }
+}

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -489,6 +489,56 @@ resource "google_cloudfunctions_function_iam_member" "get_moderation_variant_inv
     google_project_iam_member.terraform_cloudfunctions_viewer,
   ]
 }
+data "archive_file" "submit_moderation_rating_src" {
+  type        = "zip"
+  source_dir  = "${path.module}/cloud-functions/submit-moderation-rating"
+  output_path = "${path.module}/build/submit-moderation-rating.zip"
+}
+
+resource "google_storage_bucket_object" "submit_moderation_rating" {
+  name   = "${var.environment}-submit-moderation-rating-${data.archive_file.submit_moderation_rating_src.output_sha256}.zip"
+  bucket = google_storage_bucket.gcf_source_bucket.name
+  source = data.archive_file.submit_moderation_rating_src.output_path
+}
+
+resource "google_cloudfunctions_function" "submit_moderation_rating" {
+  name                         = "${var.environment}-submit-moderation-rating"
+  runtime                      = var.cloud_functions_runtime
+  entry_point                  = "submitModerationRating"
+  source_archive_bucket        = google_storage_bucket.gcf_source_bucket.name
+  source_archive_object        = google_storage_bucket_object.submit_moderation_rating.name
+  trigger_http                 = true
+  https_trigger_security_level = var.https_security_level
+  service_account_email        = google_service_account.cloud_function_runtime.email
+  region                       = var.region
+
+  environment_variables = {
+    GCLOUD_PROJECT       = var.project_id
+    GOOGLE_CLOUD_PROJECT = var.project_id
+    FIREBASE_CONFIG      = jsonencode({ projectId = var.project_id })
+  }
+
+  depends_on = [
+    google_project_service.cloudfunctions,
+    google_project_service.cloudbuild,
+    google_project_iam_member.cloudfunctions_access,
+    google_service_account_iam_member.terraform_can_impersonate_runtime,
+    google_service_account_iam_member.terraform_can_impersonate_default_compute,
+  ]
+}
+
+resource "google_cloudfunctions_function_iam_member" "submit_moderation_rating_invoker" {
+  project        = var.project_id
+  region         = var.region
+  cloud_function = google_cloudfunctions_function.submit_moderation_rating.name
+  role           = "roles/cloudfunctions.invoker"
+  member         = "allUsers"
+  depends_on = [
+    google_cloudfunctions_function.submit_moderation_rating,
+    google_project_iam_member.terraform_cloudfunctions_viewer,
+  ]
+}
+
 
 data "archive_file" "process_src" {
   type        = "zip"

--- a/infra/mod.html
+++ b/infra/mod.html
@@ -23,6 +23,8 @@
       <button id="signoutBtn" type="button">Sign out</button>
     </div>
     <div id="actions">
+      <button id="approveBtn" type="button" disabled>Approve</button>
+      <button id="rejectBtn" type="button" disabled>Reject</button>
       <form id="nextPageForm">
         <input type="hidden" id="idTokenField" />
         <button id="nextPageBtn" type="submit" disabled>Next page</button>

--- a/infra/moderate.js
+++ b/infra/moderate.js
@@ -4,6 +4,8 @@ const GET_VARIANT_URL =
   'https://europe-west1-irien-465710.cloudfunctions.net/prod-get-moderation-variant';
 const ASSIGN_JOB_URL =
   'https://europe-west1-irien-465710.cloudfunctions.net/prod-assign-moderation-job';
+const SUBMIT_RATING_URL =
+  'https://europe-west1-irien-465710.cloudfunctions.net/prod-submit-moderation-rating';
 
 /**
  * Ask the back-end for a new moderation job.
@@ -53,20 +55,36 @@ async function loadVariant() {
       });
       container.appendChild(list);
     }
-    const actions = document.getElementById('actions');
-    actions.innerHTML = '';
-    const approve = document.createElement('button');
-    approve.type = 'button';
-    approve.textContent = 'Approve';
-    approve.disabled = true;
-    const reject = document.createElement('button');
-    reject.type = 'button';
-    reject.textContent = 'Reject';
-    reject.disabled = true;
-    actions.appendChild(approve);
-    actions.appendChild(reject);
+    const approve = document.getElementById('approveBtn');
+    const reject = document.getElementById('rejectBtn');
+    if (approve && reject) {
+      approve.disabled = false;
+      reject.disabled = false;
+      approve.onclick = () => submitRating(true);
+      reject.onclick = () => submitRating(false);
+    }
   } catch (err) {
     console.error(err);
+  }
+}
+
+/**
+ *
+ * @param isApproved
+ */
+async function submitRating(isApproved) {
+  const approve = document.getElementById('approveBtn');
+  const reject = document.getElementById('rejectBtn');
+  if (approve) approve.disabled = true;
+  if (reject) reject.disabled = true;
+  try {
+    await authedFetch(SUBMIT_RATING_URL, {
+      method: 'POST',
+      body: JSON.stringify({ isApproved }),
+    });
+  } catch (err) {
+    console.error(err);
+    alert("Sorry, that didn't work. See console for details.");
   }
 }
 
@@ -88,6 +106,10 @@ initGoogleSignIn({
       if (button) {
         button.disabled = true;
       }
+      const approve = document.getElementById('approveBtn');
+      const reject = document.getElementById('rejectBtn');
+      if (approve) approve.disabled = true;
+      if (reject) reject.disabled = true;
       document.body.classList.remove('authed');
     };
     loadVariant();


### PR DESCRIPTION
## Summary
- add submitModerationRating cloud function to store moderator approvals and clear assignments
- wire function into terraform deployment
- enable approve/reject buttons in moderation UI and send rating via new endpoint

## Testing
- `npm test`
- `npm run lint` (warnings: complexity, no-ternary, camelcase, jsdoc)


------
https://chatgpt.com/codex/tasks/task_e_6893b3395d24832e9ae66d9f9c255171