### PR TITLE
Sort render variant options by position

### DIFF
--- a/infra/cloud-functions/render-variant/index.js
+++ b/infra/cloud-functions/render-variant/index.js
@@ -59,7 +59,10 @@ async function render(snap, ctx) {
   console.log('[renderVariant] html rendered for %s', docName);
 
   const optionsSnap = await snap.ref.collection('options').get();
-  const options = optionsSnap.docs.map(doc => doc.data().content || '');
+  const options = optionsSnap.docs
+    .map(doc => doc.data())
+    .sort((a, b) => (a.position ?? 0) - (b.position ?? 0))
+    .map(data => data.content || '');
   let storyTitle = '';
   if (!page.incomingOptionId) {
     const storySnap = await pageSnap.ref.parent.parent.get();


### PR DESCRIPTION
## Summary
- sort variant rendering options by their `position` field so output is ordered

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894a8033834832eb9690ab1ab9098f5