### PR TITLE
Invalidate CDN cache for contents pages

### DIFF
--- a/test/cloud-functions/renderContents.test.js
+++ b/test/cloud-functions/renderContents.test.js
@@ -1,0 +1,57 @@
+import { describe, test, expect, jest, beforeEach } from '@jest/globals';
+import { mockSave, mockFile, mockBucket } from '@google-cloud/storage';
+import { render } from '../../infra/cloud-functions/render-contents/index.js';
+
+describe('render contents', () => {
+  beforeEach(() => {
+    mockSave.mockClear();
+    mockFile.mockClear();
+    mockBucket.mockClear();
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ access_token: 'token' }),
+      })
+      .mockResolvedValue({ ok: true });
+  });
+
+  test('invalidates cache for generated pages', async () => {
+    const ids = Array.from({ length: 31 }, (_, i) => `s${i + 1}`);
+    await render({
+      fetchTopStoryIds: async () => ids,
+      fetchStoryInfo: async id => ({
+        title: id,
+        pageNumber: Number(id.slice(1)),
+      }),
+    });
+
+    const pathCalls = fetch.mock.calls
+      .slice(1)
+      .map(([, opts]) => JSON.parse(opts.body).path);
+    expect(pathCalls).toEqual(['/index.html', '/contents/2.html']);
+  });
+
+  test('logs error when cache invalidation fails', async () => {
+    const ids = Array.from({ length: 31 }, (_, i) => `s${i + 1}`);
+    const consoleError = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ access_token: 'token' }),
+      })
+      .mockRejectedValueOnce(new Error('network'))
+      .mockResolvedValue({ ok: false, status: 500 });
+
+    await render({
+      fetchTopStoryIds: async () => ids,
+      fetchStoryInfo: async () => ({ title: 't', pageNumber: 1 }),
+    });
+
+    expect(consoleError).toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+});

--- a/test/mocks/firebase-functions.js
+++ b/test/mocks/firebase-functions.js
@@ -1,3 +1,3 @@
 export const region = () => ({
-  firestore: { document: () => ({ onWrite: () => {} }) },
+  firestore: { document: () => ({ onWrite: () => {}, onCreate: () => {} }) },
 });


### PR DESCRIPTION
## Summary
- invalidate CDN cache when contents pages are rendered
- support dependency injection for easier testing
- test contents rendering cache invalidation and error logging

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68989587ce8c832e8c96a72a03c7942f