### PR TITLE
Handle CDN invalidation errors in render-variant

### DIFF
--- a/infra/cloud-functions/render-variant/index.js
+++ b/infra/cloud-functions/render-variant/index.js
@@ -37,22 +37,28 @@ async function invalidatePaths(paths) {
   const token = await getAccessTokenFromMetadata();
   await Promise.all(
     paths.map(async path => {
-      const res = await fetch(
-        `https://compute.googleapis.com/compute/v1/projects/${PROJECT}/global/urlMaps/${URL_MAP}/invalidateCache`,
-        {
-          method: 'POST',
-          headers: {
-            Authorization: `Bearer ${token}`,
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({
-            host: CDN_HOST,
-            path,
-            requestId: crypto.randomUUID(),
-          }),
+      try {
+        const res = await fetch(
+          `https://compute.googleapis.com/compute/v1/projects/${PROJECT}/global/urlMaps/${URL_MAP}/invalidateCache`,
+          {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${token}`,
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+              host: CDN_HOST,
+              path,
+              requestId: crypto.randomUUID(),
+            }),
+          }
+        );
+        if (!res.ok) {
+          console.error(`invalidate ${path} failed: ${res.status}`);
         }
-      );
-      if (!res.ok) throw new Error(`invalidate ${path} failed: ${res.status}`);
+      } catch (e) {
+        console.error(`invalidate ${path} error`, e?.message || e);
+      }
     })
   );
 }

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -206,6 +206,13 @@ resource "google_project_iam_member" "terraform_loadbalancer_admin" {
   member  = "serviceAccount:terraform@${var.project_id}.iam.gserviceaccount.com"
 }
 
+resource "google_project_iam_member" "runtime_loadbalancer_admin" {
+  project = var.project_id
+  role    = "roles/compute.loadBalancerAdmin"
+  member  = "serviceAccount:${google_service_account.cloud_function_runtime.email}"
+  depends_on = [google_service_account.cloud_function_runtime]
+}
+
 resource "google_project_iam_member" "terraform_security_admin" {
   project = var.project_id
   role    = "roles/compute.securityAdmin"

--- a/test/cloud-functions/renderVariant.test.js
+++ b/test/cloud-functions/renderVariant.test.js
@@ -65,6 +65,25 @@ describe('render', () => {
     expect(mockSave.mock.calls[0][1]).toEqual({ contentType: 'text/html' });
   });
 
+  test('logs error when cache invalidation fails', async () => {
+    const snap = createSnap([{ content: 'Go', position: 0 }]);
+    const consoleError = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ access_token: 'token' }),
+      })
+      .mockRejectedValueOnce(new Error('network'))
+      .mockResolvedValue({ ok: false, status: 500 });
+
+    await render(snap, { params: { storyId: 's1', variantId: 'v1' } });
+    expect(consoleError).toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+
   test('invalidates parent variant when incoming option', async () => {
     const snap = createSnap([{ content: 'Go', position: 0 }]);
     snap.data = () => ({


### PR DESCRIPTION
## Summary
- allow Cloud Function runtime service account to invalidate CDN cache
- prevent render-variant from failing when CDN invalidation fails
- test that cache invalidation errors are logged and non-fatal

## Testing
- `npm test`
- `npm run lint` *(warnings: Async arrow function has a complexity of 4. Maximum allowed is 2 ...)*

------
https://chatgpt.com/codex/tasks/task_e_689890840c64832e985bc1318bfbfd91