### PR TITLE
Render variants on write and hide HTML when visibility drops

### DIFF
--- a/infra/cloud-functions/hide-variant-html/index.js
+++ b/infra/cloud-functions/hide-variant-html/index.js
@@ -1,0 +1,46 @@
+import { initializeApp } from 'firebase-admin/app';
+import { Storage } from '@google-cloud/storage';
+import * as functions from 'firebase-functions';
+
+initializeApp();
+const storage = new Storage();
+const BUCKET = 'www.dendritestories.co.nz';
+const VISIBILITY_THRESHOLD = 0.5;
+
+/**
+ * Delete the rendered HTML for a variant when it is removed or its visibility drops below the threshold.
+ */
+export const hideVariantHtml = functions
+  .region('europe-west1')
+  .firestore.document('stories/{storyId}/pages/{pageId}/variants/{variantId}')
+  .onWrite(async change => {
+    if (!change.after.exists) {
+      return removeFile(change.before);
+    }
+
+    const beforeVis = change.before.data()?.visibility ?? 0;
+    const afterVis = change.after.data().visibility ?? 0;
+    if (beforeVis >= VISIBILITY_THRESHOLD && afterVis < VISIBILITY_THRESHOLD) {
+      return removeFile(change.after);
+    }
+
+    return null;
+  });
+
+/**
+ *
+ * @param snap
+ */
+async function removeFile(snap) {
+  const variant = snap.data();
+  const pageSnap = await snap.ref.parent.parent.get();
+  if (!pageSnap.exists) {
+    return null;
+  }
+
+  const page = pageSnap.data();
+  const path = `p/${page.number}${variant.name}.html`;
+
+  await storage.bucket(BUCKET).file(path).delete({ ignoreNotFound: true });
+  return null;
+}

--- a/infra/cloud-functions/hide-variant-html/package.json
+++ b/infra/cloud-functions/hide-variant-html/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "hide-variant-html",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.js",
+  "dependencies": {
+    "firebase-admin": "^11.10.1",
+    "firebase-functions": "^4.4.1",
+    "@google-cloud/storage": "^7.16.0"
+  }
+}
+

--- a/infra/cloud-functions/render-variant/index.js
+++ b/infra/cloud-functions/render-variant/index.js
@@ -6,63 +6,83 @@ import { buildHtml } from './buildHtml.js';
 
 initializeApp();
 const storage = new Storage();
+const VISIBILITY_THRESHOLD = 0.5;
 
 /**
- * Cloud Function triggered when a new variant is created.
+ * Render a variant when it is created or its visibility crosses upwards past the threshold.
  */
 export const renderVariant = functions
   .region('europe-west1')
   .firestore.document('stories/{storyId}/pages/{pageId}/variants/{variantId}')
