### PR TITLE
Neutralize Google sign-in button background

### DIFF
--- a/infra/dendrite.css
+++ b/infra/dendrite.css
@@ -148,3 +148,12 @@ a {
   margin: 0 auto;
   padding: 0 1rem;
 }
+
+/* Neutralize background for Google sign-in button */
+.g_id_signin,
+.abcRioButton {
+  background: transparent !important;
+  border: none !important;
+  box-shadow: none !important;
+  padding: 0 !important;
+}


### PR DESCRIPTION
## Summary
- Neutralize Google sign-in button background with transparent styling

## Testing
- `npm test`
- `npm run lint` *(warnings: Ternary operator usage, camelcase, missing JSDoc, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a48cae7608832e86baf17f6446871e