### PR TITLE
Use submission ID for new variant

### DIFF
--- a/infra/cloud-functions/process-new-page/index.js
+++ b/infra/cloud-functions/process-new-page/index.js
@@ -48,7 +48,7 @@ export const processNewPage = functions
     }
 
     const newPageId = crypto.randomUUID();
-    const variantId = crypto.randomUUID();
+    const variantId = snap.id;
     const newPageRef = storyRef.collection('pages').doc(newPageId);
     const newVariantRef = newPageRef.collection('variants').doc(variantId);
 


### PR DESCRIPTION
## Summary
- Use the new page submission's document ID as the Firestore document ID for the initial variant in `processNewPage`

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6895d36c5518832eb311a4ac0f579680