-  .onCreate(async (snap, ctx) => {
-    const variant = snap.data();
-
-    const pageSnap = await snap.ref.parent.parent.get();
-    if (!pageSnap.exists) {
-      return null;
-    }
-    const page = pageSnap.data();
-
-    const optionsSnap = await snap.ref.collection('options').get();
-    const options = optionsSnap.docs.map(doc => doc.data().content || '');
-    let storyTitle = '';
-    if (!page.incomingOptionId) {
-      const storySnap = await pageSnap.ref.parent.parent.get();
-      if (storySnap.exists) {
-        storyTitle = storySnap.data().title || '';
-      }
+  .onWrite(async (change, ctx) => {
+    if (!change.before.exists) {
+      return render(change.after, ctx);
     }
 
-    const html = buildHtml(page.number, variant.content, options, storyTitle);
-    const filePath = `p/${page.number}${variant.name}.html`;
-
-    await storage
-      .bucket('www.dendritestories.co.nz')
-      .file(filePath)
-      .save(html, { contentType: 'text/html' });
-
-    const variantsSnap = await snap.ref.parent.get();
-    const variants = variantsSnap.docs.map(doc => ({
-      name: doc.data().name || '',
-      content: doc.data().content || '',
-    }));
-    const altsHtml = buildAltsHtml(page.number, variants);
-    const altsPath = `p/${page.number}-alts.html`;
-
-    await storage
-      .bucket('www.dendritestories.co.nz')
-      .file(altsPath)
-      .save(altsHtml, { contentType: 'text/html' });
-
-    const pendingPath = `pending/${ctx.params.storyId}.json`;
-    await storage
-      .bucket('www.dendritestories.co.nz')
-      .file(pendingPath)
-      .save(JSON.stringify({ path: filePath }), {
-        contentType: 'application/json',
-        metadata: { cacheControl: 'no-store' }, // 🔑 stop both positive *and* negative caching
-      });
+    const beforeVis = change.before.data().visibility ?? 0;
+    const afterVis = change.after.data().visibility ?? 0;
+    if (beforeVis < VISIBILITY_THRESHOLD && afterVis >= VISIBILITY_THRESHOLD) {
+      return render(change.after, ctx);
+    }
 
     return null;
   });
+
+/**
+ *
+ * @param snap
+ * @param ctx
+ */
+async function render(snap, ctx) {
+  const variant = snap.data();
+
+  const pageSnap = await snap.ref.parent.parent.get();
+  if (!pageSnap.exists) {
+    return null;
+  }
+  const page = pageSnap.data();
+
+  const optionsSnap = await snap.ref.collection('options').get();
+  const options = optionsSnap.docs.map(doc => doc.data().content || '');
+  let storyTitle = '';
+  if (!page.incomingOptionId) {
+    const storySnap = await pageSnap.ref.parent.parent.get();
+    if (storySnap.exists) {
+      storyTitle = storySnap.data().title || '';
+    }
+  }
+
+  const html = buildHtml(page.number, variant.content, options, storyTitle);
+  const filePath = `p/${page.number}${variant.name}.html`;
+
+  await storage
+    .bucket('www.dendritestories.co.nz')
+    .file(filePath)
+    .save(html, { contentType: 'text/html' });
+
+  const variantsSnap = await snap.ref.parent.get();
+  const variants = variantsSnap.docs.map(doc => ({
+    name: doc.data().name || '',
+    content: doc.data().content || '',
+  }));
+  const altsHtml = buildAltsHtml(page.number, variants);
+  const altsPath = `p/${page.number}-alts.html`;
+
+  await storage
+    .bucket('www.dendritestories.co.nz')
+    .file(altsPath)
+    .save(altsHtml, { contentType: 'text/html' });
+
+  const pendingPath = `pending/${ctx.params.storyId}.json`;
+  await storage
+    .bucket('www.dendritestories.co.nz')
+    .file(pendingPath)
+    .save(JSON.stringify({ path: filePath }), {
+      contentType: 'application/json',
+      metadata: { cacheControl: 'no-store' }, // 🔑 stop both positive *and* negative caching
+    });
+
+  return null;
+}
 
 export { buildAltsHtml, buildHtml };

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -696,7 +696,48 @@ resource "google_cloudfunctions_function" "render_variant" {
 
 
   event_trigger {
-    event_type = "providers/cloud.firestore/eventTypes/document.create"
+    event_type = "providers/cloud.firestore/eventTypes/document.write"
+    resource   = "projects/${var.project_id}/databases/(default)/documents/stories/{storyId}/pages/{pageId}/variants/{variantId}"
+  }
+
+  depends_on = [
+    google_project_service.cloudfunctions,
+    google_project_service.cloudbuild,
+    google_project_iam_member.cloudfunctions_access
+  ]
+}
+
+data "archive_file" "hide_variant_html_src" {
+  type        = "zip"
+  source_dir  = "${path.module}/cloud-functions/hide-variant-html"
+  output_path = "${path.module}/build/hide-variant-html.zip"
+}
+
+resource "google_storage_bucket_object" "hide_variant_html" {
+  name   = "${var.environment}-hide-variant-html-${data.archive_file.hide_variant_html_src.output_sha256}.zip"
+  bucket = google_storage_bucket.gcf_source_bucket.name
+  source = data.archive_file.hide_variant_html_src.output_path
+}
+
+resource "google_cloudfunctions_function" "hide_variant_html" {
+  name        = "${var.environment}-hide-variant-html"
+  runtime     = var.cloud_functions_runtime
+  region      = var.region
+  entry_point = "hideVariantHtml"
+
+  source_archive_bucket = google_storage_bucket.gcf_source_bucket.name
+  source_archive_object = google_storage_bucket_object.hide_variant_html.name
+
+  service_account_email = google_service_account.cloud_function_runtime.email
+
+  environment_variables = {
+    GCLOUD_PROJECT       = var.project_id
+    GOOGLE_CLOUD_PROJECT = var.project_id
+    FIREBASE_CONFIG      = jsonencode({ projectId = var.project_id })
+  }
+
+  event_trigger {
+    event_type = "providers/cloud.firestore/eventTypes/document.write"
     resource   = "projects/${var.project_id}/databases/(default)/documents/stories/{storyId}/pages/{pageId}/variants/{variantId}"
   }
 


### PR DESCRIPTION
## Summary
- render variants on Firestore writes and re-render when visibility crosses the threshold
- remove rendered HTML when a variant is deleted or visibility falls below the threshold
- wire new Cloud Function and updated triggers in Terraform

## Testing
- `npm test`
- `npm run lint` *(fails: 53 warnings, 0 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68943a039010832e8f3b54004dd77b51