### PR TITLE
Remove global variant count check from moderation job

### DIFF
--- a/infra/cloud-functions/assign-moderation-job/index.js
+++ b/infra/cloud-functions/assign-moderation-job/index.js
@@ -58,13 +58,6 @@ async function handleAssignModerationJob(req, res) {
     return;
   }
 
-  const total = (await db.collectionGroup('variants').count().get()).data()
-    .count;
-  if (!total) {
-    res.status(404).send('No variants to moderate');
-    return;
-  }
-
   const zeroRepCount = (
     await db
       .collectionGroup('variants')


### PR DESCRIPTION
## Summary
- Remove unnecessary variant count check in assignModerationJob cloud function since at least one variant exists

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68983f13317c832e88b2ec1e85165da5