### PR TITLE
Align admin screen header with contents page

### DIFF
--- a/infra/admin.html
+++ b/infra/admin.html
@@ -4,14 +4,29 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Admin</title>
+    <link rel="stylesheet" href="/dendrite.css" />
   </head>
   <body>
-    <div id="signinButton"></div>
-    <div id="adminContent" style="display: none">
+    <header class="header">
+      <nav class="nav">
+        <a href="/">
+          <img
+            src="/img/logo.png"
+            alt="Dendrite logo"
+            style="height: 1em; vertical-align: middle; margin-right: 0.5em"
+          />
+          Dendrite
+        </a>
+        <a href="new-story.html">New story</a>
+        <a href="mod.html">Moderate</a>
+        <div id="signinButton"></div>
+      </nav>
+    </header>
+    <main id="adminContent" style="display: none">
       <h1>Admin</h1>
       <p>Welcome.</p>
       <button id="renderBtn">Render contents</button>
-    </div>
+    </main>
     <script src="https://accounts.google.com/gsi/client" defer></script>
     <script type="module" src="./admin.js"></script>
   </body>


### PR DESCRIPTION
## Summary
- Style admin page with `dendrite.css` and navigation header matching the contents page

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a3fd074338832e9394dfb6089c7133