### PR TITLE
chore: log rendered variant path

### DIFF
--- a/infra/cloud-functions/render-variant/index.js
+++ b/infra/cloud-functions/render-variant/index.js
@@ -55,6 +55,9 @@ async function render(snap, ctx) {
   }
   const page = pageSnap.data();
 
+  const docName = `/${snap.ref.path}`;
+  console.log('[renderVariant] html rendered for %s', docName);
+
   const optionsSnap = await snap.ref.collection('options').get();
   const options = optionsSnap.docs.map(doc => doc.data().content || '');
   let storyTitle = '';


### PR DESCRIPTION
## Summary
- log full Firestore document path when a variant's HTML is rendered

## Testing
- `npm run lint` *(warnings: complexity, jsdoc)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68948c9528fc832eaa2e4e8235a3d539