### PR TITLE
feat: add auth to new story creation

### DIFF
--- a/infra/cloud-functions/process-new-story/index.js
+++ b/infra/cloud-functions/process-new-story/index.js
@@ -55,7 +55,7 @@ export const processNewStory = functions
     batch.set(variantRef, {
       name: 'a',
       content: sub.content,
-      authorId: null,
+      authorId: sub.authorId || null,
       authorName: sub.author,
       createdAt: FieldValue.serverTimestamp(),
     });

--- a/infra/new-story.html
+++ b/infra/new-story.html
@@ -11,6 +11,10 @@
   <body>
     <h1><a href="/">Dendrite</a></h1>
     <h2>New story</h2>
+    <div id="signinButton"></div>
+    <div id="signoutWrap" style="display: none">
+      <button id="signoutBtn" type="button">Sign out</button>
+    </div>
     <form
       action="https://europe-west1-irien-465710.cloudfunctions.net/prod-submit-new-story"
       method="post"
@@ -42,11 +46,39 @@
       </div>
       <p id="saving" style="display: none">Saving...</p>
     </form>
-    <script>
+    <!-- Google Identity Services -->
+    <script src="https://accounts.google.com/gsi/client" defer></script>
+    <script type="module">
+      import { initGoogleSignIn, getIdToken, signOut } from './googleAuth.js';
+
       document.addEventListener('DOMContentLoaded', () => {
         const form = document.querySelector('form');
         const button = form.querySelector("button[type='submit']");
         const saving = document.getElementById('saving');
+        const signin = document.getElementById('signinButton');
+        const signoutWrap = document.getElementById('signoutWrap');
+        const signoutBtn = document.getElementById('signoutBtn');
+
+        initGoogleSignIn({
+          onSignIn: () => {
+            document.body.classList.add('authed');
+            signin.style.display = 'none';
+            signoutWrap.style.display = '';
+          },
+        });
+
+        signoutBtn.addEventListener('click', async () => {
+          await signOut();
+          document.body.classList.remove('authed');
+          signoutWrap.style.display = 'none';
+          signin.style.display = '';
+        });
+
+        if (getIdToken()) {
+          document.body.classList.add('authed');
+          signin.style.display = 'none';
+          signoutWrap.style.display = '';
+        }
 
         form.addEventListener('submit', async event => {
           event.preventDefault();
@@ -61,9 +93,15 @@
 
           try {
             const formData = new URLSearchParams(new FormData(form));
+            const headers = {};
+            const token = getIdToken();
+            if (token) {
+              headers.Authorization = `Bearer ${token}`;
+            }
             const response = await fetch(form.action, {
               method: form.method,
               body: formData,
+              headers,
             });
             if (!response.ok) {
               throw new Error('Submission failed');


### PR DESCRIPTION
## Summary
- add Google sign-in/out to new-story form and include auth token when submitting
- capture Firebase user ID in submit-new-story cloud function
- persist authorId on variants when processing new stories

## Testing
- `npm test`
- `npm run lint` (warnings: 51)


------
https://chatgpt.com/codex/tasks/task_e_68946e512028832e849e37a87627bafa