### PR TITLE
Consolidate Cloud Scheduler IAM and add dependency

### DIFF
--- a/infra/cloud-scheduler-iam.tf
+++ b/infra/cloud-scheduler-iam.tf
@@ -1,8 +1,0 @@
-# Cloud Scheduler IAM roles for Terraform
-
-resource "google_project_iam_member" "terraform_cloudscheduler_admin" {
-  project = var.project_id
-  role    = "roles/cloudscheduler.admin"
-  member  = "serviceAccount:terraform@${var.project_id}.iam.gserviceaccount.com"
-}
-

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -207,6 +207,12 @@ resource "google_project_iam_member" "terraform_create_sa" {
   member  = "serviceAccount:terraform@${var.project_id}.iam.gserviceaccount.com"
 }
 
+resource "google_project_iam_member" "terraform_cloudscheduler_admin" {
+  project = var.project_id
+  role    = "roles/cloudscheduler.admin"
+  member  = "serviceAccount:terraform@${var.project_id}.iam.gserviceaccount.com"
+}
+
 resource "google_project_iam_member" "ci_firebaserules_admin" {
   project = var.project_id
   role    = "roles/firebaserules.admin"
@@ -946,6 +952,7 @@ resource "google_cloud_scheduler_job" "generate_stats_daily" {
   depends_on = [
     google_project_service.cloudscheduler,
     google_cloudfunctions_function.generate_stats,
+    google_project_iam_member.terraform_cloudscheduler_admin,
   ]
 }
 


### PR DESCRIPTION
## Summary
- move Cloud Scheduler admin IAM binding into main Terraform configuration
- ensure stats job waits for Cloud Scheduler IAM setup

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a489ca0848832e89d03ff1b7270ff2