### PR TITLE
Add protected admin page

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Admin</title>
+  </head>
+  <body>
+    <div id="signinButton"></div>
+    <div id="adminContent" style="display: none">
+      <h1>Admin</h1>
+      <p>Welcome.</p>
+    </div>
+    <script src="https://accounts.google.com/gsi/client" defer></script>
+    <script type="module" src="./admin.js"></script>
+  </body>
+</html>

--- a/public/admin.js
+++ b/public/admin.js
@@ -1,0 +1,22 @@
+import { initGoogleSignIn, getIdToken } from "./googleAuth.js";
+import { getAuth } from "https://www.gstatic.com/firebasejs/12.0.0/firebase-auth.js";
+
+const ADMIN_UID = "qcYSrXTaj1MZUoFsAloBwT86GNM2";
+
+function checkAccess() {
+  const user = getAuth().currentUser;
+  if (!user || user.uid !== ADMIN_UID) {
+    window.location.href = "/index.html";
+    return;
+  }
+  const content = document.getElementById("adminContent");
+  const signin = document.getElementById("signinButton");
+  if (content) content.style.display = "";
+  if (signin) signin.style.display = "none";
+}
+
+initGoogleSignIn({ onSignIn: checkAccess });
+
+if (getIdToken()) {
+  checkAccess();
+}

--- a/public/googleAuth.js
+++ b/public/googleAuth.js
@@ -1,0 +1,48 @@
+import { initializeApp } from 'https://www.gstatic.com/firebasejs/12.0.0/firebase-app.js';
+import {
+  getAuth,
+  GoogleAuthProvider,
+  signInWithCredential,
+} from 'https://www.gstatic.com/firebasejs/12.0.0/firebase-auth.js';
+
+initializeApp({
+  apiKey: 'AIzaSyDRc1CakoDi6airj7t7DgY4KDSlxNwKIIQ',
+  authDomain: 'irien-465710.firebaseapp.com',
+  projectId: 'irien-465710',
+});
+
+const auth = getAuth();
+
+export const initGoogleSignIn = ({ onSignIn } = {}) => {
+  if (!window.google || !google.accounts?.id) {
+    console.error('Google Identity script missing');
+    return;
+  }
+
+  google.accounts.id.initialize({
+    client_id:
+      '848377461162-7je7r4pg7mnaj85gq558cf4gt0mk8j9b.apps.googleusercontent.com',
+    callback: async ({ credential }) => {
+      const cred = GoogleAuthProvider.credential(credential);
+      await signInWithCredential(auth, cred);
+      const idToken = await auth.currentUser.getIdToken();
+      sessionStorage.setItem('id_token', idToken);
+      onSignIn?.(idToken);
+    },
+    ux_mode: 'popup',
+  });
+
+  google.accounts.id.renderButton(document.getElementById('signinButton'), {
+    theme: 'outline',
+    size: 'large',
+    text: 'signin_with',
+  });
+};
+
+export const getIdToken = () => sessionStorage.getItem('id_token');
+
+export const signOut = async () => {
+  await auth.signOut();
+  sessionStorage.removeItem('id_token');
+  google.accounts.id.disableAutoSelect();
+};


### PR DESCRIPTION
## Summary
- Add `admin.html` with Google Identity button
- Implement `admin.js` to restrict access to a specific Firebase UID
- Copy `googleAuth.js` for frontend authentication support

## Testing
- `npm test`
- `npm run lint` (89 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68a3131c8c64832eb5ce174e260c6125