### PR TITLE
Support incremental variant names

### DIFF
--- a/infra/cloud-functions/process-new-page/index.js
+++ b/infra/cloud-functions/process-new-page/index.js
@@ -2,6 +2,7 @@ import { initializeApp } from 'firebase-admin/app';
 import { getFirestore, FieldValue } from 'firebase-admin/firestore';
 import * as functions from 'firebase-functions';
 import crypto from 'crypto';
+import { incrementVariantName } from './variantName.js';
 
 initializeApp();
 const db = getFirestore();
@@ -31,36 +32,64 @@ export const processNewPage = functions
     const pageRef = variantRef.parent.parent;
     const storyRef = pageRef.parent.parent;
 
-    let i = 0;
-    let candidate = 1;
-    while (true) {
-      const max = 2 ** i;
-      candidate = Math.floor(Math.random() * max) + 1;
-      const existing = await db
-        .collectionGroup('pages')
-        .where('number', '==', candidate)
-        .limit(1)
-        .get();
-      if (existing.empty) {
-        break;
+    const optionData = optionSnap.data();
+    let pageDocRef = optionData.targetPage;
+    let pageNumber;
+    const batch = db.batch();
+
+    if (pageDocRef) {
+      try {
+        const existingPageSnap = await pageDocRef.get();
+        if (existingPageSnap.exists) {
+          pageNumber = existingPageSnap.data().number;
+        } else {
+          pageDocRef = null;
+        }
+      } catch {
+        pageDocRef = null;
       }
-      i += 1;
     }
 
-    const newPageId = crypto.randomUUID();
-    const variantId = snap.id;
-    const newPageRef = storyRef.collection('pages').doc(newPageId);
-    const newVariantRef = newPageRef.collection('variants').doc(variantId);
+    if (!pageDocRef) {
+      let i = 0;
+      let candidate = 1;
+      while (true) {
+        const max = 2 ** i;
+        candidate = Math.floor(Math.random() * max) + 1;
+        const existing = await db
+          .collectionGroup('pages')
+          .where('number', '==', candidate)
+          .limit(1)
+          .get();
+        if (existing.empty) {
+          break;
+        }
+        i += 1;
+      }
+      pageNumber = candidate;
+      const newPageId = crypto.randomUUID();
+      pageDocRef = storyRef.collection('pages').doc(newPageId);
+      batch.set(pageDocRef, {
+        number: pageNumber,
+        incomingOption: incomingOptionFullName,
+        createdAt: FieldValue.serverTimestamp(),
+      });
+      batch.update(optionRef, { targetPage: pageDocRef });
+    }
 
-    const batch = db.batch();
-    batch.set(newPageRef, {
-      number: candidate,
-      incomingOption: incomingOptionFullName,
-      createdAt: FieldValue.serverTimestamp(),
-    });
+    const variantsSnap = await pageDocRef
+      .collection('variants')
+      .orderBy('name', 'desc')
+      .limit(1)
+      .get();
+    const nextName = variantsSnap.empty
+      ? 'a'
+      : incrementVariantName(variantsSnap.docs[0].data().name);
+    const variantId = snap.id;
+    const newVariantRef = pageDocRef.collection('variants').doc(variantId);
 
     batch.set(newVariantRef, {
-      name: 'a',
+      name: nextName,
       content: sub.content,
       authorId: null,
       incomingOption: incomingOptionFullName,
@@ -80,7 +109,6 @@ export const processNewPage = functions
       });
     });
 
-    batch.update(optionRef, { targetPage: newPageRef });
     batch.update(variantRef, { dirty: null });
     batch.update(snap.ref, { processed: true });
 

--- a/infra/cloud-functions/process-new-page/variantName.js
+++ b/infra/cloud-functions/process-new-page/variantName.js
@@ -1,0 +1,19 @@
+/**
+ * Increment a variant name in base-26 alphabetic order.
+ * @param {string} name Current variant name.
+ * @returns {string} Next variant name.
+ */
+export function incrementVariantName(name) {
+  const letters = name.split('');
+  let i = letters.length - 1;
+  while (i >= 0) {
+    const code = letters[i].charCodeAt(0);
+    if (code >= 97 && code < 122) {
+      letters[i] = String.fromCharCode(code + 1);
+      return letters.join('');
+    }
+    letters[i] = 'a';
+    i -= 1;
+  }
+  return 'a'.repeat(name.length + 1);
+}

--- a/infra/cloud-functions/render-variant/buildHtml.js
+++ b/infra/cloud-functions/render-variant/buildHtml.js
@@ -31,7 +31,7 @@ export function buildHtml(
       const slug = `${pageNumber}-${variantName}-${opt.position}`;
       const href =
         opt.targetPageNumber !== undefined
-          ? `/p/${opt.targetPageNumber}a.html`
+          ? `/p/${opt.targetPageNumber}${opt.targetVariantName || ''}.html`
           : `../new-page.html?option=${slug}`;
       return `<li><a href="${href}">${escapeHtml(opt.content)}</a></li>`;
     })

