### PR TITLE
Add page moderation stats

### DIFF
--- a/test/cloud-functions/generateStats.test.js
+++ b/test/cloud-functions/generateStats.test.js
@@ -1,0 +1,41 @@
+import {
+  buildHtml,
+  getPageCount,
+  getUnmoderatedPageCount,
+} from '../../infra/cloud-functions/generate-stats/index.js';
+
+describe('generate stats helpers', () => {
+  test('buildHtml outputs counts', () => {
+    const html = buildHtml(1, 2, 3);
+    expect(html).toContain('<p>Number of stories: 1</p>');
+    expect(html).toContain('<p>Number of pages: 2</p>');
+    expect(html).toContain('<p>Number of unmoderated pages: 3</p>');
+  });
+
+  test('getPageCount returns page count', async () => {
+    const mockDb = {
+      collection: () => ({
+        count: () => ({
+          get: () => Promise.resolve({ data: () => ({ count: 5 }) }),
+        }),
+      }),
+    };
+    await expect(getPageCount(mockDb)).resolves.toBe(5);
+  });
+
+  test('getUnmoderatedPageCount sums zero and null counts', async () => {
+    const mockDb = {
+      collection: () => ({
+        where: (_field, _op, value) => ({
+          count: () => ({
+            get: () =>
+              Promise.resolve({
+                data: () => ({ count: value === 0 ? 2 : 3 }),
+              }),
+          }),
+        }),
+      }),
+    };
+    await expect(getUnmoderatedPageCount(mockDb)).resolves.toBe(5);
+  });
+});


### PR DESCRIPTION
## Summary
- include page counts and unmoderated page counts in generated stats HTML
- expose helpers to count pages and unmoderated pages
- test stats helpers

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4990ec68c832ea4b47c5f587ab00e