### PR TITLE
Add daily stats generator and admin trigger

### DIFF
--- a/infra/admin.html
+++ b/infra/admin.html
@@ -26,6 +26,7 @@
       <h1>Admin</h1>
       <p>Welcome.</p>
       <button id="renderBtn">Render contents</button>
+      <button id="statsBtn" style="margin-left: 1em">Generate stats</button>
       <form id="regenForm" style="margin-top: 1em">
         <label for="regenInput">Page variant</label>
         <input id="regenInput" type="text" placeholder="5a" required />

--- a/infra/admin.js
+++ b/infra/admin.js
@@ -6,6 +6,8 @@ const RENDER_URL =
   'https://europe-west1-irien-465710.cloudfunctions.net/prod-trigger-render-contents';
 const REGENERATE_URL =
   'https://europe-west1-irien-465710.cloudfunctions.net/prod-mark-variant-dirty';
+const STATS_URL =
+  'https://europe-west1-irien-465710.cloudfunctions.net/prod-generate-stats';
 
 /**
  * Redirects unauthorized users and reveals admin content for the correct UID.
@@ -38,6 +40,25 @@ async function triggerRender() {
     alert('Render triggered');
   } catch {
     alert('Render failed');
+  }
+}
+
+/**
+ * Trigger stats generation.
+ */
+async function triggerStats() {
+  const token = getIdToken();
+  if (!token) {
+    return;
+  }
+  try {
+    await fetch(STATS_URL, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    alert('Stats generated');
+  } catch {
+    alert('Stats generation failed');
   }
 }
 
@@ -77,6 +98,7 @@ async function regenerateVariant(e) {
 }
 
 document.getElementById('renderBtn')?.addEventListener('click', triggerRender);
+document.getElementById('statsBtn')?.addEventListener('click', triggerStats);
 document
   .getElementById('regenForm')
   ?.addEventListener('submit', regenerateVariant);

--- a/infra/cloud-functions/generate-stats/index.js
+++ b/infra/cloud-functions/generate-stats/index.js
@@ -1,0 +1,170 @@
+import crypto from 'crypto';
+import { initializeApp } from 'firebase-admin/app';
+import { getFirestore } from 'firebase-admin/firestore';
+import { getAuth } from 'firebase-admin/auth';
+import { Storage } from '@google-cloud/storage';
+import * as functions from 'firebase-functions';
+import express from 'express';
+import cors from 'cors';
+
+initializeApp();
+const db = getFirestore();
+const auth = getAuth();
+const storage = new Storage();
+
+const ADMIN_UID = 'qcYSrXTaj1MZUoFsAloBwT86GNM2';
+const allowed = [
+  'https://mattheard.net',
+  'https://dendritestories.co.nz',
+  'https://www.dendritestories.co.nz',
+];
+const PROJECT = process.env.GOOGLE_CLOUD_PROJECT || process.env.GCLOUD_PROJECT;
+const URL_MAP = process.env.URL_MAP || 'prod-dendrite-url-map';
+const CDN_HOST = process.env.CDN_HOST || 'www.dendritestories.co.nz';
+const BUCKET = 'www.dendritestories.co.nz';
+
+const app = express();
+app.use(
+  cors({
+    origin: (origin, cb) => {
+      if (!origin || allowed.includes(origin)) {
+        cb(null, true);
+      } else {
+        cb(new Error('CORS'));
+      }
+    },
+    methods: ['POST'],
+  })
+);
+
+/**
+ * Build stats HTML page.
+ * @param {number} count Story count.
+ * @returns {string} HTML page.
+ */
+function buildHtml(count) {
+  return `<!doctype html><html lang="en"><head><meta charset="UTF-8" /><meta name="viewport" content="width=device-width, initial-scale=1" /><title>Dendrite stats</title><link rel="stylesheet" href="/dendrite.css" /></head><body><header class="header"><nav class="nav"><a href="/"><img src="/img/logo.png" alt="Dendrite logo" style="height:1em;vertical-align:middle;margin-right:0.5em" />Dendrite</a><a href="new-story.html">New story</a><a href="mod.html">Moderate</a><div id="signinButton"></div></nav></header><main><h1>Stats</h1><p>Number of stories: ${count}</p></main><script src="https://accounts.google.com/gsi/client" defer></script><script type="module">import { initGoogleSignIn } from './googleAuth.js'; initGoogleSignIn();</script></body></html>`;
+}
+
+/**
+ * Count stories in Firestore.
+ * @returns {Promise<number>} Story count.
+ */
+async function getStoryCount() {
+  const snap = await db.collection('stories').count().get();
+  return snap.data().count || 0;
+}
+
+/**
+ * Retrieve access token from metadata server.
+ * @returns {Promise<string>} Access token.
+ */
+async function getAccessTokenFromMetadata() {
+  const r = await fetch(
+    'http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token',
+    { headers: { 'Metadata-Flavor': 'Google' } }
+  );
+  if (!r.ok) throw new Error(`metadata token: HTTP ${r.status}`);
+  const { access_token } = await r.json();
+  return access_token;
+}
+
+/**
+ * Invalidate CDN caches for given paths.
+ * @param {string[]} paths Paths to invalidate.
+ */
+async function invalidatePaths(paths) {
+  const token = await getAccessTokenFromMetadata();
+  await Promise.all(
+    paths.map(async path => {
+      try {
+        const res = await fetch(
+          `https://compute.googleapis.com/compute/v1/projects/${PROJECT}/global/urlMaps/${URL_MAP}/invalidateCache`,
+          {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${token}`,
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+              host: CDN_HOST,
+              path,
+              requestId: crypto.randomUUID(),
+            }),
+          }
+        );
+        if (!res.ok) {
+          console.error(`invalidate ${path} failed: ${res.status}`);
+        }
+      } catch (e) {
+        console.error(`invalidate ${path} error`, e?.message || e);
+      }
+    })
+  );
+}
+
+/**
+ * Generate stats page and upload to storage.
+ * @param {{countFn?: () => Promise<number>}} [deps] Optional dependencies.
+ */
+async function generate(deps = {}) {
+  const countFn = deps.countFn || getStoryCount;
+  const count = await countFn();
+  const html = buildHtml(count);
+  const bucket = storage.bucket(BUCKET);
+  await bucket.file('stats.html').save(html, {
+    contentType: 'text/html',
+    metadata: { cacheControl: 'no-cache' },
+  });
+  await invalidatePaths(['/stats.html']);
+  return null;
+}
+
+/**
+ * Handle HTTP requests to generate stats.
+ * @param {import('express').Request} req HTTP request.
+ * @param {import('express').Response} res HTTP response.
+ * @param {{genFn?: typeof generate}} [deps] Optional dependencies.
+ * @returns {Promise<void>} Promise resolving when response is sent.
+ */
+async function handleRequest(req, res, deps = {}) {
+  if (req.method !== 'POST') {
+    res.status(405).send('POST only');
+    return;
+  }
+  const isCron = req.get('X-Appengine-Cron') === 'true';
+  if (!isCron) {
+    const authHeader = req.get('Authorization') || '';
+    const match = authHeader.match(/^Bearer (.+)$/);
+    if (!match) {
+      res.status(401).send('Missing token');
+      return;
+    }
+    let decoded;
+    try {
+      decoded = await auth.verifyIdToken(match[1]);
+    } catch (e) {
+      res.status(401).send(e?.message || 'Invalid token');
+      return;
+    }
+    if (decoded.uid !== ADMIN_UID) {
+      res.status(403).send('Forbidden');
+      return;
+    }
+  }
+  const genFn = deps.genFn || generate;
+  try {
+    await genFn();
+    res.status(200).json({ ok: true });
+  } catch (e) {
+    res.status(500).json({ error: e?.message || 'generate failed' });
+  }
+}
+
+app.post('/', handleRequest);
+
+export const generateStats = functions
+  .region('europe-west1')
+  .https.onRequest(app);
+
+export { buildHtml, getStoryCount, generate, handleRequest };

--- a/infra/cloud-functions/generate-stats/package.json
+++ b/infra/cloud-functions/generate-stats/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "generate-stats",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.js",
+  "dependencies": {
+    "@google-cloud/storage": "^7.16.0",
+    "firebase-admin": "^11.10.1",
+    "firebase-functions": "^4.4.1",
+    "express": "^4.19.2",
+    "cors": "^2.8.5"
+  }
+}


### PR DESCRIPTION
## Summary
- add generate-stats Cloud Function to count stories and publish stats.html
- schedule daily execution at midnight UTC and trigger from admin page
- add admin button and placeholder stats page
- remove Terraform-managed stats page so Cloud Function manages stats output

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a47e6066f0832ea4304ae5bd35b7e0