### PR TITLE
chore: grant Cloud Scheduler admin to terraform

### DIFF
--- a/infra/cloud-scheduler-iam.tf
+++ b/infra/cloud-scheduler-iam.tf
@@ -1,0 +1,8 @@
+# Cloud Scheduler IAM roles for Terraform
+
+resource "google_project_iam_member" "terraform_cloudscheduler_admin" {
+  project = var.project_id
+  role    = "roles/cloudscheduler.admin"
+  member  = "serviceAccount:terraform@${var.project_id}.iam.gserviceaccount.com"
+}
+


### PR DESCRIPTION
## Summary
- allow terraform service account to administer Cloud Scheduler

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a488216304832eab7968729c7f8d84