### PR TITLE
Query options by position in findExistingOption

### DIFF
--- a/infra/cloud-functions/submit-new-page/helpers.js
+++ b/infra/cloud-functions/submit-new-page/helpers.js
@@ -58,11 +58,11 @@ export async function findExistingOption(db, info) {
   const variantRef = variantSnap.docs[0].ref;
   const optionsSnap = await variantRef
     .collection('options')
-    .orderBy('createdAt')
-    .limit(info.optionNumber + 1)
+    .where('position', '==', info.optionNumber)
+    .limit(1)
     .get();
-  if (optionsSnap.size <= info.optionNumber) {
+  if (optionsSnap.empty) {
     return null;
   }
-  return optionsSnap.docs[info.optionNumber].ref.path;
+  return optionsSnap.docs[0].ref.path;
 }

--- a/test/cloud-functions/submitNewPageHelpers.test.js
+++ b/test/cloud-functions/submitNewPageHelpers.test.js
@@ -24,10 +24,10 @@ describe('findExistingOption', () => {
     const optionPath = 'stories/s1/pages/p1/variants/v1/options/opt1';
     const variantRef = {
       collection: jest.fn(() => ({
-        orderBy: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
         limit: jest.fn().mockReturnThis(),
         get: jest.fn().mockResolvedValue({
-          size: 1,
+          empty: false,
           docs: [{ ref: { path: optionPath } }],
         }),
       })),
@@ -59,11 +59,29 @@ describe('findExistingOption', () => {
   });
 
   test('returns null when option missing', async () => {
+    const variantRef = {
+      collection: jest.fn(() => ({
+        where: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        get: jest.fn().mockResolvedValue({ empty: true }),
+      })),
+    };
+    const pageRef = {
+      collection: jest.fn(() => ({
+        where: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        get: jest
+          .fn()
+          .mockResolvedValue({ empty: false, docs: [{ ref: variantRef }] }),
+      })),
+    };
     const db = {
       collectionGroup: jest.fn(() => ({
         where: jest.fn().mockReturnThis(),
         limit: jest.fn().mockReturnThis(),
-        get: jest.fn().mockResolvedValue({ empty: true }),
+        get: jest
+          .fn()
+          .mockResolvedValue({ empty: false, docs: [{ ref: pageRef }] }),
       })),
     };
     const result = await findExistingOption(db, {


### PR DESCRIPTION
## Summary
- refine findExistingOption to query options by `position` instead of relying on ordered limits
- update tests for submit-new-page helpers to cover position-based lookups and missing option cases

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a04ae3ef28832e977a16d41b42fc45