### PR TITLE
Add rewrite link for variant pages

### DIFF
--- a/infra/cloud-functions/render-variant/buildHtml.js
+++ b/infra/cloud-functions/render-variant/buildHtml.js
@@ -26,6 +26,7 @@ function renderInlineMarkdown(text) {
  * @param {string} [author] Author name.
  * @param parentUrl
  * @param firstPageUrl
+ * @param incomingOptionSlug
  * @returns {string} HTML page.
  */
 export function buildHtml(
@@ -36,7 +37,8 @@ export function buildHtml(
   storyTitle = '',
   author = '',
   parentUrl = '',
-  firstPageUrl = ''
+  firstPageUrl = '',
+  incomingOptionSlug = ''
 ) {
   const items = options
     .map(opt => {
@@ -57,6 +59,9 @@ export function buildHtml(
   const parentHtml = parentUrl ? `<p><a href="${parentUrl}">Back</a></p>` : '';
   const firstHtml = firstPageUrl
     ? `<p><a href="${firstPageUrl}">First page</a></p>`
+    : '';
+  const rewriteLink = incomingOptionSlug
+    ? `<a href="../new-page.html?option=${incomingOptionSlug}">Rewrite</a> `
     : '';
   const variantSlug = `${pageNumber}${variantName}`;
   const reportHtml =
@@ -82,7 +87,7 @@ export function buildHtml(
     `<link rel="stylesheet" href="/dendrite.css" />` +
     `</head><body>` +
     `<header class="header"><nav class="nav"><a href="/"><img src="/img/logo.png" alt="Dendrite logo" style="height:1em;vertical-align:middle;margin-right:0.5em;" />Dendrite</a><a href="/new-story.html">New story</a><a href="/mod.html">Moderate</a><a href="/stats.html">Stats</a><div id="signinButton"></div></nav></header>` +
-    `<main>${title}${paragraphs}<ol>${items}</ol>${authorHtml}${parentHtml}${firstHtml}<p><a href="./${pageNumber}-alts.html">Other variants</a></p>${pageNumberHtml}${reportHtml}</main>` +
+    `<main>${title}${paragraphs}<ol>${items}</ol>${authorHtml}${parentHtml}${firstHtml}<p>${rewriteLink}<a href="./${pageNumber}-alts.html">Other variants</a></p>${pageNumberHtml}${reportHtml}</main>` +
     `<script src="https://accounts.google.com/gsi/client" defer></script><script type="module">import { initGoogleSignIn } from '../googleAuth.js'; initGoogleSignIn();</script>` +
     `</body></html>`
   );

--- a/infra/cloud-functions/render-variant/index.js
+++ b/infra/cloud-functions/render-variant/index.js
@@ -176,22 +176,28 @@ async function render(snap, ctx) {
 
   const authorName = variant.authorName || variant.author || '';
   let parentUrl;
+  let incomingOptionSlug;
   if (variant.incomingOption) {
     try {
       const optionRef = db.doc(variant.incomingOption);
       const parentVariantRef = optionRef.parent.parent;
       const parentPageRef = parentVariantRef.parent.parent;
 
-      const [parentVariantSnap, parentPageSnap] = await Promise.all([
-        parentVariantRef.get(),
-        parentPageRef.get(),
-      ]);
+      const [optionSnap, parentVariantSnap, parentPageSnap] = await Promise.all(
+        [optionRef.get(), parentVariantRef.get(), parentPageRef.get()]
+      );
 
       if (parentVariantSnap.exists && parentPageSnap.exists) {
         const parentName = parentVariantSnap.data().name;
         if (parentName) {
           const parentNumber = parentPageSnap.data().number;
           parentUrl = `/p/${parentNumber}${parentName}.html`;
+          if (optionSnap.exists) {
+            const position = optionSnap.data().position;
+            if (position !== undefined) {
+              incomingOptionSlug = `${parentNumber}-${parentName}-${position}`;
+            }
+          }
         }
       }
     } catch (e) {
@@ -207,7 +213,8 @@ async function render(snap, ctx) {
     storyTitle,
     authorName,
     parentUrl,
-    firstPageUrl
+    firstPageUrl,
+    incomingOptionSlug
   );
   const filePath = `p/${page.number}${variant.name}.html`;
   const openVariant = options.some(opt => opt.targetPageNumber === undefined);

--- a/test/cloud-functions/buildHtml.test.js
+++ b/test/cloud-functions/buildHtml.test.js
@@ -58,6 +58,13 @@ describe('buildHtml', () => {
     expect(html).toContain('<a href="./1-alts.html">Other variants</a>');
   });
 
+  test('includes rewrite link when incoming option slug provided', () => {
+    const html = buildHtml(2, 'b', 'content', [], '', '', '', '', '1-a-0');
+    expect(html).toContain(
+      '<a href="../new-page.html?option=1-a-0">Rewrite</a> <a href="./2-alts.html">Other variants</a>'
+    );
+  });
+
   test('shows page number with navigation links', () => {
     const html = buildHtml(5, 'b', 'content', []);
     expect(html).toContain(

--- a/test/cloud-functions/renderVariant.test.js
+++ b/test/cloud-functions/renderVariant.test.js
@@ -127,7 +127,12 @@ describe('render', () => {
       }),
       parent: { parent: parentPageRef },
     };
-    mockDoc.mockReturnValue({ parent: { parent: parentVariantRef } });
+    mockDoc.mockReturnValue({
+      parent: { parent: parentVariantRef },
+      get: jest
+        .fn()
+        .mockResolvedValue({ exists: true, data: () => ({ position: 4 }) }),
+    });
 
     await render(snap, { params: { storyId: 's1', variantId: 'v1' } });
 
@@ -158,11 +163,51 @@ describe('render', () => {
       }),
       parent: { parent: parentPageRef },
     };
-    mockDoc.mockReturnValue({ parent: { parent: parentVariantRef } });
+    mockDoc.mockReturnValue({
+      parent: { parent: parentVariantRef },
+      get: jest
+        .fn()
+        .mockResolvedValue({ exists: true, data: () => ({ position: 2 }) }),
+    });
 
     await render(snap, { params: { storyId: 's1', variantId: 'v1' } });
     const html = mockSave.mock.calls[0][0];
     expect(html).toContain('<a href="/p/7b.html">Back</a>');
     expect(html).toContain('<a href="/p/1a.html">First page</a>');
+  });
+
+  test('includes rewrite link when incoming option provided', async () => {
+    const snap = createSnap([{ content: 'Go', position: 0 }]);
+    snap.data = () => ({
+      name: 'a',
+      content: 'content',
+      incomingOption: 'stories/s1/pages/p1/variants/pv/options/o1',
+    });
+
+    const parentPageRef = {
+      get: jest.fn().mockResolvedValue({
+        exists: true,
+        data: () => ({ number: 7 }),
+      }),
+    };
+    const parentVariantRef = {
+      get: jest.fn().mockResolvedValue({
+        exists: true,
+        data: () => ({ name: 'b' }),
+      }),
+      parent: { parent: parentPageRef },
+    };
+    mockDoc.mockReturnValue({
+      parent: { parent: parentVariantRef },
+      get: jest
+        .fn()
+        .mockResolvedValue({ exists: true, data: () => ({ position: 3 }) }),
+    });
+
+    await render(snap, { params: { storyId: 's1', variantId: 'v1' } });
+    const html = mockSave.mock.calls[0][0];
+    expect(html).toContain(
+      '<a href="../new-page.html?option=7-b-3">Rewrite</a> <a href="./5-alts.html">Other variants</a>'
+    );
   });
 });


### PR DESCRIPTION
## Summary
- include optional rewrite link before "Other variants" in variant HTML
- derive incoming option slug in render function and forward to HTML builder
- add tests covering rewrite link rendering

## Testing
- `npm test`
- `npm run lint` *(shows warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a5051d9620832ebe105916d359f6fe