### PR TITLE
feat: allow CORS on assign moderation job

### DIFF
--- a/infra/cloud-functions/assign-moderation-job/package.json
+++ b/infra/cloud-functions/assign-moderation-job/package.json
@@ -5,6 +5,8 @@
   "main": "index.js",
   "dependencies": {
     "firebase-admin": "^11.10.1",
-    "firebase-functions": "^4.4.1"
+    "firebase-functions": "^4.4.1",
+    "express": "^4.19.2",
+    "cors": "^2.8.5"
   }
 }


### PR DESCRIPTION
## Summary
- wrap assign moderation job function with Express and add CORS whitelist for production domains
- include express and cors dependencies for the function

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6893b997133c832eb962d4d2a800a453