### PR TITLE
Fix header width in new story form

### DIFF
--- a/infra/dendrite.css
+++ b/infra/dendrite.css
@@ -71,7 +71,6 @@ body {
   max-width: 72ch;
   margin: 0 auto;
   padding: 0 var(--s4); /* same horizontal padding as main */
-  width: 100%;
 }
 
 .nav-links {


### PR DESCRIPTION
## Summary
- avoid header overflow by removing fixed width from navigation bar

## Testing
- `npm test`
- `npm run lint` *(warnings: 128)*

------
https://chatgpt.com/codex/tasks/task_e_68a575be6da4832e87cc504382029229