### PR TITLE
Use URL-encoded form submission on new page

### DIFF
--- a/infra/new-page.html
+++ b/infra/new-page.html
@@ -21,7 +21,7 @@
     <form
       action="https://europe-west1-irien-465710.cloudfunctions.net/prod-submit-new-page"
       method="post"
-      enctype="multipart/form-data"
+      enctype="application/x-www-form-urlencoded"
     >
       <input type="hidden" name="incoming_option" />
       <div>


### PR DESCRIPTION
## Summary
- Submit new page form as a standard `application/x-www-form-urlencoded` request instead of `multipart/form-data`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894c7be2c4c832ebb6dc7cd4ba11959