### PR TITLE
fix: correct prod update variant visibility name

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -589,13 +589,13 @@ data "archive_file" "prod_update_variant_visibility_src" {
 }
 
 resource "google_storage_bucket_object" "prod_update_variant_visibility" {
-  name   = "${var.environment}-prod-update-variant-visibility-${data.archive_file.prod_update_variant_visibility_src.output_sha256}.zip"
+  name   = "${var.environment}-update-variant-visibility-${data.archive_file.prod_update_variant_visibility_src.output_sha256}.zip"
   bucket = google_storage_bucket.gcf_source_bucket.name
   source = data.archive_file.prod_update_variant_visibility_src.output_path
 }
 
 resource "google_cloudfunctions_function" "prod_update_variant_visibility" {
-  name        = "${var.environment}-prod-update-variant-visibility"
+  name        = "${var.environment}-update-variant-visibility"
   runtime     = var.cloud_functions_runtime
   region      = var.region
   entry_point = "prodUpdateVariantVisibility"


### PR DESCRIPTION
## Summary
- ensure prod update variant visibility Cloud Function and source object use `${var.environment}` prefix

## Testing
- `npx prettier -w infra/main.tf` *(fails: No parser could be inferred for file)*
- `terraform fmt infra/main.tf` *(fails: command not found)*
- `npm test`
- `npm run lint` (43 warnings, 0 errors)


------
https://chatgpt.com/codex/tasks/task_e_6893c5250088832e9f33fcdd132f2350