### PR TITLE
Add rand property to new Cloud Function variants

### DIFF
--- a/infra/cloud-functions/process-new-page/index.js
+++ b/infra/cloud-functions/process-new-page/index.js
@@ -65,6 +65,7 @@ export const processNewPage = functions
       authorId: null,
       incomingOption: incomingOptionFullName,
       moderatorReputationSum: 0,
+      rand: Math.random(),
       createdAt: FieldValue.serverTimestamp(),
     });
 

--- a/infra/cloud-functions/process-new-story/index.js
+++ b/infra/cloud-functions/process-new-story/index.js
@@ -58,6 +58,7 @@ export const processNewStory = functions
       authorId: sub.authorId || null,
       authorName: sub.author,
       moderatorReputationSum: 0,
+      rand: Math.random(),
       createdAt: FieldValue.serverTimestamp(),
     });
 


### PR DESCRIPTION
## Summary
- include a rand field on story and page variants generated by processNewStory and processNewPage
- rand uses Math.random() to store a uniform value between 0 and 1

## Testing
- `npm test`
- `npm run lint` (warnings)


------
https://chatgpt.com/codex/tasks/task_e_68976ad227c0832e97a71bd4415f9282