### PR TITLE
Use hyperlink with flag icon for variant reporting

### DIFF
--- a/infra/cloud-functions/render-variant/buildHtml.js
+++ b/infra/cloud-functions/render-variant/buildHtml.js
@@ -60,8 +60,8 @@ export function buildHtml(
     : '';
   const variantSlug = `${pageNumber}${variantName}`;
   const reportHtml =
-    '<p><button id="reportBtn" type="button">Report</button></p>' +
-    `<script>document.getElementById('reportBtn').onclick=async()=>{try{await fetch('https://europe-west1-irien-465710.cloudfunctions.net/prod-report-for-moderation',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({variant:'${variantSlug}'})});alert('Thanks for your report.');}catch(e){alert('Sorry, something went wrong.');}};</script>`;
+    '<p><a id="reportLink" href="#">⚑ Report</a></p>' +
+    `<script>document.getElementById('reportLink').onclick=async e=>{e.preventDefault();try{await fetch('https://europe-west1-irien-465710.cloudfunctions.net/prod-report-for-moderation',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({variant:'${variantSlug}'})});alert('Thanks for your report.');}catch(e){alert('Sorry, something went wrong.');}};</script>`;
   const pageNumberHtml =
     `<p style="text-align:center">` +
     `<a style="text-decoration:none" href="/p/${pageNumber - 1}a.html">◀</a> ` +

--- a/test/cloud-functions/buildHtml.test.js
+++ b/test/cloud-functions/buildHtml.test.js
@@ -65,11 +65,9 @@ describe('buildHtml', () => {
     );
   });
 
-  test('includes report button and script', () => {
+  test('includes report link and script', () => {
     const html = buildHtml(1, 'a', 'content', []);
-    expect(html).toContain(
-      '<button id="reportBtn" type="button">Report</button>'
-    );
+    expect(html).toContain('<a id="reportLink" href="#">⚑ Report</a>');
     expect(html).toContain("JSON.stringify({variant:'1a'})");
     expect(html).toContain('prod-report-for-moderation');
   });


### PR DESCRIPTION
## Summary
- Replace report button with a flag-icon hyperlink in render variant HTML
- Update tests to verify new report link

## Testing
- `npm test`
- `npm run lint` *(121 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a484b2da3c832e991d29df1f61c0ce