### PR TITLE
Hide incoming option field in new page form

### DIFF
--- a/infra/new-page.html
+++ b/infra/new-page.html
@@ -23,11 +23,7 @@
       method="post"
       enctype="multipart/form-data"
     >
-      <div>
-        <label
-          >Incoming option <input type="text" name="incoming_option"
-        /></label>
-      </div>
+      <input type="hidden" name="incoming_option" />
       <div>
         <label>Content <textarea name="content"></textarea></label>
       </div>


### PR DESCRIPTION
## Summary
- hide the incoming option text field in the new page form while keeping its value settable via `option` query parameter

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689488e68610832ea3039b10570fecb2