### PR TITLE
feat: mark parent variant dirty when linking new page

### DIFF
--- a/infra/cloud-functions/process-new-page/index.js
+++ b/infra/cloud-functions/process-new-page/index.js
@@ -79,6 +79,7 @@ export const processNewPage = functions
     });
 
     batch.update(optionRef, { targetPage: newPageRef });
+    batch.update(variantRef, { dirty: null });
     batch.update(snap.ref, { processed: true });
 
     await batch.commit();


### PR DESCRIPTION
## Summary
- ensure process-new-page marks the parent variant as dirty after linking a new page

## Testing
- `npm test`
- `npm run lint` *(warnings: Async function 'handleSubmit' has a complexity of 11. Maximum allowed is 2, Identifier 'client_id' is not in camel case, Identifier 'ux_mode' is not in camel case)*

------
https://chatgpt.com/codex/tasks/task_e_68961c1bb370832eab8459da2744b18c