### PR TITLE
Log variant document path when hiding HTML

### DIFF
--- a/infra/cloud-functions/hide-variant-html/index.js
+++ b/infra/cloud-functions/hide-variant-html/index.js
@@ -42,5 +42,6 @@ async function removeFile(snap) {
   const path = `p/${page.number}${variant.name}.html`;
 
   await storage.bucket(BUCKET).file(path).delete({ ignoreNotFound: true });
+  functions.logger.info(`Deleted HTML for variant ${snap.ref.path}`);
   return null;
 }


### PR DESCRIPTION
## Summary
- log the full variant document path whenever its HTML is deleted in hideVariantHtml

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68948c6f72ac832ea051ee917ad21c88