### PR TITLE
Handle Firestore aggregate errors when assigning moderation jobs

### DIFF
--- a/infra/cloud-functions/assign-moderation-job/index.js
+++ b/infra/cloud-functions/assign-moderation-job/index.js
@@ -58,13 +58,24 @@ async function handleAssignModerationJob(req, res) {
     return;
   }
 
-  const zeroRepCount = (
-    await db
+  let zeroRepCount;
+  try {
+    const snap = await db
       .collectionGroup('variants')
       .where('moderatorReputationSum', '==', 0)
       .count()
-      .get()
-  ).data().count;
+      .get();
+
+    zeroRepCount = snap.data().count;
+  } catch (err) {
+    console.error('aggregate failed', {
+      code: err.code,
+      message: err.message,
+      details: err.details,
+    });
+    res.status(500).json({ error: 'aggregate_failed', code: err.code });
+    return;
+  }
 
   const n = Math.random();
   let query;


### PR DESCRIPTION
## Summary
- handle errors thrown by Firestore aggregate query when counting variants with zero moderator reputation

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6898426369ec832ea783916dc408cd5f