### PR TITLE
feat: use uuid for moderation rating id

### DIFF
--- a/infra/cloud-functions/submit-moderation-rating/index.js
+++ b/infra/cloud-functions/submit-moderation-rating/index.js
@@ -4,6 +4,7 @@ import { getFirestore, FieldValue } from 'firebase-admin/firestore';
 import * as functions from 'firebase-functions';
 import express from 'express';
 import cors from 'cors';
+import { randomUUID } from 'crypto';
 
 initializeApp();
 const db = getFirestore();
@@ -90,7 +91,8 @@ async function handleSubmitModerationRating(req, res) {
   const variantRef = moderatorData.variant;
   const variantId = variantRef.id;
 
-  await db.collection('moderationRatings').add({
+  const ratingId = randomUUID();
+  await db.collection('moderationRatings').doc(ratingId).set({
     moderatorId: uid,
     variantId,
     isApproved,


### PR DESCRIPTION
## Summary
- save moderation ratings with a crypto-generated UUID instead of Firestore's auto-generated id

## Testing
- `npm test`
- `npm run lint` *(fails: 36 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6893ba052c3c832ea504a0ca7830be28