### PR TITLE
Support incremental variant names

### DIFF
--- a/infra/cloud-functions/render-variant/buildHtml.js
+++ b/infra/cloud-functions/render-variant/buildHtml.js
@@ -31,7 +31,7 @@ export function buildHtml(
       const slug = `${pageNumber}-${variantName}-${opt.position}`;
       const href =
         opt.targetPageNumber !== undefined
-          ? `/p/${opt.targetPageNumber}a.html`
+          ? `/p/${opt.targetPageNumber}${opt.targetVariantName || ''}.html`
           : `../new-page.html?option=${slug}`;
       return `<li><a href="${href}">${escapeHtml(opt.content)}</a></li>`;
     })

--- a/src/utils/variantName.js
+++ b/src/utils/variantName.js
@@ -1,0 +1,19 @@
+/**
+ * Increment a variant name in base-26 alphabetic order.
+ * @param {string} name Current variant name.
+ * @returns {string} Next variant name.
+ */
+export function incrementVariantName(name) {
+  const letters = name.split('');
+  let i = letters.length - 1;
+  while (i >= 0) {
+    const code = letters[i].charCodeAt(0);
+    if (code >= 97 && code < 122) {
+      letters[i] = String.fromCharCode(code + 1);
+      return letters.join('');
+    }
+    letters[i] = 'a';
+    i -= 1;
+  }
+  return 'a'.repeat(name.length + 1);
+}

--- a/test/cloud-functions/buildHtml.test.js
+++ b/test/cloud-functions/buildHtml.test.js
@@ -26,9 +26,14 @@ describe('buildHtml', () => {
 
   test('links option with target page to existing page', () => {
     const html = buildHtml(5, 'a', 'content', [
-      { content: 'Go right', position: 1, targetPageNumber: 42 },
+      {
+        content: 'Go right',
+        position: 1,
+        targetPageNumber: 42,
+        targetVariantName: 'b',
+      },
     ]);
-    expect(html).toContain('<li><a href="/p/42a.html">Go right</a></li>');
+    expect(html).toContain('<li><a href="/p/42b.html">Go right</a></li>');
   });
 
   test('includes author below options when provided', () => {

--- a/test/cloud-functions/renderVariant.test.js
+++ b/test/cloud-functions/renderVariant.test.js
@@ -12,11 +12,20 @@ function createSnap(optionData) {
   const optionsCollection = {
     get: jest.fn().mockResolvedValue({ docs: optionsDocs }),
   };
+  const rootVariantCollection = {
+    orderBy: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    get: jest.fn().mockResolvedValue({
+      empty: false,
+      docs: [{ data: () => ({ name: 'a' }) }],
+    }),
+  };
   const rootPageRef = {
     get: jest.fn().mockResolvedValue({
       exists: true,
       data: () => ({ number: 1 }),
     }),
+    collection: jest.fn(() => rootVariantCollection),
   };
   const storyRef = {
     get: jest.fn().mockResolvedValue({

--- a/test/utils/variantName.test.js
+++ b/test/utils/variantName.test.js
@@ -1,0 +1,18 @@
+import { describe, test, expect } from '@jest/globals';
+import { incrementVariantName } from '../../src/utils/variantName.js';
+
+describe('incrementVariantName', () => {
+  test('increments single letter', () => {
+    expect(incrementVariantName('a')).toBe('b');
+  });
+
+  test('wraps z to aa', () => {
+    expect(incrementVariantName('z')).toBe('aa');
+  });
+
+  test('increments multi-letter name', () => {
+    expect(incrementVariantName('az')).toBe('ba');
+    expect(incrementVariantName('zz')).toBe('aaa');
+    expect(incrementVariantName('zzzzz')).toBe('aaaaaa');
+  });
+});


### PR DESCRIPTION
## Summary
- Reuse existing page when processing submissions and increment variant name alphabetically
- Render variants using stored names for parent and first page links and option targets
- Add helper for incrementing variant names and corresponding tests

## Testing
- `npm test`
- `npm run lint` (warnings: Async arrow function has a complexity of 5... etc.)

------
https://chatgpt.com/codex/tasks/task_e_6898c38d4324832eb78526ae55fad934