### PR TITLE
Render author name below variant options

### DIFF
--- a/infra/cloud-functions/render-variant/buildHtml.js
+++ b/infra/cloud-functions/render-variant/buildHtml.js
@@ -11,6 +11,7 @@ import { escapeHtml } from './buildAltsHtml.js';
  *   targetPageNumber?: number,
  * }>} options Option info.
  * @param {string} [storyTitle] Story title.
+ * @param {string} [author] Author name.
  * @returns {string} HTML page.
  */
 export function buildHtml(
@@ -18,7 +19,8 @@ export function buildHtml(
   variantName,
   content,
   options,
-  storyTitle = ''
+  storyTitle = '',
+  author = ''
 ) {
   const items = options
     .map(opt => {
@@ -31,5 +33,6 @@ export function buildHtml(
     })
     .join('');
   const title = storyTitle ? `<h1>${escapeHtml(storyTitle)}</h1>` : '';
-  return `<!doctype html><html lang="en"><head><meta charset="UTF-8" /><meta name="viewport" content="width=device-width, initial-scale=1" /><title>Dendrite</title><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.fluid.classless.min.css" /></head><body><h1><img src="../img/logo.png" alt="Dendrite logo" style="height:1em;vertical-align:middle;margin-right:0.5em;" /><a href="/">Dendrite</a></h1>${title}<p>${escapeHtml(content)}</p><ol>${items}</ol><p><a href="./${pageNumber}-alts.html">More options</a></p></body></html>`;
+  const authorHtml = author ? `<p>By ${escapeHtml(author)}</p>` : '';
+  return `<!doctype html><html lang="en"><head><meta charset="UTF-8" /><meta name="viewport" content="width=device-width, initial-scale=1" /><title>Dendrite</title><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.fluid.classless.min.css" /></head><body><h1><img src="../img/logo.png" alt="Dendrite logo" style="height:1em;vertical-align:middle;margin-right:0.5em;" /><a href="/">Dendrite</a></h1>${title}<p>${escapeHtml(content)}</p><ol>${items}</ol>${authorHtml}<p><a href="./${pageNumber}-alts.html">More options</a></p></body></html>`;
 }

--- a/infra/cloud-functions/render-variant/index.js
+++ b/infra/cloud-functions/render-variant/index.js
@@ -88,12 +88,15 @@ async function render(snap, ctx) {
     }
   }
 
+  const authorName = variant.authorName || variant.author || '';
+
   const html = buildHtml(
     page.number,
     variant.name,
     variant.content,
     options,
-    storyTitle
+    storyTitle,
+    authorName
   );
   const filePath = `p/${page.number}${variant.name}.html`;
 

--- a/test/cloud-functions/buildHtml.test.js
+++ b/test/cloud-functions/buildHtml.test.js
@@ -30,4 +30,11 @@ describe('buildHtml', () => {
     ]);
     expect(html).toContain('<li><a href="/p/42a.html">Go right</a></li>');
   });
+
+  test('includes author below options when provided', () => {
+    const html = buildHtml(3, 'a', 'content', [], '', 'Jane Doe');
+    const optionsIndex = html.indexOf('</ol>');
+    const authorIndex = html.indexOf('<p>By Jane Doe</p>');
+    expect(authorIndex).toBeGreaterThan(optionsIndex);
+  });
 });


### PR DESCRIPTION
## Summary
- Render author name beneath variant option list via buildHtml helper
- Pass variant author information to render function
- Test HTML rendering includes author block

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689642d3c0c4832e8e337db3e4e42b35