### PR TITLE
feat(render-variant): add story title to head

### DIFF
--- a/infra/cloud-functions/render-variant/buildHtml.js
+++ b/infra/cloud-functions/render-variant/buildHtml.js
@@ -50,6 +50,9 @@ export function buildHtml(
     })
     .join('');
   const title = storyTitle ? `<h1>${escapeHtml(storyTitle)}</h1>` : '';
+  const headTitle = storyTitle
+    ? `Dendrite - ${escapeHtml(storyTitle)}`
+    : 'Dendrite';
   const authorHtml = author ? `<p>By ${escapeHtml(author)}</p>` : '';
   const parentHtml = parentUrl ? `<p><a href="${parentUrl}">Back</a></p>` : '';
   const firstHtml = firstPageUrl
@@ -68,7 +71,7 @@ export function buildHtml(
     `<!doctype html>` +
     `<html lang="en"><head><meta charset="UTF-8" />` +
     `<meta name="viewport" content="width=device-width, initial-scale=1" />` +
-    `<title>Dendrite</title>` +
+    `<title>${headTitle}</title>` +
     `<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.fluid.classless.min.css" />` +
     `<link rel="stylesheet" href="/dendrite.css" />` +
     `</head><body><div class="page">` +

--- a/test/cloud-functions/buildHtml.test.js
+++ b/test/cloud-functions/buildHtml.test.js
@@ -2,6 +2,11 @@ import { describe, test, expect } from '@jest/globals';
 import { buildHtml } from '../../infra/cloud-functions/render-variant/buildHtml.js';
 
 describe('buildHtml', () => {
+  test('sets default head title when story title missing', () => {
+    const html = buildHtml(1, 'a', 'hello', []);
+    expect(html).toContain('<title>Dendrite</title>');
+  });
+
   test('omits story title when not provided', () => {
     const html = buildHtml(1, 'a', 'hello', []);
     expect(html).not.toContain('<h1>My Story</h1>');
@@ -13,6 +18,11 @@ describe('buildHtml', () => {
     const contentIndex = html.indexOf('<p>hello</p>');
     expect(titleIndex).toBeGreaterThan(-1);
     expect(titleIndex).toBeLessThan(contentIndex);
+  });
+
+  test('includes story title in head title when provided', () => {
+    const html = buildHtml(1, 'a', 'hello', [], 'My Story');
+    expect(html).toContain('<title>Dendrite - My Story</title>');
   });
 
   test('links option without target page using slug', () => {


### PR DESCRIPTION
## Summary
- include story title in variant page `<title>` as `Dendrite - {title}`
- cover new head title behavior with tests

## Testing
- `npm test`
- `npm run lint` *(fails: 99 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a415d37810832e8fa309f169d1e0e3