### PR TITLE
Auto-assign moderation jobs

### DIFF
--- a/infra/mod.html
+++ b/infra/mod.html
@@ -16,7 +16,10 @@
       Please contribute to keeping Dendrite an excellent place to read and
       write.
     </p>
-    <p>Click the "Next page" button to be shown a page to approve or reject.</p>
+    <p>
+      When you're signed in, a page will be shown to approve or reject. After
+      submitting a rating, the next page will load automatically.
+    </p>
     <div id="pageContent"></div>
     <div id="signinButton"></div>
     <div id="signoutWrap" style="display: none">
@@ -25,10 +28,6 @@
     <div id="actions">
       <button id="approveBtn" type="button" disabled>Approve</button>
       <button id="rejectBtn" type="button" disabled>Reject</button>
-      <form id="nextPageForm">
-        <input type="hidden" id="idTokenField" />
-        <button id="nextPageBtn" type="submit" disabled>Next page</button>
-      </form>
     </div>
 
     <!-- Google Identity Services -->


### PR DESCRIPTION
## Summary
- remove manual "Next page" control from moderation page
- automatically assign a new moderation job when no job exists or after rating submission

## Testing
- `npm test`
- `npm run lint` *(fails: 43 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6893ca35e188832e8dc8bd85899f84b0