### PR TITLE
Use full option path for SubmitNewPage

### DIFF
--- a/infra/cloud-functions/process-new-story/index.js
+++ b/infra/cloud-functions/process-new-story/index.js
@@ -48,7 +48,7 @@ export const processNewStory = functions
 
     batch.set(pageRef, {
       number: candidate,
-      incomingOptionId: null,
+      incomingOptionFullName: null,
       createdAt: FieldValue.serverTimestamp(),
     });
 

--- a/infra/cloud-functions/render-variant/index.js
+++ b/infra/cloud-functions/render-variant/index.js
@@ -67,7 +67,7 @@ async function render(snap, ctx) {
       position: data.position ?? 0,
     }));
   let storyTitle = '';
-  if (!page.incomingOptionId) {
+  if (!page.incomingOptionFullName) {
     const storySnap = await pageSnap.ref.parent.parent.get();
     if (storySnap.exists) {
       storyTitle = storySnap.data().title || '';

--- a/infra/cloud-functions/submit-new-page/helpers.js
+++ b/infra/cloud-functions/submit-new-page/helpers.js
@@ -47,7 +47,7 @@ export function parseIncomingOption(str) {
  * @param {object} db Firestore database instance.
  * @param {{pageNumber: number, variantName: string, optionNumber: number}} info
  *   Location details.
- * @returns {Promise<string|null>} Option identifier or null when not found.
+ * @returns {Promise<string|null>} Option document path or null when not found.
  */
 export async function findExistingOption(db, info) {
   if (!db || !info) {
@@ -79,5 +79,5 @@ export async function findExistingOption(db, info) {
   if (optionsSnap.size <= info.optionNumber) {
     return null;
   }
-  return optionsSnap.docs[info.optionNumber].id;
+  return optionsSnap.docs[info.optionNumber].ref.path;
 }

--- a/infra/cloud-functions/submit-new-page/index.js
+++ b/infra/cloud-functions/submit-new-page/index.js
@@ -53,7 +53,7 @@ async function handleSubmit(req, res) {
 
   const parsed = parseIncomingOption(incomingOption);
 
-  let incomingOptionId = null;
+  let incomingOptionFullName = null;
   if (!parsed) {
     res.status(400).json({ error: 'invalid incoming option' });
     return;
@@ -63,7 +63,7 @@ async function handleSubmit(req, res) {
     res.status(400).json({ error: 'incoming option not found' });
     return;
   }
-  incomingOptionId = found;
+  incomingOptionFullName = found;
 
   const options = [];
   for (let i = 0; i < 4; i += 1) {
@@ -79,7 +79,7 @@ async function handleSubmit(req, res) {
 
   const id = crypto.randomUUID();
   await db.collection('pageFormSubmissions').doc(id).set({
-    incomingOptionId,
+    incomingOptionFullName,
     content,
     author,
     options,
@@ -88,7 +88,7 @@ async function handleSubmit(req, res) {
 
   res.status(201).json({
     id,
-    incomingOptionId,
+    incomingOptionFullName,
     content,
     author,
     options,

--- a/infra/rules/firestore.rules
+++ b/infra/rules/firestore.rules
@@ -37,16 +37,16 @@ service cloud.firestore {
         /*  PAGES  */
         allow read, create: if true;
 
-        /*  Exactly-once update: set incomingOptionId
-            - incomingOptionId must currently be null
+        /*  Exactly-once update: set incomingOptionFullName
+            - incomingOptionFullName must currently be null
             - it’s the ONLY field that may change
             - new value must be a string
         */
         allow update: if
-          resource.data.incomingOptionId == null &&
+          resource.data.incomingOptionFullName == null &&
           request.resource.data.diff(resource.data).changedKeys()
-                .hasOnly(['incomingOptionId']) &&
-          request.resource.data.incomingOptionId is string;
+                .hasOnly(['incomingOptionFullName']) &&
+          request.resource.data.incomingOptionFullName is string;
 
         allow delete: if false;
 

--- a/test/cloud-functions/submitNewPageHelpers.test.js
+++ b/test/cloud-functions/submitNewPageHelpers.test.js
@@ -20,13 +20,16 @@ describe('parseIncomingOption', () => {
 });
 
 describe('findExistingOption', () => {
-  test('returns option id when found', async () => {
-    const optionId = 'opt1';
+  test('returns option path when found', async () => {
+    const optionPath = 'stories/s1/pages/p1/variants/v1/options/opt1';
     const variantRef = {
       collection: jest.fn(() => ({
         orderBy: jest.fn().mockReturnThis(),
         limit: jest.fn().mockReturnThis(),
-        get: jest.fn().mockResolvedValue({ size: 1, docs: [{ id: optionId }] }),
+        get: jest.fn().mockResolvedValue({
+          size: 1,
+          docs: [{ ref: { path: optionPath } }],
+        }),
       })),
     };
     const pageRef = {
@@ -52,7 +55,7 @@ describe('findExistingOption', () => {
       variantName: 'a',
       optionNumber: 0,
     });
-    expect(result).toBe(optionId);
+    expect(result).toBe(optionPath);
   });
 
   test('returns null when option missing', async () => {


### PR DESCRIPTION
## Summary
- Capture the full Firestore path of the incoming option and persist it with page submissions
- Resolve page creation logic against stored option paths instead of bare UUIDs
- Update Firestore rules and related functions to reference `incomingOptionFullName`

## Testing
- `npm test`
- `npm run lint` *(fails: 53 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6894d6d7f17c832e9ac93ace71cb78c5