### PR TITLE
Filter hidden variants from alternate pages

### DIFF
--- a/infra/cloud-functions/render-variant/index.js
+++ b/infra/cloud-functions/render-variant/index.js
@@ -3,10 +3,10 @@ import { Storage } from '@google-cloud/storage';
 import * as functions from 'firebase-functions';
 import { buildAltsHtml } from './buildAltsHtml.js';
 import { buildHtml } from './buildHtml.js';
+import { getVisibleVariants, VISIBILITY_THRESHOLD } from './visibility.js';
 
 initializeApp();
 const storage = new Storage();
-const VISIBILITY_THRESHOLD = 0.5;
 
 /**
  * Render a variant when it is created or its visibility crosses upwards past the threshold.
@@ -61,10 +61,7 @@ async function render(snap, ctx) {
     .save(html, { contentType: 'text/html' });
 
   const variantsSnap = await snap.ref.parent.get();
-  const variants = variantsSnap.docs.map(doc => ({
-    name: doc.data().name || '',
-    content: doc.data().content || '',
-  }));
+  const variants = getVisibleVariants(variantsSnap.docs);
   const altsHtml = buildAltsHtml(page.number, variants);
   const altsPath = `p/${page.number}-alts.html`;
 

--- a/infra/cloud-functions/render-variant/visibility.js
+++ b/infra/cloud-functions/render-variant/visibility.js
@@ -1,0 +1,15 @@
+export const VISIBILITY_THRESHOLD = 0.5;
+
+/**
+ * Filter variants to only include those above the visibility threshold.
+ * @param {Array<{data: () => {name?: string, content?: string, visibility?: number}}>} docs Variant docs.
+ * @returns {Array<{name: string, content: string}>} Visible variants.
+ */
+export function getVisibleVariants(docs) {
+  return docs
+    .filter(doc => (doc.data().visibility ?? 0) >= VISIBILITY_THRESHOLD)
+    .map(doc => ({
+      name: doc.data().name || '',
+      content: doc.data().content || '',
+    }));
+}

--- a/test/cloud-functions/getVisibleVariants.test.js
+++ b/test/cloud-functions/getVisibleVariants.test.js
@@ -1,0 +1,13 @@
+import { describe, test, expect } from '@jest/globals';
+import { getVisibleVariants } from '../../infra/cloud-functions/render-variant/visibility.js';
+
+describe('getVisibleVariants', () => {
+  test('excludes variants below visibility threshold', () => {
+    const docs = [
+      { data: () => ({ name: 'a', content: 'A', visibility: 0.6 }) },
+      { data: () => ({ name: 'b', content: 'B', visibility: 0.4 }) },
+    ];
+    const variants = getVisibleVariants(docs);
+    expect(variants).toEqual([{ name: 'a', content: 'A' }]);
+  });
+});


### PR DESCRIPTION
## Summary
- filter out variants below the visibility threshold when generating an alt variants page
- extract visibility threshold and filtering helper
- test that invisible variants are excluded from alt lists

## Testing
- `npm test`
- `npm run lint` *(fails: 51 warnings)*


------
https://chatgpt.com/codex/tasks/task_e_68947b5d7f3c832e948c76a9da6d543a