### PR TITLE
Increment variant count in story stats

### DIFF
--- a/infra/cloud-functions/process-new-page/index.js
+++ b/infra/cloud-functions/process-new-page/index.js
@@ -110,6 +110,12 @@ export const processNewPage = functions
       });
     });
 
+    batch.set(
+      db.doc(`storyStats/${storyRef.id}`),
+      { variantCount: FieldValue.increment(1) },
+      { merge: true }
+    );
+
     batch.update(variantRef, { dirty: null });
     batch.update(snap.ref, { processed: true });
 


### PR DESCRIPTION
## Summary
- increment `storyStats/<storyId>.variantCount` when processing a new page variant

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3111a3130832e847dceb22ea7c8f2