### PR TITLE
Link variant options to new page

### DIFF
--- a/infra/cloud-functions/render-variant/buildHtml.js
+++ b/infra/cloud-functions/render-variant/buildHtml.js
@@ -3,13 +3,25 @@ import { escapeHtml } from './buildAltsHtml.js';
 /**
  * Build HTML page for the variant.
  * @param {number} pageNumber Page number.
+ * @param {string} variantName Variant name.
  * @param {string} content Variant content.
- * @param {Array<string>} options Option texts.
+ * @param {Array<{content: string, position: number}>} options Option info.
  * @param {string} [storyTitle] Story title.
  * @returns {string} HTML page.
  */
-export function buildHtml(pageNumber, content, options, storyTitle = '') {
-  const items = options.map(opt => `<li>${escapeHtml(opt)}</li>`).join('');
+export function buildHtml(
+  pageNumber,
+  variantName,
+  content,
+  options,
+  storyTitle = ''
+) {
+  const items = options
+    .map(opt => {
+      const slug = `${pageNumber}-${variantName}-${opt.position}`;
+      return `<li><a href="../new-page.html?option=${slug}">${escapeHtml(opt.content)}</a></li>`;
+    })
+    .join('');
   const title = storyTitle ? `<h1>${escapeHtml(storyTitle)}</h1>` : '';
   return `<!doctype html><html lang="en"><head><meta charset="UTF-8" /><meta name="viewport" content="width=device-width, initial-scale=1" /><title>Dendrite</title><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.fluid.classless.min.css" /></head><body><h1><img src="../img/logo.png" alt="Dendrite logo" style="height:1em;vertical-align:middle;margin-right:0.5em;" /><a href="/">Dendrite</a></h1>${title}<p>${escapeHtml(content)}</p><ol>${items}</ol><p><a href="./${pageNumber}-alts.html">More options</a></p></body></html>`;
 }

--- a/infra/cloud-functions/render-variant/index.js
+++ b/infra/cloud-functions/render-variant/index.js
@@ -62,7 +62,10 @@ async function render(snap, ctx) {
   const options = optionsSnap.docs
     .map(doc => doc.data())
     .sort((a, b) => (a.position ?? 0) - (b.position ?? 0))
-    .map(data => data.content || '');
+    .map(data => ({
+      content: data.content || '',
+      position: data.position ?? 0,
+    }));
   let storyTitle = '';
   if (!page.incomingOptionId) {
     const storySnap = await pageSnap.ref.parent.parent.get();
@@ -71,7 +74,13 @@ async function render(snap, ctx) {
     }
   }
 
-  const html = buildHtml(page.number, variant.content, options, storyTitle);
+  const html = buildHtml(
+    page.number,
+    variant.name,
+    variant.content,
+    options,
+    storyTitle
+  );
   const filePath = `p/${page.number}${variant.name}.html`;
 
   await storage

--- a/test/cloud-functions/buildHtml.test.js
+++ b/test/cloud-functions/buildHtml.test.js
@@ -3,15 +3,24 @@ import { buildHtml } from '../../infra/cloud-functions/render-variant/buildHtml.
 
 describe('buildHtml', () => {
   test('omits story title when not provided', () => {
-    const html = buildHtml(1, 'hello', []);
+    const html = buildHtml(1, 'a', 'hello', []);
     expect(html).not.toContain('<h1>My Story</h1>');
   });
 
   test('includes story title before content when provided', () => {
-    const html = buildHtml(1, 'hello', [], 'My Story');
+    const html = buildHtml(1, 'a', 'hello', [], 'My Story');
     const titleIndex = html.indexOf('<h1>My Story</h1>');
     const contentIndex = html.indexOf('<p>hello</p>');
     expect(titleIndex).toBeGreaterThan(-1);
     expect(titleIndex).toBeLessThan(contentIndex);
+  });
+
+  test('links options using slug', () => {
+    const html = buildHtml(12, 'a', 'content', [
+      { content: 'Go left', position: 0 },
+    ]);
+    expect(html).toContain(
+      '<li><a href="../new-page.html?option=12-a-0">Go left</a></li>'
+    );
   });
 });


### PR DESCRIPTION
## Summary
- hyperlink variant options to `../new-page.html` with slug query built from page number, variant name, and option position
- pass variant name and option positions into HTML builder and test slugged links

## Testing
- `npm test`
- `npm run lint` *(fails: 53 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6894cbc2b94c832e9ce25171aea34a9b