### PR TITLE
Use variant ID for pending render output when incoming option exists

### DIFF
--- a/infra/cloud-functions/render-variant/index.js
+++ b/infra/cloud-functions/render-variant/index.js
@@ -98,7 +98,10 @@ async function render(snap, ctx) {
     .file(altsPath)
     .save(altsHtml, { contentType: 'text/html' });
 
-  const pendingPath = `pending/${ctx.params.storyId}.json`;
+  const pendingName = variant.incomingOption
+    ? ctx.params.variantId
+    : ctx.params.storyId;
+  const pendingPath = `pending/${pendingName}.json`;
   await storage
     .bucket('www.dendritestories.co.nz')
     .file(pendingPath)


### PR DESCRIPTION
## Summary
- Use variant ID as pending JSON filename when a variant has an incoming option, otherwise use story ID

## Testing
- `npm test`
- `npm run lint` *(warnings: Method 'origin' has a complexity of 3..., Async function 'handleSubmit' has a complexity of 11..., ... 54 warnings in total)*

------
https://chatgpt.com/codex/tasks/task_e_6895d487b9cc832ebaa62ecaad722c63