### PR TITLE
Collapse Google sign-in into hamburger menu

### DIFF
--- a/infra/404.html
+++ b/infra/404.html
@@ -17,13 +17,24 @@
           />
           Dendrite
         </a>
-        <a href="/new-story.html">New story</a>
-        <a href="/mod.html">Moderate</a>
-        <a href="/stats.html">Stats</a>
-        <div id="signinButton"></div>
-        <div id="signoutWrap" style="display: none">
-          <button id="signoutBtn" type="button">Sign out</button>
+        <div class="nav-links">
+          <a href="/new-story.html">New story</a>
+          <a href="/mod.html">Moderate</a>
+          <a href="/stats.html">Stats</a>
+          <div id="signinButton"></div>
+          <div id="signoutWrap" style="display: none">
+            <button id="signoutBtn" type="button">Sign out</button>
+          </div>
         </div>
+        <button
+          id="menuButton"
+          class="menu-toggle"
+          type="button"
+          aria-label="Menu"
+          aria-expanded="false"
+        >
+          &#9776;
+        </button>
       </nav>
     </header>
     <main>
@@ -36,6 +47,15 @@
       import { initGoogleSignIn, getIdToken, signOut } from './googleAuth.js';
 
       document.addEventListener('DOMContentLoaded', () => {
+        const nav = document.querySelector('.nav');
+        const menuButton = document.getElementById('menuButton');
+
+        menuButton.addEventListener('click', () => {
+          const expanded = menuButton.getAttribute('aria-expanded') === 'true';
+          menuButton.setAttribute('aria-expanded', String(!expanded));
+          nav.classList.toggle('open');
+        });
+
         const signin = document.getElementById('signinButton');
         const signoutWrap = document.getElementById('signoutWrap');
         const signoutBtn = document.getElementById('signoutBtn');

--- a/infra/admin.html
+++ b/infra/admin.html
@@ -17,10 +17,21 @@
           />
           Dendrite
         </a>
-        <a href="/new-story.html">New story</a>
-        <a href="/mod.html">Moderate</a>
-        <a href="/stats.html">Stats</a>
-        <div id="signinButton"></div>
+        <div class="nav-links">
+          <a href="/new-story.html">New story</a>
+          <a href="/mod.html">Moderate</a>
+          <a href="/stats.html">Stats</a>
+          <div id="signinButton"></div>
+        </div>
+        <button
+          id="menuButton"
+          class="menu-toggle"
+          type="button"
+          aria-label="Menu"
+          aria-expanded="false"
+        >
+          &#9776;
+        </button>
       </nav>
     </header>
     <main id="adminContent" style="display: none">

--- a/infra/admin.js
+++ b/infra/admin.js
@@ -1,6 +1,15 @@
 import { initGoogleSignIn, getIdToken } from './googleAuth.js';
 import { getAuth } from 'https://www.gstatic.com/firebasejs/12.0.0/firebase-auth.js';
 
+const nav = document.querySelector('.nav');
+const menuButton = document.getElementById('menuButton');
+
+menuButton?.addEventListener('click', () => {
+  const expanded = menuButton.getAttribute('aria-expanded') === 'true';
+  menuButton.setAttribute('aria-expanded', String(!expanded));
+  nav?.classList.toggle('open');
+});
+
 const ADMIN_UID = 'qcYSrXTaj1MZUoFsAloBwT86GNM2';
 const RENDER_URL =
   'https://europe-west1-irien-465710.cloudfunctions.net/prod-trigger-render-contents';

--- a/infra/cloud-functions/generate-stats/index.js
+++ b/infra/cloud-functions/generate-stats/index.js
@@ -45,7 +45,62 @@ app.use(
  * @returns {string} HTML page.
  */
 function buildHtml(storyCount, pageCount, unmoderatedCount) {
-  return `<!doctype html><html lang="en"><head><meta charset="UTF-8" /><meta name="viewport" content="width=device-width, initial-scale=1" /><title>Dendrite stats</title><link rel="stylesheet" href="/dendrite.css" /></head><body><header class="header"><nav class="nav"><a href="/"><img src="/img/logo.png" alt="Dendrite logo" style="height:1em;vertical-align:middle;margin-right:0.5em" />Dendrite</a><a href="/new-story.html">New story</a><a href="/mod.html">Moderate</a><a href="/stats.html">Stats</a><div id="signinButton"></div></nav></header><main><h1>Stats</h1><p>Number of stories: ${storyCount}</p><p>Number of pages: ${pageCount}</p><p>Number of unmoderated pages: ${unmoderatedCount}</p></main><script src="https://accounts.google.com/gsi/client" defer></script><script type="module">import { initGoogleSignIn } from './googleAuth.js'; initGoogleSignIn();</script></body></html>`;
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Dendrite stats</title>
+    <link rel="stylesheet" href="/dendrite.css" />
+  </head>
+  <body>
+    <header class="header">
+      <nav class="nav">
+        <a href="/">
+          <img
+            src="/img/logo.png"
+            alt="Dendrite logo"
+            style="height:1em;vertical-align:middle;margin-right:0.5em"
+          />
+          Dendrite
+        </a>
+        <div class="nav-links">
+          <a href="/new-story.html">New story</a>
+          <a href="/mod.html">Moderate</a>
+          <a href="/stats.html">Stats</a>
+          <div id="signinButton"></div>
+        </div>
+        <button
+          id="menuButton"
+          class="menu-toggle"
+          type="button"
+          aria-label="Menu"
+          aria-expanded="false"
+        >
+          &#9776;
+        </button>
+      </nav>
+    </header>
+    <main>
+      <h1>Stats</h1>
+      <p>Number of stories: ${storyCount}</p>
+      <p>Number of pages: ${pageCount}</p>
+      <p>Number of unmoderated pages: ${unmoderatedCount}</p>
+    </main>
+    <script src="https://accounts.google.com/gsi/client" defer></script>
+    <script type="module">
+      import { initGoogleSignIn } from './googleAuth.js';
+      const nav = document.querySelector('.nav');
+      const menuButton = document.getElementById('menuButton');
+      menuButton.addEventListener('click', () => {
+        const expanded = menuButton.getAttribute('aria-expanded') === 'true';
+        menuButton.setAttribute('aria-expanded', String(!expanded));
+        nav.classList.toggle('open');
+      });
+      initGoogleSignIn();
+    </script>
+  </body>
+</html>`;
 }
 
 /**

--- a/infra/cloud-functions/render-contents/htmlSnippets.js
+++ b/infra/cloud-functions/render-contents/htmlSnippets.js
@@ -1,5 +1,81 @@
 export const LIST_ITEM_HTML = (pageNumber, title) =>
   `<li><a href="./p/${pageNumber}a.html">${title}</a></li>`;
 
-export const PAGE_HTML = list =>
-  `<!doctype html><html lang="en"><head><meta charset="UTF-8" /><meta name="viewport" content="width=device-width, initial-scale=1" /><title>Dendrite</title><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.fluid.classless.min.css" /><link rel="stylesheet" href="/dendrite.css" /></head><body><header class="header"><nav class="nav"><a href="/"><img src="/img/logo.png" alt="Dendrite logo" style="height:1em;vertical-align:middle;margin-right:0.5em;" />Dendrite</a><a href="/new-story.html">New story</a><a href="/mod.html">Moderate</a><a href="/stats.html">Stats</a><div id="signinButton"></div><div id="signoutWrap" style="display:none"><button id="signoutBtn" type="button">Sign out</button></div></nav></header><main><h1>Contents</h1><ol class="contents">${list}</ol></main><script src="https://accounts.google.com/gsi/client" defer></script><script type="module">import { initGoogleSignIn, signOut, getIdToken } from './googleAuth.js';const sb=document.getElementById('signinButton');const sw=document.getElementById('signoutWrap');const so=document.getElementById('signoutBtn');initGoogleSignIn({onSignIn:()=>{sb.style.display='none';sw.style.display='';}});so.onclick=async()=>{await signOut();sb.style.display='';sw.style.display='none';};if(getIdToken()){sb.style.display='none';sw.style.display='';}</script></body></html>`;
+export const PAGE_HTML = list => `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Dendrite</title>
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.fluid.classless.min.css"
+    />
+    <link rel="stylesheet" href="/dendrite.css" />
+  </head>
+  <body>
+    <header class="header">
+      <nav class="nav">
+        <a href="/">
+          <img
+            src="/img/logo.png"
+            alt="Dendrite logo"
+            style="height:1em;vertical-align:middle;margin-right:0.5em;"
+          />
+          Dendrite
+        </a>
+        <div class="nav-links">
+          <a href="/new-story.html">New story</a>
+          <a href="/mod.html">Moderate</a>
+          <a href="/stats.html">Stats</a>
+          <div id="signinButton"></div>
+          <div id="signoutWrap" style="display:none">
+            <button id="signoutBtn" type="button">Sign out</button>
+          </div>
+        </div>
+        <button
+          id="menuButton"
+          class="menu-toggle"
+          type="button"
+          aria-label="Menu"
+          aria-expanded="false"
+        >
+          &#9776;
+        </button>
+      </nav>
+    </header>
+    <main>
+      <h1>Contents</h1>
+      <ol class="contents">${list}</ol>
+    </main>
+    <script src="https://accounts.google.com/gsi/client" defer></script>
+    <script type="module">
+      import { initGoogleSignIn, signOut, getIdToken } from './googleAuth.js';
+      const nav = document.querySelector('.nav');
+      const menuButton = document.getElementById('menuButton');
+      menuButton.addEventListener('click', () => {
+        const expanded = menuButton.getAttribute('aria-expanded') === 'true';
+        menuButton.setAttribute('aria-expanded', String(!expanded));
+        nav.classList.toggle('open');
+      });
+      const sb = document.getElementById('signinButton');
+      const sw = document.getElementById('signoutWrap');
+      const so = document.getElementById('signoutBtn');
+      initGoogleSignIn({
+        onSignIn: () => {
+          sb.style.display = 'none';
+          sw.style.display = '';
+        },
+      });
+      so.onclick = async () => {
+        await signOut();
+        sb.style.display = '';
+        sw.style.display = 'none';
+      };
+      if (getIdToken()) {
+        sb.style.display = 'none';
+        sw.style.display = '';
+      }
+    </script>
+  </body>
+</html>`;

--- a/infra/cloud-functions/render-variant/buildAltsHtml.js
+++ b/infra/cloud-functions/render-variant/buildAltsHtml.js
@@ -28,5 +28,59 @@ export function buildAltsHtml(pageNumber, variants) {
       return `<li><a href="/p/${pageNumber}${v.name}.html">${escapeHtml(words)}</a></li>`;
     })
     .join('');
-  return `<!doctype html><html lang="en"><head><meta charset="UTF-8" /><meta name="viewport" content="width=device-width, initial-scale=1" /><title>Dendrite</title><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.fluid.classless.min.css" /><link rel="stylesheet" href="/dendrite.css" /></head><body><header class="header"><nav class="nav"><a href="/"><img src="/img/logo.png" alt="Dendrite logo" style="height:1em;vertical-align:middle;margin-right:0.5em;" />Dendrite</a><a href="/new-story.html">New story</a><a href="/mod.html">Moderate</a><a href="/stats.html">Stats</a><div id="signinButton"></div></nav></header><main><ol>${items}</ol></main><script src="https://accounts.google.com/gsi/client" defer></script><script type="module">import { initGoogleSignIn } from '../googleAuth.js'; initGoogleSignIn();</script></body></html>`;
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Dendrite</title>
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.fluid.classless.min.css"
+    />
+    <link rel="stylesheet" href="/dendrite.css" />
+  </head>
+  <body>
+    <header class="header">
+      <nav class="nav">
+        <a href="/">
+          <img
+            src="/img/logo.png"
+            alt="Dendrite logo"
+            style="height:1em;vertical-align:middle;margin-right:0.5em;"
+          />
+          Dendrite
+        </a>
+        <div class="nav-links">
+          <a href="/new-story.html">New story</a>
+          <a href="/mod.html">Moderate</a>
+          <a href="/stats.html">Stats</a>
+          <div id="signinButton"></div>
+        </div>
+        <button
+          id="menuButton"
+          class="menu-toggle"
+          type="button"
+          aria-label="Menu"
+          aria-expanded="false"
+        >
+          &#9776;
+        </button>
+      </nav>
+    </header>
+    <main><ol>${items}</ol></main>
+    <script src="https://accounts.google.com/gsi/client" defer></script>
+    <script type="module">
+      import { initGoogleSignIn } from '../googleAuth.js';
+      const nav = document.querySelector('.nav');
+      const menuButton = document.getElementById('menuButton');
+      menuButton.addEventListener('click', () => {
+        const expanded = menuButton.getAttribute('aria-expanded') === 'true';
+        menuButton.setAttribute('aria-expanded', String(!expanded));
+        nav.classList.toggle('open');
+      });
+      initGoogleSignIn();
+    </script>
+  </body>
+</html>`;
 }

--- a/infra/cloud-functions/render-variant/buildHtml.js
+++ b/infra/cloud-functions/render-variant/buildHtml.js
@@ -78,17 +78,59 @@ export function buildHtml(
     .split('\n')
     .map(line => `<p>${renderInlineMarkdown(line)}</p>`)
     .join('');
-  return (
-    `<!doctype html>` +
-    `<html lang="en"><head><meta charset="UTF-8" />` +
-    `<meta name="viewport" content="width=device-width, initial-scale=1" />` +
-    `<title>${headTitle}</title>` +
-    `<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.fluid.classless.min.css" />` +
-    `<link rel="stylesheet" href="/dendrite.css" />` +
-    `</head><body>` +
-    `<header class="header"><nav class="nav"><a href="/"><img src="/img/logo.png" alt="Dendrite logo" style="height:1em;vertical-align:middle;margin-right:0.5em;" />Dendrite</a><a href="/new-story.html">New story</a><a href="/mod.html">Moderate</a><a href="/stats.html">Stats</a><div id="signinButton"></div></nav></header>` +
-    `<main>${title}${paragraphs}<ol>${items}</ol>${authorHtml}${parentHtml}${firstHtml}<p>${rewriteLink}<a href="./${pageNumber}-alts.html">Other variants</a></p>${pageNumberHtml}${reportHtml}</main>` +
-    `<script src="https://accounts.google.com/gsi/client" defer></script><script type="module">import { initGoogleSignIn } from '../googleAuth.js'; initGoogleSignIn();</script>` +
-    `</body></html>`
-  );
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>${headTitle}</title>
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.fluid.classless.min.css"
+    />
+    <link rel="stylesheet" href="/dendrite.css" />
+  </head>
+  <body>
+    <header class="header">
+      <nav class="nav">
+        <a href="/">
+          <img
+            src="/img/logo.png"
+            alt="Dendrite logo"
+            style="height:1em;vertical-align:middle;margin-right:0.5em;"
+          />
+          Dendrite
+        </a>
+        <div class="nav-links">
+          <a href="/new-story.html">New story</a>
+          <a href="/mod.html">Moderate</a>
+          <a href="/stats.html">Stats</a>
+          <div id="signinButton"></div>
+        </div>
+        <button
+          id="menuButton"
+          class="menu-toggle"
+          type="button"
+          aria-label="Menu"
+          aria-expanded="false"
+        >
+          &#9776;
+        </button>
+      </nav>
+    </header>
+    <main>${title}${paragraphs}<ol>${items}</ol>${authorHtml}${parentHtml}${firstHtml}<p>${rewriteLink}<a href="./${pageNumber}-alts.html">Other variants</a></p>${pageNumberHtml}${reportHtml}</main>
+    <script src="https://accounts.google.com/gsi/client" defer></script>
+    <script type="module">
+      import { initGoogleSignIn } from '../googleAuth.js';
+      const nav = document.querySelector('.nav');
+      const menuButton = document.getElementById('menuButton');
+      menuButton.addEventListener('click', () => {
+        const expanded = menuButton.getAttribute('aria-expanded') === 'true';
+        menuButton.setAttribute('aria-expanded', String(!expanded));
+        nav.classList.toggle('open');
+      });
+      initGoogleSignIn();
+    </script>
+  </body>
+</html>`;
 }

--- a/infra/dendrite.css
+++ b/infra/dendrite.css
@@ -78,23 +78,28 @@ body {
   display: flex;
   gap: var(--s3);
   align-items: center;
-  margin-left: auto;
 }
 
 .menu-toggle {
-  display: none;
+  display: block;
+  margin-left: auto;
   background: none;
   border: none;
   font: inherit;
   cursor: pointer;
 }
 
-@media (max-width: 600px) {
-  .menu-toggle {
-    display: block;
-    margin-left: auto;
-  }
+#signinButton,
+#signoutWrap {
+  display: none;
+}
 
+.nav.open #signinButton,
+.nav.open #signoutWrap {
+  display: block;
+}
+
+@media (max-width: 600px) {
   .nav-links {
     display: none;
     flex-direction: column;

--- a/infra/mod.html
+++ b/infra/mod.html
@@ -21,13 +21,24 @@
           />
           Dendrite
         </a>
-        <a href="/new-story.html">New story</a>
-        <a href="/mod.html">Moderate</a>
-        <a href="/stats.html">Stats</a>
-        <div id="signinButton"></div>
-        <div id="signoutWrap" style="display: none">
-          <button id="signoutBtn" type="button">Sign out</button>
+        <div class="nav-links">
+          <a href="/new-story.html">New story</a>
+          <a href="/mod.html">Moderate</a>
+          <a href="/stats.html">Stats</a>
+          <div id="signinButton"></div>
+          <div id="signoutWrap" style="display: none">
+            <button id="signoutBtn" type="button">Sign out</button>
+          </div>
         </div>
+        <button
+          id="menuButton"
+          class="menu-toggle"
+          type="button"
+          aria-label="Menu"
+          aria-expanded="false"
+        >
+          &#9776;
+        </button>
       </nav>
     </header>
     <main>

--- a/infra/moderate.js
+++ b/infra/moderate.js
@@ -1,5 +1,20 @@
 import { initGoogleSignIn, getIdToken, signOut } from './googleAuth.js';
 
+if (
+  typeof document !== 'undefined' &&
+  typeof document.querySelector === 'function' &&
+  typeof document.getElementById === 'function'
+) {
+  const nav = document.querySelector('.nav');
+  const menuButton = document.getElementById('menuButton');
+
+  menuButton?.addEventListener('click', () => {
+    const expanded = menuButton.getAttribute('aria-expanded') === 'true';
+    menuButton.setAttribute('aria-expanded', String(!expanded));
+    nav?.classList.toggle('open');
+  });
+}
+
 const GET_VARIANT_URL =
   'https://europe-west1-irien-465710.cloudfunctions.net/prod-get-moderation-variant';
 const ASSIGN_JOB_URL =

--- a/infra/new-page.html
+++ b/infra/new-page.html
@@ -17,13 +17,24 @@
           />
           Dendrite
         </a>
-        <a href="/new-story.html">New story</a>
-        <a href="/mod.html">Moderate</a>
-        <a href="/stats.html">Stats</a>
-        <div id="signinButton"></div>
-        <div id="signoutWrap" style="display: none">
-          <button id="signoutBtn" type="button">Sign out</button>
+        <div class="nav-links">
+          <a href="/new-story.html">New story</a>
+          <a href="/mod.html">Moderate</a>
+          <a href="/stats.html">Stats</a>
+          <div id="signinButton"></div>
+          <div id="signoutWrap" style="display: none">
+            <button id="signoutBtn" type="button">Sign out</button>
+          </div>
         </div>
+        <button
+          id="menuButton"
+          class="menu-toggle"
+          type="button"
+          aria-label="Menu"
+          aria-expanded="false"
+        >
+          &#9776;
+        </button>
       </nav>
     </header>
     <main>
@@ -64,6 +75,15 @@
       import { initGoogleSignIn, getIdToken, signOut } from './googleAuth.js';
 
       document.addEventListener('DOMContentLoaded', () => {
+        const nav = document.querySelector('.nav');
+        const menuButton = document.getElementById('menuButton');
+
+        menuButton.addEventListener('click', () => {
+          const expanded = menuButton.getAttribute('aria-expanded') === 'true';
+          menuButton.setAttribute('aria-expanded', String(!expanded));
+          nav.classList.toggle('open');
+        });
+
         const params = new URLSearchParams(window.location.search);
         const incoming = params.get('option');
         if (incoming) {

--- a/infra/new-story.html
+++ b/infra/new-story.html
@@ -17,15 +17,6 @@
           />
           Dendrite
         </a>
-        <button
-          id="menuButton"
-          class="menu-toggle"
-          type="button"
-          aria-label="Menu"
-          aria-expanded="false"
-        >
-          &#9776;
-        </button>
         <div class="nav-links">
           <a href="/new-story.html">New story</a>
           <a href="/mod.html">Moderate</a>
@@ -35,6 +26,15 @@
             <button id="signoutBtn" type="button">Sign out</button>
           </div>
         </div>
+        <button
+          id="menuButton"
+          class="menu-toggle"
+          type="button"
+          aria-label="Menu"
+          aria-expanded="false"
+        >
+          &#9776;
+        </button>
       </nav>
     </header>
     <main>


### PR DESCRIPTION
## Summary
- Hide Google sign-in/out behind the hamburger menu and keep the toggle visible at all widths
- Wrap header navigation in a `nav-links` container across pages and cloud-function templates
- Add scripts to toggle the menu and display auth buttons only when expanded

## Testing
- `npm test`
- `npm run lint` *(warnings: Ternary operator used, camelcase, missing JSDoc, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a55737a914832ebeb9116dc6f1453e