### PR TITLE
Change variant page link text

### DIFF
--- a/infra/cloud-functions/render-variant/buildHtml.js
+++ b/infra/cloud-functions/render-variant/buildHtml.js
@@ -34,5 +34,5 @@ export function buildHtml(
     .join('');
   const title = storyTitle ? `<h1>${escapeHtml(storyTitle)}</h1>` : '';
   const authorHtml = author ? `<p>By ${escapeHtml(author)}</p>` : '';
-  return `<!doctype html><html lang="en"><head><meta charset="UTF-8" /><meta name="viewport" content="width=device-width, initial-scale=1" /><title>Dendrite</title><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.fluid.classless.min.css" /></head><body><h1><img src="../img/logo.png" alt="Dendrite logo" style="height:1em;vertical-align:middle;margin-right:0.5em;" /><a href="/">Dendrite</a></h1>${title}<p>${escapeHtml(content)}</p><ol>${items}</ol>${authorHtml}<p><a href="./${pageNumber}-alts.html">More options</a></p></body></html>`;
+  return `<!doctype html><html lang="en"><head><meta charset="UTF-8" /><meta name="viewport" content="width=device-width, initial-scale=1" /><title>Dendrite</title><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.fluid.classless.min.css" /></head><body><h1><img src="../img/logo.png" alt="Dendrite logo" style="height:1em;vertical-align:middle;margin-right:0.5em;" /><a href="/">Dendrite</a></h1>${title}<p>${escapeHtml(content)}</p><ol>${items}</ol>${authorHtml}<p><a href="./${pageNumber}-alts.html">Other variants</a></p></body></html>`;
 }

--- a/test/cloud-functions/buildHtml.test.js
+++ b/test/cloud-functions/buildHtml.test.js
@@ -37,4 +37,9 @@ describe('buildHtml', () => {
     const authorIndex = html.indexOf('<p>By Jane Doe</p>');
     expect(authorIndex).toBeGreaterThan(optionsIndex);
   });
+
+  test('links to other variants page', () => {
+    const html = buildHtml(1, 'a', 'content', []);
+    expect(html).toContain('<a href="./1-alts.html">Other variants</a>');
+  });
 });


### PR DESCRIPTION
## Summary
- update HTML generator to label the variant list link as "Other variants"
- add a test ensuring the updated text is present

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68973c35a30c832e9ad76f474fa738e7