### PR TITLE
Fix stats queries with Firestore indexes

### DIFF
--- a/infra/cloud-functions/generate-stats/index.js
+++ b/infra/cloud-functions/generate-stats/index.js
@@ -63,7 +63,7 @@ async function getStoryCount() {
  * @returns {Promise<number>} Page count.
  */
 async function getPageCount(dbRef = db) {
-  const snap = await dbRef.collection('pages').count().get();
+  const snap = await dbRef.collectionGroup('pages').count().get();
   return snap.data().count || 0;
 }
 
@@ -74,12 +74,12 @@ async function getPageCount(dbRef = db) {
  */
 async function getUnmoderatedPageCount(dbRef = db) {
   const zeroSnap = await dbRef
-    .collection('pages')
+    .collectionGroup('variants')
     .where('moderatorReputationSum', '==', 0)
     .count()
     .get();
   const nullSnap = await dbRef
-    .collection('pages')
+    .collectionGroup('variants')
     .where('moderatorReputationSum', '==', null)
     .count()
     .get();

--- a/infra/dendrite-firestore.tf
+++ b/infra/dendrite-firestore.tf
@@ -65,6 +65,28 @@ resource "google_firestore_index" "variants_moderation_rand" {
   }
 }
 
+resource "google_firestore_index" "pages_all" {
+  project     = var.project_id
+  collection  = "pages"
+  query_scope = "COLLECTION_GROUP"
+
+  fields {
+    field_path = "__name__"
+    order      = "ASCENDING"
+  }
+}
+
+# Supports: querying variants by moderatorReputationSum alone
+resource "google_firestore_index" "variants_moderation" {
+  project     = var.project_id
+  collection  = "variants"
+  query_scope = "COLLECTION_GROUP"
+
+  fields {
+    field_path = "moderatorReputationSum"
+    order      = "ASCENDING"
+  }
+}
 
 resource "google_firestore_index" "ratings_by_variant" {
   project     = var.project_id

--- a/test/cloud-functions/generateStats.test.js
+++ b/test/cloud-functions/generateStats.test.js
@@ -14,7 +14,7 @@ describe('generate stats helpers', () => {
 
   test('getPageCount returns page count', async () => {
     const mockDb = {
-      collection: () => ({
+      collectionGroup: () => ({
         count: () => ({
           get: () => Promise.resolve({ data: () => ({ count: 5 }) }),
         }),
@@ -25,7 +25,7 @@ describe('generate stats helpers', () => {
 
   test('getUnmoderatedPageCount sums zero and null counts', async () => {
     const mockDb = {
-      collection: () => ({
+      collectionGroup: () => ({
         where: (_field, _op, value) => ({
           count: () => ({
             get: () =>


### PR DESCRIPTION
## Summary
- query pages with collection group to count subcollection documents
- count unmoderated variants by moderator reputation
- declare Terraform indexes for page counts and variant moderation

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a5059404ec832e84230f858be44516