### PR TITLE
Use JS submission for new page form

### DIFF
--- a/infra/new-page.html
+++ b/infra/new-page.html
@@ -45,6 +45,7 @@
       <div>
         <button type="submit">Submit</button>
       </div>
+      <p id="saving" style="display: none">Saving...</p>
     </form>
     <script>
       document.addEventListener('DOMContentLoaded', () => {
@@ -56,6 +57,51 @@
             input.value = incoming;
           }
         }
+
+        const form = document.querySelector('form');
+        const button = form.querySelector("button[type='submit']");
+        const saving = document.getElementById('saving');
+
+        form.addEventListener('submit', async event => {
+          event.preventDefault();
+          button.disabled = true;
+          saving.style.display = 'block';
+          let dots = 1;
+          saving.textContent = 'Saving.';
+          const intervalId = setInterval(() => {
+            dots = (dots % 3) + 1;
+            saving.textContent = `Saving${'.'.repeat(dots)}`;
+          }, 500);
+
+          try {
+            const formData = new URLSearchParams(new FormData(form));
+            const response = await fetch(form.action, {
+              method: form.method,
+              body: formData,
+            });
+            if (!response.ok) {
+              throw new Error('Submission failed');
+            }
+            const { id } = await response.json();
+            let delay = 500;
+            while (true) {
+              await new Promise(resolve => setTimeout(resolve, delay));
+              const ts = Date.now();
+              const pendingRes = await fetch(`/pending/${id}.json?ts=${ts}`);
+              if (pendingRes.ok) {
+                const data = await pendingRes.json();
+                clearInterval(intervalId);
+                window.location.href = data.path;
+                return;
+              }
+              delay = Math.min(delay * 2, 8000);
+            }
+          } catch {
+            clearInterval(intervalId);
+            saving.textContent = 'Failed to save.';
+            button.disabled = false;
+          }
+        });
       });
     </script>
   </body>


### PR DESCRIPTION
## Summary
- Enhance new page form to submit via JavaScript and show a saving indicator
- Poll pending endpoint and redirect to the freshly created page once available

## Testing
- `npm test`
- `npm run lint` *(warnings: Method 'origin' has a complexity of 3... and 52 other warnings)*


------
https://chatgpt.com/codex/tasks/task_e_6894d0d20d9c832ebb0368370e1bef52