--- a/infra/cloud-functions/render-variant/variantName.js
+++ b/infra/cloud-functions/render-variant/variantName.js
@@ -1,0 +1,19 @@
+/**
+ * Increment a variant name in base-26 alphabetic order.
+ * @param {string} name Current variant name.
+ * @returns {string} Next variant name.
+ */
+export function incrementVariantName(name) {
+  const letters = name.split('');
+  let i = letters.length - 1;
+  while (i >= 0) {
+    const code = letters[i].charCodeAt(0);
+    if (code >= 97 && code < 122) {
+      letters[i] = String.fromCharCode(code + 1);
+      return letters.join('');
+    }
+    letters[i] = 'a';
+    i -= 1;
+  }
+  return 'a'.repeat(name.length + 1);
+}

--- a/infra/variantName.js
+++ b/infra/variantName.js
@@ -1,0 +1,19 @@
+/**
+ * Increment a variant name in base-26 alphabetic order.
+ * @param {string} name Current variant name.
+ * @returns {string} Next variant name.
+ */
+export function incrementVariantName(name) {
+  const letters = name.split('');
+  let i = letters.length - 1;
+  while (i >= 0) {
+    const code = letters[i].charCodeAt(0);
+    if (code >= 97 && code < 122) {
+      letters[i] = String.fromCharCode(code + 1);
+      return letters.join('');
+    }
+    letters[i] = 'a';
+    i -= 1;
+  }
+  return 'a'.repeat(name.length + 1);
+}

--- a/test/cloud-functions/buildHtml.test.js
+++ b/test/cloud-functions/buildHtml.test.js
@@ -26,9 +26,14 @@ describe('buildHtml', () => {
 
   test('links option with target page to existing page', () => {
     const html = buildHtml(5, 'a', 'content', [
-      { content: 'Go right', position: 1, targetPageNumber: 42 },
+      {
+        content: 'Go right',
+        position: 1,
+        targetPageNumber: 42,
+        targetVariantName: 'b',
+      },
     ]);
-    expect(html).toContain('<li><a href="/p/42a.html">Go right</a></li>');
+    expect(html).toContain('<li><a href="/p/42b.html">Go right</a></li>');
   });
 
   test('includes author below options when provided', () => {

--- a/test/cloud-functions/renderVariant.test.js
+++ b/test/cloud-functions/renderVariant.test.js
@@ -12,11 +12,20 @@ function createSnap(optionData) {
   const optionsCollection = {
     get: jest.fn().mockResolvedValue({ docs: optionsDocs }),
   };
+  const rootVariantCollection = {
+    orderBy: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    get: jest.fn().mockResolvedValue({
+      empty: false,
+      docs: [{ data: () => ({ name: 'a' }) }],
+    }),
+  };
   const rootPageRef = {
     get: jest.fn().mockResolvedValue({
       exists: true,
       data: () => ({ number: 1 }),
     }),
+    collection: jest.fn(() => rootVariantCollection),
   };
   const storyRef = {
     get: jest.fn().mockResolvedValue({

--- a/test/utils/variantName.test.js
+++ b/test/utils/variantName.test.js
@@ -1,0 +1,18 @@
+import { describe, test, expect } from '@jest/globals';
+import { incrementVariantName } from '../../infra/variantName.js';
+
+describe('incrementVariantName', () => {
+  test('increments single letter', () => {
+    expect(incrementVariantName('a')).toBe('b');
+  });
+
+  test('wraps z to aa', () => {
+    expect(incrementVariantName('z')).toBe('aa');
+  });
+
+  test('increments multi-letter name', () => {
+    expect(incrementVariantName('az')).toBe('ba');
+    expect(incrementVariantName('zz')).toBe('aaa');
+    expect(incrementVariantName('zzzzz')).toBe('aaaaaa');
+  });
+});


### PR DESCRIPTION
## Summary
- Reuse existing page when processing submissions and increment variant name alphabetically
- Render variants using stored names for parent and first-page links and option targets
- Add helper for incrementing variant names and corresponding tests
- Move variant name helper into infra and bundle it with Cloud Function zips

## Testing
- `npm test`
- `npm run lint` (warnings: Async arrow function has a complexity of 5; Function 'incrementVariantName' has a complexity of 4; Identifier 'access_token' is not in camel case; Missing JSDoc @returns declaration; Missing JSDoc @param "optionData" description; Missing JSDoc @param "optionData" type)

------
https://chatgpt.com/codex/tasks/task_e_6898c38d4324832eb78526ae55fad934