### PR TITLE
Link options to existing pages when target set

### DIFF
--- a/infra/cloud-functions/render-variant/buildHtml.js
+++ b/infra/cloud-functions/render-variant/buildHtml.js
@@ -5,7 +5,11 @@ import { escapeHtml } from './buildAltsHtml.js';
  * @param {number} pageNumber Page number.
  * @param {string} variantName Variant name.
  * @param {string} content Variant content.
- * @param {Array<{content: string, position: number}>} options Option info.
+ * @param {Array<{
+ *   content: string,
+ *   position: number,
+ *   targetPageNumber?: number,
+ * }>} options Option info.
  * @param {string} [storyTitle] Story title.
  * @returns {string} HTML page.
  */
@@ -19,7 +23,11 @@ export function buildHtml(
   const items = options
     .map(opt => {
       const slug = `${pageNumber}-${variantName}-${opt.position}`;
-      return `<li><a href="../new-page.html?option=${slug}">${escapeHtml(opt.content)}</a></li>`;
+      const href =
+        opt.targetPageNumber !== undefined
+          ? `/p/${opt.targetPageNumber}a.html`
+          : `../new-page.html?option=${slug}`;
+      return `<li><a href="${href}">${escapeHtml(opt.content)}</a></li>`;
     })
     .join('');
   const title = storyTitle ? `<h1>${escapeHtml(storyTitle)}</h1>` : '';

--- a/test/cloud-functions/buildHtml.test.js
+++ b/test/cloud-functions/buildHtml.test.js
@@ -15,12 +15,19 @@ describe('buildHtml', () => {
     expect(titleIndex).toBeLessThan(contentIndex);
   });
 
-  test('links options using slug', () => {
+  test('links option without target page using slug', () => {
     const html = buildHtml(12, 'a', 'content', [
       { content: 'Go left', position: 0 },
     ]);
     expect(html).toContain(
       '<li><a href="../new-page.html?option=12-a-0">Go left</a></li>'
     );
+  });
+
+  test('links option with target page to existing page', () => {
+    const html = buildHtml(5, 'a', 'content', [
+      { content: 'Go right', position: 1, targetPageNumber: 42 },
+    ]);
+    expect(html).toContain('<li><a href="/p/42a.html">Go right</a></li>');
   });
 });


### PR DESCRIPTION
## Summary
- link rendered options to existing pages when option points to a target page
- include target page numbers when building variant HTML
- test linking for both new-page and existing-page options

## Testing
- `npm test`
- `npm run lint` *(fails: 55 warnings)*


------
https://chatgpt.com/codex/tasks/task_e_68961b74fcb4832ebbafb30d8c5247a0