### PR TITLE
Add functions to manage variant HTML visibility

### DIFF
--- a/infra/cloud-functions/check-variant-html-visibility/index.js
+++ b/infra/cloud-functions/check-variant-html-visibility/index.js
@@ -1,0 +1,35 @@
+import { initializeApp } from 'firebase-admin/app';
+import * as functions from 'firebase-functions';
+import { renderVariant } from '../render-variant/index.js';
+import { hideVariantHtml } from '../hide-variant-html/index.js';
+
+initializeApp();
+
+const VISIBILITY_THRESHOLD = 0.5;
+
+/**
+ * Check variant visibility and render or hide HTML accordingly.
+ */
+export const checkVariantHtmlVisibility = functions
+  .region('europe-west1')
+  .firestore.document('stories/{storyId}/pages/{pageId}/variants/{variantId}')
+  .onWrite(async (change, ctx) => {
+    if (!change.before.exists || !change.after.exists) {
+      return null;
+    }
+    const beforeVisibility = change.before.data().visibility || 0;
+    const afterVisibility = change.after.data().visibility || 0;
+
+    if (
+      beforeVisibility < VISIBILITY_THRESHOLD &&
+      afterVisibility >= VISIBILITY_THRESHOLD
+    ) {
+      await renderVariant(change.after, ctx);
+    } else if (
+      beforeVisibility >= VISIBILITY_THRESHOLD &&
+      afterVisibility < VISIBILITY_THRESHOLD
+    ) {
+      await hideVariantHtml(change.after, ctx);
+    }
+    return null;
+  });

--- a/infra/cloud-functions/check-variant-html-visibility/package.json
+++ b/infra/cloud-functions/check-variant-html-visibility/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "check-variant-html-visibility",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.js",
+  "dependencies": {
+    "firebase-admin": "^11.10.1",
+    "firebase-functions": "^4.4.1"
+  }
+}

--- a/infra/cloud-functions/hide-variant-html/index.js
+++ b/infra/cloud-functions/hide-variant-html/index.js
@@ -1,0 +1,29 @@
+import { initializeApp } from 'firebase-admin/app';
+import { Storage } from '@google-cloud/storage';
+import * as functions from 'firebase-functions';
+
+initializeApp();
+const storage = new Storage();
+
+/**
+ * Delete the HTML file for a variant.
+ */
+export const hideVariantHtml = functions
+  .region('europe-west1')
+  .firestore.document('stories/{storyId}/pages/{pageId}/variants/{variantId}')
+  .onDelete(async snap => {
+    const variant = snap.data();
+    const pageSnap = await snap.ref.parent.parent.get();
+    if (!pageSnap.exists) {
+      return null;
+    }
+    const page = pageSnap.data();
+    const filePath = `p/${page.number}${variant.name}.html`;
+
+    await storage
+      .bucket('www.dendritestories.co.nz')
+      .file(filePath)
+      .delete({ ignoreNotFound: true });
+
+    return null;
+  });

--- a/infra/cloud-functions/hide-variant-html/package.json
+++ b/infra/cloud-functions/hide-variant-html/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "hide-variant-html",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.js",
+  "dependencies": {
+    "firebase-admin": "^11.10.1",
+    "firebase-functions": "^4.4.1",
+    "@google-cloud/storage": "^7.16.0"
+  }
+}

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -748,3 +748,85 @@ resource "google_cloudfunctions_function" "render_contents" {
     google_project_iam_member.cloudfunctions_access
   ]
 }
+
+data "archive_file" "hide_variant_html_src" {
+  type        = "zip"
+  source_dir  = "${path.module}/cloud-functions/hide-variant-html"
+  output_path = "${path.module}/build/hide-variant-html.zip"
+}
+
+resource "google_storage_bucket_object" "hide_variant_html" {
+  name   = "${var.environment}-hide-variant-html-${data.archive_file.hide_variant_html_src.output_sha256}.zip"
+  bucket = google_storage_bucket.gcf_source_bucket.name
+  source = data.archive_file.hide_variant_html_src.output_path
+}
+
+resource "google_cloudfunctions_function" "hide_variant_html" {
+  name        = "${var.environment}-hide-variant-html"
+  runtime     = var.cloud_functions_runtime
+  region      = var.region
+  entry_point = "hideVariantHtml"
+
+  source_archive_bucket = google_storage_bucket.gcf_source_bucket.name
+  source_archive_object = google_storage_bucket_object.hide_variant_html.name
+
+  service_account_email = google_service_account.cloud_function_runtime.email
+
+  environment_variables = {
+    GCLOUD_PROJECT       = var.project_id
+    GOOGLE_CLOUD_PROJECT = var.project_id
+    FIREBASE_CONFIG      = jsonencode({ projectId = var.project_id })
+  }
+
+  event_trigger {
+    event_type = "providers/cloud.firestore/eventTypes/document.delete"
+    resource   = "projects/${var.project_id}/databases/(default)/documents/stories/{storyId}/pages/{pageId}/variants/{variantId}"
+  }
+
+  depends_on = [
+    google_project_service.cloudfunctions,
+    google_project_service.cloudbuild,
+    google_project_iam_member.cloudfunctions_access
+  ]
+}
+
+data "archive_file" "check_variant_html_visibility_src" {
+  type        = "zip"
+  source_dir  = "${path.module}/cloud-functions/check-variant-html-visibility"
+  output_path = "${path.module}/build/check-variant-html-visibility.zip"
+}
+
+resource "google_storage_bucket_object" "check_variant_html_visibility" {
+  name   = "${var.environment}-check-variant-html-visibility-${data.archive_file.check_variant_html_visibility_src.output_sha256}.zip"
+  bucket = google_storage_bucket.gcf_source_bucket.name
+  source = data.archive_file.check_variant_html_visibility_src.output_path
+}
+
+resource "google_cloudfunctions_function" "check_variant_html_visibility" {
+  name        = "${var.environment}-check-variant-html-visibility"
+  runtime     = var.cloud_functions_runtime
+  region      = var.region
+  entry_point = "checkVariantHtmlVisibility"
+
+  source_archive_bucket = google_storage_bucket.gcf_source_bucket.name
+  source_archive_object = google_storage_bucket_object.check_variant_html_visibility.name
+
+  service_account_email = google_service_account.cloud_function_runtime.email
+
+  environment_variables = {
+    GCLOUD_PROJECT       = var.project_id
+    GOOGLE_CLOUD_PROJECT = var.project_id
+    FIREBASE_CONFIG      = jsonencode({ projectId = var.project_id })
+  }
+
+  event_trigger {
+    event_type = "providers/cloud.firestore/eventTypes/document.write"
+    resource   = "projects/${var.project_id}/databases/(default)/documents/stories/{storyId}/pages/{pageId}/variants/{variantId}"
+  }
+
+  depends_on = [
+    google_project_service.cloudfunctions,
+    google_project_service.cloudbuild,
+    google_project_iam_member.cloudfunctions_access
+  ]
+}


### PR DESCRIPTION
## Summary
- add `hideVariantHtml` Cloud Function to remove variant HTML pages from storage
- add `checkVariantHtmlVisibility` Cloud Function to render or hide variant HTML based on visibility threshold
- wire new functions into Terraform for deployment

## Testing
- `npm test`
- `npm run lint`
- `terraform fmt infra/main.tf` *(fails: terraform: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893cf130aac832ea6c562a96c6810fc