### PR TITLE
Initialize moderator reputation sum for new variants

### DIFF
--- a/infra/cloud-functions/process-new-page/index.js
+++ b/infra/cloud-functions/process-new-page/index.js
@@ -64,6 +64,7 @@ export const processNewPage = functions
       content: sub.content,
       authorId: null,
       incomingOption: incomingOptionFullName,
+      moderatorReputationSum: 0,
       createdAt: FieldValue.serverTimestamp(),
     });
 

--- a/infra/cloud-functions/process-new-story/index.js
+++ b/infra/cloud-functions/process-new-story/index.js
@@ -57,6 +57,7 @@ export const processNewStory = functions
       content: sub.content,
       authorId: sub.authorId || null,
       authorName: sub.author,
+      moderatorReputationSum: 0,
       createdAt: FieldValue.serverTimestamp(),
     });
 


### PR DESCRIPTION
## Summary
- Initialize `moderatorReputationSum` to `0` when creating variant docs in `processNewStory`
- Initialize `moderatorReputationSum` to `0` when creating variant docs in `processNewPage`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689768224418832e81ef91f2ec738a65