### PR TITLE
chore: add variants moderation index

### DIFF
--- a/infra/dendrite-firestore.tf
+++ b/infra/dendrite-firestore.tf
@@ -49,6 +49,22 @@ resource "google_firestore_index" "variants_author_created" {
   }
 }
 
+# Supports: variants where moderatorReputationSum == 0 and rand >= n
+resource "google_firestore_index" "variants_moderation_rand" {
+  project     = var.project_id
+  collection  = "variants"
+  query_scope = "COLLECTION_GROUP"
+
+  fields {
+    field_path = "moderatorReputationSum"
+    order      = "ASCENDING"
+  }
+  fields {
+    field_path = "rand"
+    order      = "ASCENDING"
+  }
+}
+
 
 resource "google_firestore_index" "ratings_by_variant" {
   project     = var.project_id


### PR DESCRIPTION
## Summary
- add a Firestore index for querying variants by moderator reputation sum and random seed across the collection group

## Testing
- `npx prettier infra/dendrite-firestore.tf --write` *(fails: No parser could be inferred for file)*
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68984b9bcf68832e905288428c8606df