### PR TITLE
feat: add moderation report Cloud Function

### DIFF
--- a/infra/cloud-functions/render-variant/buildHtml.js
+++ b/infra/cloud-functions/render-variant/buildHtml.js
@@ -34,5 +34,24 @@ export function buildHtml(
     .join('');
   const title = storyTitle ? `<h1>${escapeHtml(storyTitle)}</h1>` : '';
   const authorHtml = author ? `<p>By ${escapeHtml(author)}</p>` : '';
-  return `<!doctype html><html lang="en"><head><meta charset="UTF-8" /><meta name="viewport" content="width=device-width, initial-scale=1" /><title>Dendrite</title><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.fluid.classless.min.css" /><link rel="stylesheet" href="/dendrite.css" /></head><body><div class="page"><h1><img src="../img/logo.png" alt="Dendrite logo" style="height:1em;vertical-align:middle;margin-right:0.5em;" /><a href="/">Dendrite</a></h1>${title}<p>${escapeHtml(content)}</p><ol>${items}</ol>${authorHtml}<p><a href="./${pageNumber}-alts.html">Other variants</a></p></div></body></html>`;
+  const variantSlug = `${pageNumber}${variantName}`;
+  const reportHtml =
+    '<p><button id="reportBtn" type="button">Report</button></p>' +
+    `<script>document.getElementById('reportBtn').onclick=async()=>{try{await fetch('https://europe-west1-irien-465710.cloudfunctions.net/prod-report-for-moderation',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({variant:'${variantSlug}'})});alert('Thanks for your report.');}catch(e){alert('Sorry, something went wrong.');}};</script>`;
+  return (
+    `<!doctype html>` +
+    `<html lang="en"><head><meta charset="UTF-8" />` +
+    `<meta name="viewport" content="width=device-width, initial-scale=1" />` +
+    `<title>Dendrite</title>` +
+    `<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.fluid.classless.min.css" />` +
+    `<link rel="stylesheet" href="/dendrite.css" />` +
+    `</head><body><div class="page">` +
+    `<h1><img src="../img/logo.png" alt="Dendrite logo" style="height:1em;vertical-align:middle;margin-right:0.5em;" />` +
+    `<a href="/">Dendrite</a></h1>${title}<p>${escapeHtml(content)}</p>` +
+    `<ol>${items}</ol>${
+      authorHtml
+    }<p><a href="./${pageNumber}-alts.html">Other variants</a></p>${
+      reportHtml
+    }</div></body></html>`
+  );
 }

--- a/infra/cloud-functions/report-for-moderation/package.json
+++ b/infra/cloud-functions/report-for-moderation/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "report-for-moderation",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.js",
+  "dependencies": {
+    "firebase-admin": "^11.10.1",
+    "firebase-functions": "^4.4.1",
+    "express": "^4.19.2",
+    "cors": "^2.8.5"
+  }
+}

--- a/test/cloud-functions/buildHtml.test.js
+++ b/test/cloud-functions/buildHtml.test.js
@@ -42,4 +42,13 @@ describe('buildHtml', () => {
     const html = buildHtml(1, 'a', 'content', []);
     expect(html).toContain('<a href="./1-alts.html">Other variants</a>');
   });
+
+  test('includes report button and script', () => {
+    const html = buildHtml(1, 'a', 'content', []);
+    expect(html).toContain(
+      '<button id="reportBtn" type="button">Report</button>'
+    );
+    expect(html).toContain("JSON.stringify({variant:'1a'})");
+    expect(html).toContain('prod-report-for-moderation');
+  });
 });


### PR DESCRIPTION
## Summary
- rename moderation report body field to `variant`
- add `Report` button to variant pages that submits slug to moderation endpoint
- test report button rendering

## Testing
- `npm test`
- `npm run lint` (warnings only)

------
https://chatgpt.com/codex/tasks/task_e_68986b0d5d6c832ebf0da9fa273e7f50