### PR TITLE
feat: add admin render trigger

### DIFF
--- a/infra/admin.html
+++ b/infra/admin.html
@@ -10,6 +10,7 @@
     <div id="adminContent" style="display: none">
       <h1>Admin</h1>
       <p>Welcome.</p>
+      <button id="renderBtn">Render contents</button>
     </div>
     <script src="https://accounts.google.com/gsi/client" defer></script>
     <script type="module" src="./admin.js"></script>

--- a/infra/admin.js
+++ b/infra/admin.js
@@ -2,6 +2,8 @@ import { initGoogleSignIn, getIdToken } from './googleAuth.js';
 import { getAuth } from 'https://www.gstatic.com/firebasejs/12.0.0/firebase-auth.js';
 
 const ADMIN_UID = 'qcYSrXTaj1MZUoFsAloBwT86GNM2';
+const RENDER_URL =
+  'https://europe-west1-irien-465710.cloudfunctions.net/prod-trigger-render-contents';
 
 /**
  * Redirects unauthorized users and reveals admin content for the correct UID.
@@ -17,6 +19,27 @@ function checkAccess() {
   if (content) content.style.display = '';
   if (signin) signin.style.display = 'none';
 }
+
+/**
+ *
+ */
+async function triggerRender() {
+  const token = getIdToken();
+  if (!token) {
+    return;
+  }
+  try {
+    await fetch(RENDER_URL, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    alert('Render triggered');
+  } catch {
+    alert('Render failed');
+  }
+}
+
+document.getElementById('renderBtn')?.addEventListener('click', triggerRender);
 
 initGoogleSignIn({ onSignIn: checkAccess });
 

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -9,6 +9,7 @@ const config = {
     '^firebase-admin/app$': '<rootDir>/test/mocks/firebase-admin-app.js',
     '^firebase-admin/firestore$':
       '<rootDir>/test/mocks/firebase-admin-firestore.js',
+    '^firebase-admin/auth$': '<rootDir>/test/mocks/firebase-admin-auth.js',
     '^firebase-functions$': '<rootDir>/test/mocks/firebase-functions.js',
     '^@google-cloud/storage$': '<rootDir>/test/mocks/google-cloud-storage.js',
   },

--- a/test/cloud-functions/triggerRenderContents.test.js
+++ b/test/cloud-functions/triggerRenderContents.test.js
@@ -1,0 +1,126 @@
+import { describe, test, expect, beforeEach, jest } from '@jest/globals';
+import * as mod from '../../infra/cloud-functions/render-contents/index.js';
+import { mockVerifyIdToken } from '../mocks/firebase-admin-auth.js';
+
+const { handleRenderRequest } = mod;
+
+/**
+ *
+ */
+/**
+ * Create a mock response object.
+ * @returns {{status: jest.Mock, send: jest.Mock, json: jest.Mock}} Response
+ */
+function createRes() {
+  return {
+    status: jest.fn().mockReturnThis(),
+    send: jest.fn(),
+    json: jest.fn(),
+  };
+}
+
+describe('handleRenderRequest', () => {
+  beforeEach(() => {
+    mockVerifyIdToken.mockReset();
+  });
+
+  test('rejects non-POST method', async () => {
+    const req = { method: 'GET', get: () => '' };
+    const res = createRes();
+    await handleRenderRequest(req, res);
+    expect(res.status).toHaveBeenCalledWith(405);
+  });
+
+  test('rejects disallowed origin', async () => {
+    const req = {
+      method: 'POST',
+      get: h => {
+        if (h === 'Origin') {
+          return 'https://evil.com';
+        }
+        return '';
+      },
+    };
+    const res = createRes();
+    await handleRenderRequest(req, res);
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  test('rejects missing token', async () => {
+    const req = { method: 'POST', get: () => '' };
+    const res = createRes();
+    await handleRenderRequest(req, res);
+    expect(res.status).toHaveBeenCalledWith(401);
+  });
+
+  test('rejects invalid token', async () => {
+    mockVerifyIdToken.mockRejectedValue(new Error('bad'));
+    const req = {
+      method: 'POST',
+      get: h => {
+        if (h === 'Authorization') {
+          return 'Bearer x';
+        }
+        return '';
+      },
+    };
+    const res = createRes();
+    await handleRenderRequest(req, res);
+    expect(res.status).toHaveBeenCalledWith(401);
+  });
+
+  test('rejects non-admin uid', async () => {
+    mockVerifyIdToken.mockResolvedValue({ uid: 'other' });
+    const req = {
+      method: 'POST',
+      get: h => {
+        if (h === 'Authorization') {
+          return 'Bearer t';
+        }
+        return '';
+      },
+    };
+    const res = createRes();
+    await handleRenderRequest(req, res);
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  test('triggers render for admin user', async () => {
+    mockVerifyIdToken.mockResolvedValue({
+      uid: 'qcYSrXTaj1MZUoFsAloBwT86GNM2',
+    });
+    const renderFn = jest.fn().mockResolvedValue(null);
+    const req = {
+      method: 'POST',
+      get: h => {
+        if (h === 'Authorization') {
+          return 'Bearer t';
+        }
+        return '';
+      },
+    };
+    const res = createRes();
+    await handleRenderRequest(req, res, { renderFn });
+    expect(renderFn).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  test('handles render errors', async () => {
+    mockVerifyIdToken.mockResolvedValue({
+      uid: 'qcYSrXTaj1MZUoFsAloBwT86GNM2',
+    });
+    const renderFn = jest.fn().mockRejectedValue(new Error('fail'));
+    const req = {
+      method: 'POST',
+      get: h => {
+        if (h === 'Authorization') {
+          return 'Bearer t';
+        }
+        return '';
+      },
+    };
+    const res = createRes();
+    await handleRenderRequest(req, res, { renderFn });
+    expect(res.status).toHaveBeenCalledWith(500);
+  });
+});

--- a/test/mocks/firebase-admin-auth.js
+++ b/test/mocks/firebase-admin-auth.js
@@ -1,0 +1,14 @@
+import { jest } from '@jest/globals';
+
+export const mockVerifyIdToken = jest.fn();
+
+/**
+ *
+ */
+/**
+ * Return a mocked auth instance.
+ * @returns {{verifyIdToken: import('@jest/globals').Mock}} Mocked auth
+ */
+export function getAuth() {
+  return { verifyIdToken: mockVerifyIdToken };
+}

--- a/test/mocks/firebase-functions.js
+++ b/test/mocks/firebase-functions.js
@@ -1,3 +1,4 @@
 export const region = () => ({
   firestore: { document: () => ({ onWrite: () => {}, onCreate: () => {} }) },
+  https: { onRequest: () => {} },
 });


### PR DESCRIPTION
## Summary
- add admin panel button to trigger manual contents rendering
- secure HTTPS function to render contents for admin only
- cover admin trigger with tests and mocks

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a321e6ff2c832e8ed9e7204282978f