### PR TITLE
Use document references for option target pages

### DIFF
--- a/infra/cloud-functions/process-new-page/index.js
+++ b/infra/cloud-functions/process-new-page/index.js
@@ -73,13 +73,12 @@ export const processNewPage = functions
         .doc(crypto.randomUUID());
       batch.set(optRef, {
         content: text,
-        targetPageId: null,
         createdAt: FieldValue.serverTimestamp(),
         position,
       });
     });
 
-    batch.update(optionRef, { targetPageId: newPageId });
+    batch.update(optionRef, { targetPage: newPageRef });
     batch.update(snap.ref, { processed: true });
 
     await batch.commit();

--- a/infra/cloud-functions/process-new-story/index.js
+++ b/infra/cloud-functions/process-new-story/index.js
@@ -66,7 +66,6 @@ export const processNewStory = functions
         .doc(crypto.randomUUID());
       batch.set(optionRef, {
         content: text,
-        targetPageId: null,
         createdAt: FieldValue.serverTimestamp(),
         position,
       });

--- a/infra/rules/firestore.rules
+++ b/infra/rules/firestore.rules
@@ -60,15 +60,15 @@ service cloud.firestore {
             allow read, create: if true;
 
             /*  Exactly-once update: stitch option to a target page
-                - targetPageId must currently be null
+                - targetPage must currently be null
                 - it’s the ONLY field that may change
-                - new value must be a string
+                - new value must be a reference
             */
             allow update: if
-              resource.data.targetPageId == null &&
+              resource.data.targetPage == null &&
               request.resource.data.diff(resource.data).changedKeys()
-                    .hasOnly(['targetPageId']) &&
-              request.resource.data.targetPageId is string;
+                    .hasOnly(['targetPage']) &&
+              request.resource.data.targetPage is path;
 
             allow delete: if false;
           }


### PR DESCRIPTION
## Summary
- Remove `targetPageId` from new option documents in process-new-story and process-new-page
- Link stitched pages by setting `targetPage` to the new page's document reference in process-new-page
- Update Firestore rules to validate `targetPage` references instead of string IDs

## Testing
- `npm run lint` (warnings only)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896179c37c8832e977748f0fd3aa02f