### PR TITLE
Preserve newlines and basic markdown in variants

### DIFF
--- a/infra/cloud-functions/render-variant/buildHtml.js
+++ b/infra/cloud-functions/render-variant/buildHtml.js
@@ -46,6 +46,16 @@ export function buildHtml(
   const reportHtml =
     '<p><button id="reportBtn" type="button">Report</button></p>' +
     `<script>document.getElementById('reportBtn').onclick=async()=>{try{await fetch('https://europe-west1-irien-465710.cloudfunctions.net/prod-report-for-moderation',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({variant:'${variantSlug}'})});alert('Thanks for your report.');}catch(e){alert('Sorry, something went wrong.');}};</script>`;
+  const paragraphs = String(content ?? '')
+    .replace(/\r\n?/g, '\n')
+    .split('\n')
+    .map(line => {
+      let html = escapeHtml(line);
+      html = html.replace(/(\*\*|__)(.*?)\1/g, '<strong>$2</strong>');
+      html = html.replace(/(\*|_)(.*?)\1/g, '<em>$2</em>');
+      return `<p>${html}</p>`;
+    })
+    .join('');
   return (
     `<!doctype html>` +
     `<html lang="en"><head><meta charset="UTF-8" />` +
@@ -55,7 +65,7 @@ export function buildHtml(
     `<link rel="stylesheet" href="/dendrite.css" />` +
     `</head><body><div class="page">` +
     `<h1><img src="../img/logo.png" alt="Dendrite logo" style="height:1em;vertical-align:middle;margin-right:0.5em;" />` +
-    `<a href="/">Dendrite</a></h1>${title}<p>${escapeHtml(content)}</p>` +
+    `<a href="/">Dendrite</a></h1>${title}${paragraphs}` +
     `<ol>${items}</ol>${authorHtml}${parentHtml}${firstHtml}<p><a href="./${pageNumber}-alts.html">Other variants</a></p>${reportHtml}</div></body></html>`
   );
 }

--- a/infra/cloud-functions/submit-new-page/index.js
+++ b/infra/cloud-functions/submit-new-page/index.js
@@ -48,7 +48,7 @@ async function handleSubmit(req, res) {
 
   const incomingOption =
     rawIncomingOption?.toString().trim().slice(0, 120) || '';
-  content = content.toString().trim().slice(0, 10_000);
+  content = content.toString().replace(/\r\n?/g, '\n').slice(0, 10_000);
   author = author.toString().trim().slice(0, 120);
 
   const parsed = parseIncomingOption(incomingOption);

--- a/infra/cloud-functions/submit-new-story/index.js
+++ b/infra/cloud-functions/submit-new-story/index.js
@@ -41,7 +41,7 @@ app.use(express.urlencoded({ extended: false, limit: '20kb' }));
 async function handleSubmit(req, res) {
   let { title = 'Untitled', content = '', author = '???' } = req.body;
   title = title.toString().trim().slice(0, 120);
-  content = content.toString().trim().slice(0, 10_000);
+  content = content.toString().replace(/\r\n?/g, '\n').slice(0, 10_000);
   author = author.toString().trim().slice(0, 120);
 
   let authorId = null;

--- a/test/cloud-functions/buildHtml.test.js
+++ b/test/cloud-functions/buildHtml.test.js
@@ -52,6 +52,16 @@ describe('buildHtml', () => {
     expect(html).toContain('prod-report-for-moderation');
   });
 
+  test('renders each line in separate paragraph', () => {
+    const html = buildHtml(1, 'a', 'one\ntwo', []);
+    expect(html).toContain('<p>one</p><p>two</p>');
+  });
+
+  test('renders markdown bold and italics', () => {
+    const html = buildHtml(1, 'a', 'a *b* and **c**', []);
+    expect(html).toContain('<p>a <em>b</em> and <strong>c</strong></p>');
+  });
+
   test('includes parent and first page links when provided', () => {
     const html = buildHtml(
       2,


### PR DESCRIPTION
## Summary
- Keep newline characters when submitting new stories and pages
- Render variant content as paragraphs and support bold/italic markdown
- Test paragraph splitting and markdown rendering

## Testing
- `npm test`
- `npm run lint` *(warns: Identifier 'access_token' is not in camel case, Missing JSDoc @returns declaration, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6898b6f18a40832e8faac52c10d8e1d2