### PR TITLE
Default variant visibility to 1.0 when unspecified

### DIFF
--- a/infra/cloud-functions/render-variant/visibility.js
+++ b/infra/cloud-functions/render-variant/visibility.js
@@ -7,7 +7,7 @@ export const VISIBILITY_THRESHOLD = 0.5;
  */
 export function getVisibleVariants(docs) {
   return docs
-    .filter(doc => (doc.data().visibility ?? 0) >= VISIBILITY_THRESHOLD)
+    .filter(doc => (doc.data().visibility ?? 1) >= VISIBILITY_THRESHOLD)
     .map(doc => ({
       name: doc.data().name || '',
       content: doc.data().content || '',

--- a/test/cloud-functions/getVisibleVariants.test.js
+++ b/test/cloud-functions/getVisibleVariants.test.js
@@ -10,4 +10,13 @@ describe('getVisibleVariants', () => {
     const variants = getVisibleVariants(docs);
     expect(variants).toEqual([{ name: 'a', content: 'A' }]);
   });
+
+  test('defaults missing visibility to 1.0', () => {
+    const docs = [
+      { data: () => ({ name: 'a', content: 'A' }) },
+      { data: () => ({ name: 'b', content: 'B', visibility: 0.4 }) },
+    ];
+    const variants = getVisibleVariants(docs);
+    expect(variants).toEqual([{ name: 'a', content: 'A' }]);
+  });
 });


### PR DESCRIPTION
## Summary
- Default variant visibility to 1.0 when not provided so docs without a `visibility` field are considered visible
- Add regression test for missing visibility case

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689896b08168832e853ff4ffb9c8b5cc