### PR TITLE
Prevent caching for open variants

### DIFF
--- a/infra/cloud-functions/render-variant/index.js
+++ b/infra/cloud-functions/render-variant/index.js
@@ -99,11 +99,15 @@ async function render(snap, ctx) {
     authorName
   );
   const filePath = `p/${page.number}${variant.name}.html`;
+  const openVariant = options.some(opt => opt.targetPageNumber === undefined);
 
   await storage
     .bucket('www.dendritestories.co.nz')
     .file(filePath)
-    .save(html, { contentType: 'text/html' });
+    .save(html, {
+      contentType: 'text/html',
+      ...(openVariant && { metadata: { cacheControl: 'no-store' } }),
+    });
 
   const variantsSnap = await snap.ref.parent.get();
   const variants = getVisibleVariants(variantsSnap.docs);
@@ -130,4 +134,4 @@ async function render(snap, ctx) {
   return null;
 }
 
-export { buildAltsHtml, buildHtml };
+export { buildAltsHtml, buildHtml, render };

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -6,6 +6,11 @@ const config = {
     '^(\\.{1,2}/.*)\\.js$': '$1',
     '^https://www\\.gstatic\\.com/firebasejs/12\\.0\\.0/(.*)$':
       '<rootDir>/test/mocks/$1',
+    '^firebase-admin/app$': '<rootDir>/test/mocks/firebase-admin-app.js',
+    '^firebase-admin/firestore$':
+      '<rootDir>/test/mocks/firebase-admin-firestore.js',
+    '^firebase-functions$': '<rootDir>/test/mocks/firebase-functions.js',
+    '^@google-cloud/storage$': '<rootDir>/test/mocks/google-cloud-storage.js',
   },
   // Use node environment by default, but allow override for browser testing
   testEnvironment: 'node',

--- a/test/cloud-functions/renderVariant.test.js
+++ b/test/cloud-functions/renderVariant.test.js
@@ -1,0 +1,58 @@
+import { describe, test, expect, jest, beforeEach } from '@jest/globals';
+import { mockSave, mockFile, mockBucket } from '@google-cloud/storage';
+import { render } from '../../infra/cloud-functions/render-variant/index.js';
+
+/**
+ *
+ * @param optionData
+ */
+function createSnap(optionData) {
+  const optionsDocs = optionData.map(d => ({ data: () => d }));
+  const optionsCollection = {
+    get: jest.fn().mockResolvedValue({ docs: optionsDocs }),
+  };
+  const pageRef = {};
+  const pageSnap = {
+    exists: true,
+    data: () => ({ number: 1, incomingOption: true }),
+    ref: pageRef,
+  };
+  pageRef.get = jest.fn().mockResolvedValue(pageSnap);
+  const variantsCollection = {
+    get: jest.fn().mockResolvedValue({ docs: [] }),
+    parent: pageRef,
+  };
+  return {
+    data: () => ({ name: 'a', content: 'content', incomingOption: false }),
+    ref: {
+      path: 'stories/s1/pages/p1/variants/v1',
+      parent: variantsCollection,
+      collection: jest.fn(() => optionsCollection),
+    },
+  };
+}
+
+describe('render', () => {
+  beforeEach(() => {
+    mockSave.mockClear();
+    mockFile.mockClear();
+    mockBucket.mockClear();
+  });
+
+  test('sets cache control when variant open', async () => {
+    const snap = createSnap([{ content: 'Go', position: 0 }]);
+    await render(snap, { params: { storyId: 's1', variantId: 'v1' } });
+    expect(mockSave.mock.calls[0][1]).toMatchObject({
+      contentType: 'text/html',
+      metadata: { cacheControl: 'no-store' },
+    });
+  });
+
+  test('omits cache control when variant closed', async () => {
+    const snap = createSnap([
+      { content: 'Go', position: 0, targetPageNumber: 2 },
+    ]);
+    await render(snap, { params: { storyId: 's1', variantId: 'v1' } });
+    expect(mockSave.mock.calls[0][1]).toEqual({ contentType: 'text/html' });
+  });
+});

--- a/test/mocks/firebase-admin-app.js
+++ b/test/mocks/firebase-admin-app.js
@@ -1,0 +1,1 @@
+export const initializeApp = () => {};

--- a/test/mocks/firebase-admin-firestore.js
+++ b/test/mocks/firebase-admin-firestore.js
@@ -1,0 +1,1 @@
+export const FieldValue = { delete: () => {} };

--- a/test/mocks/firebase-functions.js
+++ b/test/mocks/firebase-functions.js
@@ -1,0 +1,3 @@
+export const region = () => ({
+  firestore: { document: () => ({ onWrite: () => {} }) },
+});

--- a/test/mocks/google-cloud-storage.js
+++ b/test/mocks/google-cloud-storage.js
@@ -1,0 +1,11 @@
+import { jest } from '@jest/globals';
+
+export const mockSave = jest.fn();
+export const mockFile = jest.fn(() => ({ save: mockSave }));
+export const mockBucket = jest.fn(() => ({ file: mockFile }));
+
+export class Storage {
+  bucket(...args) {
+    return mockBucket(...args);
+  }
+}


### PR DESCRIPTION
## Summary
- stop caching variant HTML when any option lacks a target page
- map Firebase and Storage modules to local mocks for testing and add unit tests for cache behavior

## Testing
- `npm test`
- `npm run lint` *(fails: warnings only)*

------
https://chatgpt.com/codex/tasks/task_e_68970b3c3160832ebf40457dbf6aabad