### PR TITLE
Improve admin render error messages

### DIFF
--- a/infra/admin.html
+++ b/infra/admin.html
@@ -39,6 +39,7 @@
       <p>Welcome.</p>
       <button id="renderBtn">Render contents</button>
       <button id="statsBtn" style="margin-left: 1em">Generate stats</button>
+      <p id="renderStatus"></p>
       <form id="regenForm" style="margin-top: 1em">
         <label for="regenInput">Page variant</label>
         <input id="regenInput" type="text" placeholder="5a" required />

--- a/infra/admin.js
+++ b/infra/admin.js
@@ -17,6 +17,7 @@ const REGENERATE_URL =
   'https://europe-west1-irien-465710.cloudfunctions.net/prod-mark-variant-dirty';
 const STATS_URL =
   'https://europe-west1-irien-465710.cloudfunctions.net/prod-generate-stats';
+const renderStatus = document.getElementById('renderStatus');
 
 /**
  * Redirects unauthorized users and reveals admin content for the correct UID.
@@ -39,16 +40,30 @@ function checkAccess() {
 async function triggerRender() {
   const token = getIdToken();
   if (!token) {
+    if (renderStatus)
+      renderStatus.textContent = 'Render failed: missing ID token';
     return;
   }
   try {
-    await fetch(RENDER_URL, {
+    const res = await fetch(RENDER_URL, {
       method: 'POST',
       headers: { Authorization: `Bearer ${token}` },
     });
+    if (!res.ok) {
+      const body = await res.text();
+      if (renderStatus)
+        renderStatus.textContent = `Render failed: ${res.status} ${res.statusText}${
+          body ? ` - ${body}` : ''
+        }`;
+      return;
+    }
     alert('Render triggered');
-  } catch {
-    alert('Render failed');
+    if (renderStatus) renderStatus.textContent = 'Render triggered';
+  } catch (e) {
+    if (renderStatus)
+      renderStatus.textContent = `Render failed: ${
+        e instanceof Error ? e.message : String(e)
+      }`;
   }
 }
 


### PR DESCRIPTION
## Summary
- Show render errors in a copyable paragraph on the admin page
- Include detailed reasons such as missing tokens or HTTP failures when triggering renders

## Testing
- `npm test`
- `npm run lint` *(warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a57805c354832e85d97e281a286e5e