### PR TITLE
Add variant visibility update function

### DIFF
--- a/infra/cloud-functions/prod-update-variant-visibility/index.js
+++ b/infra/cloud-functions/prod-update-variant-visibility/index.js
@@ -1,0 +1,54 @@
+import { initializeApp } from 'firebase-admin/app';
+import { getFirestore, FieldPath } from 'firebase-admin/firestore';
+import * as functions from 'firebase-functions';
+
+initializeApp();
+const db = getFirestore();
+
+/**
+ * Update variant visibility when a new moderation rating is created.
+ */
+export const prodUpdateVariantVisibility = functions
+  .region('europe-west1')
+  .firestore.document('moderationRatings/{ratingId}')
+  .onCreate(async snap => {
+    const { variantId, isApproved } = snap.data();
+    if (!variantId || typeof isApproved !== 'boolean') {
+      return null;
+    }
+
+    const newRating = isApproved ? 1.0 : 0.0;
+
+    const variantSnap = await db
+      .collectionGroup('variants')
+      .where(FieldPath.documentId(), '==', variantId)
+      .limit(1)
+      .get();
+    if (variantSnap.empty) {
+      return null;
+    }
+
+    const variantDoc = variantSnap.docs[0];
+    const variantData = variantDoc.data();
+    const visibility =
+      typeof variantData.visibility === 'number' ? variantData.visibility : 0;
+    const moderationRatingCount =
+      typeof variantData.moderationRatingCount === 'number'
+        ? variantData.moderationRatingCount
+        : 0;
+    const moderatorReputationSum =
+      typeof variantData.moderatorReputationSum === 'number'
+        ? variantData.moderatorReputationSum
+        : 0;
+
+    const numerator = visibility * moderatorReputationSum + newRating * 1;
+    const denominator = moderationRatingCount + 1;
+    const newVisibility = numerator / denominator;
+
+    await variantDoc.ref.update({
+      visibility: newVisibility,
+      moderatorRatingCount: moderationRatingCount + 1,
+      moderatorReputationSum: moderatorReputationSum + 1,
+    });
+    return null;
+  });

--- a/infra/cloud-functions/prod-update-variant-visibility/package.json
+++ b/infra/cloud-functions/prod-update-variant-visibility/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "prod-update-variant-visibility",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.js",
+  "dependencies": {
+    "firebase-admin": "^11.10.1",
+    "firebase-functions": "^4.4.1"
+  }
+}


### PR DESCRIPTION
## Summary
- add `prod-update-variant-visibility` Cloud Function to update variant visibility metrics when a new moderation rating is recorded

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893be668048832e834b01742ac8dfc8