### PR TITLE
Store full variant path in moderation ratings

### DIFF
--- a/infra/cloud-functions/submit-moderation-rating/index.js
+++ b/infra/cloud-functions/submit-moderation-rating/index.js
@@ -89,7 +89,7 @@ async function handleSubmitModerationRating(req, res) {
   }
 
   const variantRef = moderatorData.variant;
-  const variantId = variantRef.id;
+  const variantId = `/${variantRef.path}`;
 
   const ratingId = randomUUID();
   await db.collection('moderationRatings').doc(ratingId).set({


### PR DESCRIPTION
## Summary
- store the full Firestore path of the rated variant in moderation ratings
- resolve variant documents by full path when updating visibility

## Testing
- `npm test`
- `npm run lint` *(warnings: 43, 0 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6893c5d2ac20832eb6066e33946989ea