### PR TITLE
fix: remove bold from header links

### DIFF
--- a/infra/dendrite.css
+++ b/infra/dendrite.css
@@ -75,7 +75,7 @@ body {
   width: 100%;
 }
 
-.header a {
+.header a:first-of-type {
   font-weight: 600;
 }
 


### PR DESCRIPTION
### Summary
- only bold the main site link in the header so "New story" and "Moderate" links render with normal weight

### Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a42612bf2c832ea6c2cdd91d86de12