### PR TITLE
feat: support dark mode for Google sign in

### DIFF
--- a/infra/googleAuth.js
+++ b/infra/googleAuth.js
@@ -32,11 +32,23 @@ export const initGoogleSignIn = ({ onSignIn } = {}) => {
     ux_mode: 'popup',
   });
 
-  google.accounts.id.renderButton(document.getElementById('signinButton'), {
-    theme: 'outline',
-    size: 'large',
-    text: 'signin_with',
-  });
+  const mql = window.matchMedia('(prefers-color-scheme: dark)');
+
+  const renderButton = () => {
+    const el = document.getElementById('signinButton');
+    if (!el) {
+      return;
+    }
+    el.innerHTML = '';
+    google.accounts.id.renderButton(el, {
+      theme: mql.matches ? 'filled_black' : 'filled_blue',
+      size: 'large',
+      text: 'signin_with',
+    });
+  };
+
+  renderButton();
+  mql.addEventListener('change', renderButton);
 };
 
 export const getIdToken = () => sessionStorage.getItem('id_token');

--- a/test/browser/googleAuth.test.js
+++ b/test/browser/googleAuth.test.js
@@ -41,4 +41,33 @@ describe('googleAuth', () => {
     expect(sessionStorage.getItem('id_token')).toBeNull();
     expect(disableAutoSelect).toHaveBeenCalled();
   });
+
+  it('renders the correct theme and updates on scheme change', () => {
+    const renderButton = jest.fn();
+    const listeners = {};
+    const mql = {
+      matches: false,
+      addEventListener: (ev, cb) => {
+        listeners[ev] = cb;
+      },
+    };
+    global.document.getElementById.mockReturnValue({ innerHTML: '' });
+    global.window = {
+      google: { accounts: { id: { initialize: jest.fn(), renderButton } } },
+      matchMedia: jest.fn().mockReturnValue(mql),
+    };
+    global.google = global.window.google;
+    initGoogleSignIn();
+    expect(renderButton).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({ theme: 'filled_blue' })
+    );
+    renderButton.mockClear();
+    mql.matches = true;
+    listeners.change();
+    expect(renderButton).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({ theme: 'filled_black' })
+    );
+  });
 });

--- a/test/browser/moderate.test.js
+++ b/test/browser/moderate.test.js
@@ -29,6 +29,10 @@ describe('authedFetch', () => {
           },
         },
       },
+      matchMedia: jest.fn().mockReturnValue({
+        matches: false,
+        addEventListener: jest.fn(),
+      }),
     };
     global.google = global.window.google;
     global.document = { getElementById: jest.fn() };


### PR DESCRIPTION
## Summary
- render Google sign-in with filled_blue or filled_black theme based on system color scheme
- update tests to cover theme switching and provide matchMedia stubs

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a42f6d8784832e814f3c5e7d0c7650