### PR TITLE
Allow static-site domain for SubmitNewPage CORS

### DIFF
--- a/infra/cloud-functions/submit-new-page/index.js
+++ b/infra/cloud-functions/submit-new-page/index.js
@@ -13,6 +13,7 @@ const app = express();
 const allowed = [
   'https://mattheard.net',
   'https://dendritestories.co.nz',
+  'https://www.dendritestories.co.nz', // static-site domain
 ];
 app.use(
   cors({


### PR DESCRIPTION
## Summary
- allow static-site domain in SubmitNewPage CORS configuration

## Testing
- `npm test`
- `npm run lint` *(warnings: 51)*

------
https://chatgpt.com/codex/tasks/task_e_6894a03e7fdc832e9aea22e489211d8d