### PR TITLE
Add Terraform resources for Dendrite admin page

### DIFF
--- a/infra/admin.html
+++ b/infra/admin.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Admin</title>
+  </head>
+  <body>
+    <div id="signinButton"></div>
+    <div id="adminContent" style="display: none">
+      <h1>Admin</h1>
+      <p>Welcome.</p>
+    </div>
+    <script src="https://accounts.google.com/gsi/client" defer></script>
+    <script type="module" src="./admin.js"></script>
+  </body>
+</html>

--- a/infra/admin.js
+++ b/infra/admin.js
@@ -1,0 +1,25 @@
+import { initGoogleSignIn, getIdToken } from './googleAuth.js';
+import { getAuth } from 'https://www.gstatic.com/firebasejs/12.0.0/firebase-auth.js';
+
+const ADMIN_UID = 'qcYSrXTaj1MZUoFsAloBwT86GNM2';
+
+/**
+ * Redirects unauthorized users and reveals admin content for the correct UID.
+ */
+function checkAccess() {
+  const user = getAuth().currentUser;
+  if (!user || user.uid !== ADMIN_UID) {
+    window.location.href = '/index.html';
+    return;
+  }
+  const content = document.getElementById('adminContent');
+  const signin = document.getElementById('signinButton');
+  if (content) content.style.display = '';
+  if (signin) signin.style.display = 'none';
+}
+
+initGoogleSignIn({ onSignIn: checkAccess });
+
+if (getIdToken()) {
+  checkAccess();
+}

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -102,6 +102,20 @@ resource "google_storage_bucket_object" "dendrite_moderate_js" {
   content_type = "application/javascript"
 }
 
+resource "google_storage_bucket_object" "dendrite_admin_html" {
+  name         = "admin.html"
+  bucket       = google_storage_bucket.dendrite_static.name
+  source       = "${path.module}/admin.html"
+  content_type = "text/html"
+}
+
+resource "google_storage_bucket_object" "dendrite_admin_js" {
+  name         = "admin.js"
+  bucket       = google_storage_bucket.dendrite_static.name
+  source       = "${path.module}/admin.js"
+  content_type = "application/javascript"
+}
+
 resource "google_storage_bucket_object" "dendrite_css" {
   name         = "dendrite.css"
   bucket       = google_storage_bucket.dendrite_static.name


### PR DESCRIPTION
## Summary
- add admin page HTML and JS
- expose admin page through Terraform static bucket objects

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a3155c07c0832e99ddddd3a16a1e3a