### PR TITLE
Remove underline from navigation arrows

### DIFF
--- a/infra/cloud-functions/render-variant/buildHtml.js
+++ b/infra/cloud-functions/render-variant/buildHtml.js
@@ -62,7 +62,12 @@ export function buildHtml(
   const reportHtml =
     '<p><button id="reportBtn" type="button">Report</button></p>' +
     `<script>document.getElementById('reportBtn').onclick=async()=>{try{await fetch('https://europe-west1-irien-465710.cloudfunctions.net/prod-report-for-moderation',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({variant:'${variantSlug}'})});alert('Thanks for your report.');}catch(e){alert('Sorry, something went wrong.');}};</script>`;
-  const pageNumberHtml = `<p style="text-align:center"><a href="/p/${pageNumber - 1}a.html">◀</a> ${pageNumber} <a href="/p/${pageNumber + 1}a.html">▶</a></p>`;
+  const pageNumberHtml =
+    `<p style="text-align:center">` +
+    `<a style="text-decoration:none" href="/p/${pageNumber - 1}a.html">◀</a> ` +
+    `${pageNumber} ` +
+    `<a style="text-decoration:none" href="/p/${pageNumber + 1}a.html">▶</a>` +
+    `</p>`;
   const paragraphs = String(content ?? '')
     .replace(/\r\n?/g, '\n')
     .split('\n')

--- a/test/cloud-functions/buildHtml.test.js
+++ b/test/cloud-functions/buildHtml.test.js
@@ -61,7 +61,7 @@ describe('buildHtml', () => {
   test('shows page number with navigation links', () => {
     const html = buildHtml(5, 'b', 'content', []);
     expect(html).toContain(
-      '<p style="text-align:center"><a href="/p/4a.html">◀</a> 5 <a href="/p/6a.html">▶</a></p>'
+      '<p style="text-align:center"><a style="text-decoration:none" href="/p/4a.html">◀</a> 5 <a style="text-decoration:none" href="/p/6a.html">▶</a></p>'
     );
   });
 


### PR DESCRIPTION
## Summary
- Remove underline from previous/next navigation arrows in render-variant HTML
- Update buildHtml test to expect inline style on arrow links

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a41bef7784832e8dc6b3199d240438