### PR TITLE
Rename incoming option field in pages and variants

### DIFF
--- a/infra/cloud-functions/process-new-page/index.js
+++ b/infra/cloud-functions/process-new-page/index.js
@@ -55,7 +55,7 @@ export const processNewPage = functions
     const batch = db.batch();
     batch.set(newPageRef, {
       number: candidate,
-      incomingOptionFullName,
+      incomingOption: incomingOptionFullName,
       createdAt: FieldValue.serverTimestamp(),
     });
 
@@ -63,7 +63,7 @@ export const processNewPage = functions
       name: 'a',
       content: sub.content,
       authorId: null,
-      incomingOptionFullName,
+      incomingOption: incomingOptionFullName,
       createdAt: FieldValue.serverTimestamp(),
     });
 

--- a/infra/cloud-functions/process-new-story/index.js
+++ b/infra/cloud-functions/process-new-story/index.js
@@ -48,7 +48,7 @@ export const processNewStory = functions
 
     batch.set(pageRef, {
       number: candidate,
-      incomingOptionFullName: null,
+      incomingOption: null,
       createdAt: FieldValue.serverTimestamp(),
     });
 

--- a/infra/cloud-functions/render-variant/index.js
+++ b/infra/cloud-functions/render-variant/index.js
@@ -67,7 +67,7 @@ async function render(snap, ctx) {
       position: data.position ?? 0,
     }));
   let storyTitle = '';
-  if (!page.incomingOptionFullName) {
+  if (!page.incomingOption) {
     const storySnap = await pageSnap.ref.parent.parent.get();
     if (storySnap.exists) {
       storyTitle = storySnap.data().title || '';

--- a/infra/rules/firestore.rules
+++ b/infra/rules/firestore.rules
@@ -37,16 +37,16 @@ service cloud.firestore {
         /*  PAGES  */
         allow read, create: if true;
 
-        /*  Exactly-once update: set incomingOptionFullName
-            - incomingOptionFullName must currently be null
+        /*  Exactly-once update: set incomingOption
+            - incomingOption must currently be null
             - it’s the ONLY field that may change
             - new value must be a string
         */
         allow update: if
-          resource.data.incomingOptionFullName == null &&
+          resource.data.incomingOption == null &&
           request.resource.data.diff(resource.data).changedKeys()
-                .hasOnly(['incomingOptionFullName']) &&
-          request.resource.data.incomingOptionFullName is string;
+                .hasOnly(['incomingOption']) &&
+          request.resource.data.incomingOption is string;
 
         allow delete: if false;
 


### PR DESCRIPTION
## Summary
- store incoming option path on new pages and variants as `incomingOption`
- read new field during rendering and root story creation
- update Firestore rules for the renamed field

## Testing
- `npm test`
- `npm run lint` *(warnings: complexity, camelcase)*

------
https://chatgpt.com/codex/tasks/task_e_6895c656c048832ea9d60f73ddd663fa