### PR TITLE
Add navigation between variant link and report button

### DIFF
--- a/infra/cloud-functions/render-variant/buildHtml.js
+++ b/infra/cloud-functions/render-variant/buildHtml.js
@@ -62,6 +62,7 @@ export function buildHtml(
   const reportHtml =
     '<p><button id="reportBtn" type="button">Report</button></p>' +
     `<script>document.getElementById('reportBtn').onclick=async()=>{try{await fetch('https://europe-west1-irien-465710.cloudfunctions.net/prod-report-for-moderation',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({variant:'${variantSlug}'})});alert('Thanks for your report.');}catch(e){alert('Sorry, something went wrong.');}};</script>`;
+  const pageNumberHtml = `<p style="text-align:center"><a href="/p/${pageNumber - 1}a.html">◀</a> ${pageNumber} <a href="/p/${pageNumber + 1}a.html">▶</a></p>`;
   const paragraphs = String(content ?? '')
     .replace(/\r\n?/g, '\n')
     .split('\n')
@@ -76,7 +77,7 @@ export function buildHtml(
     `<link rel="stylesheet" href="/dendrite.css" />` +
     `</head><body>` +
     `<header class="header"><nav class="nav"><a href="/"><img src="/img/logo.png" alt="Dendrite logo" style="height:1em;vertical-align:middle;margin-right:0.5em;" />Dendrite</a><a href="../new-story.html">New story</a><a href="../mod.html">Moderate</a><div id="signinButton"></div></nav></header>` +
-    `<main>${title}${paragraphs}<ol>${items}</ol>${authorHtml}${parentHtml}${firstHtml}<p><a href="./${pageNumber}-alts.html">Other variants</a></p>${reportHtml}</main>` +
+    `<main>${title}${paragraphs}<ol>${items}</ol>${authorHtml}${parentHtml}${firstHtml}<p><a href="./${pageNumber}-alts.html">Other variants</a></p>${pageNumberHtml}${reportHtml}</main>` +
     `<script src="https://accounts.google.com/gsi/client" defer></script><script type="module">import { initGoogleSignIn } from '../googleAuth.js'; initGoogleSignIn();</script>` +
     `</body></html>`
   );

--- a/test/cloud-functions/buildHtml.test.js
+++ b/test/cloud-functions/buildHtml.test.js
@@ -58,6 +58,13 @@ describe('buildHtml', () => {
     expect(html).toContain('<a href="./1-alts.html">Other variants</a>');
   });
 
+  test('shows page number with navigation links', () => {
+    const html = buildHtml(5, 'b', 'content', []);
+    expect(html).toContain(
+      '<p style="text-align:center"><a href="/p/4a.html">◀</a> 5 <a href="/p/6a.html">▶</a></p>'
+    );
+  });
+
   test('includes report button and script', () => {
     const html = buildHtml(1, 'a', 'content', []);
     expect(html).toContain(


### PR DESCRIPTION
## Summary
- display current page number with previous/next arrow links in variant render output
- test page navigation rendering in buildHtml

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a417ebeb50832e93c9b4fbdda8e859