### PR TITLE
feat: purge CDN cache for rendered variants

### DIFF
--- a/test/mocks/firebase-admin-firestore.js
+++ b/test/mocks/firebase-admin-firestore.js
@@ -1,1 +1,12 @@
+import { jest } from '@jest/globals';
+
 export const FieldValue = { delete: () => {} };
+
+export const mockDoc = jest.fn();
+
+/**
+ *
+ */
+export function getFirestore() {
+  return { doc: mockDoc };
+}


### PR DESCRIPTION
## Summary
- invalidate CDN paths for newly rendered variant pages and their parents
- add Firestore and fetch helpers for cache invalidation
- expand tests with Firestore mock and parent invalidation coverage

## Testing
- `npm test`
- `npm run lint` *(warns: Async function complexity, camelcase, jsdoc)*

------
https://chatgpt.com/codex/tasks/task_e_68988aa9b438832e8800fb7e93029f3a