### PR TITLE
Render markdown in option content

### DIFF
--- a/infra/cloud-functions/render-variant/buildHtml.js
+++ b/infra/cloud-functions/render-variant/buildHtml.js
@@ -1,6 +1,18 @@
 import { escapeHtml } from './buildAltsHtml.js';
 
 /**
+ * Render inline markdown for bold and italics.
+ * @param {string} text Text to render.
+ * @returns {string} HTML string.
+ */
+function renderInlineMarkdown(text) {
+  let html = escapeHtml(String(text ?? ''));
+  html = html.replace(/(\*\*|__)(.*?)\1/g, '<strong>$2</strong>');
+  html = html.replace(/(\*|_)(.*?)\1/g, '<em>$2</em>');
+  return html;
+}
+
+/**
  * Build HTML page for the variant.
  * @param {number} pageNumber Page number.
  * @param {string} variantName Variant name.
@@ -33,7 +45,8 @@ export function buildHtml(
         opt.targetPageNumber !== undefined
           ? `/p/${opt.targetPageNumber}${opt.targetVariantName || ''}.html`
           : `../new-page.html?option=${slug}`;
-      return `<li><a href="${href}">${escapeHtml(opt.content)}</a></li>`;
+      const optionHtml = renderInlineMarkdown(opt.content);
+      return `<li><a href="${href}">${optionHtml}</a></li>`;
     })
     .join('');
   const title = storyTitle ? `<h1>${escapeHtml(storyTitle)}</h1>` : '';
@@ -49,12 +62,7 @@ export function buildHtml(
   const paragraphs = String(content ?? '')
     .replace(/\r\n?/g, '\n')
     .split('\n')
-    .map(line => {
-      let html = escapeHtml(line);
-      html = html.replace(/(\*\*|__)(.*?)\1/g, '<strong>$2</strong>');
-      html = html.replace(/(\*|_)(.*?)\1/g, '<em>$2</em>');
-      return `<p>${html}</p>`;
-    })
+    .map(line => `<p>${renderInlineMarkdown(line)}</p>`)
     .join('');
   return (
     `<!doctype html>` +

--- a/test/cloud-functions/buildHtml.test.js
+++ b/test/cloud-functions/buildHtml.test.js
@@ -67,6 +67,15 @@ describe('buildHtml', () => {
     expect(html).toContain('<p>a <em>b</em> and <strong>c</strong></p>');
   });
 
+  test('renders markdown in option content', () => {
+    const html = buildHtml(1, 'a', 'content', [
+      { content: 'Go *left* and **bold**', position: 0 },
+    ]);
+    expect(html).toContain(
+      '<li><a href="../new-page.html?option=1-a-0">Go <em>left</em> and <strong>bold</strong></a></li>'
+    );
+  });
+
   test('includes parent and first page links when provided', () => {
     const html = buildHtml(
       2,


### PR DESCRIPTION
## Summary
- Render variant options using same inline markdown parser as variant content
- Test option markdown rendering in buildHtml

## Testing
- `npm test`
- `npm run lint` *(14 warnings, 0 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6898f1da5c14832e87bbbb94302f1670