### PR TITLE
Allow submitting new pages by page number

### DIFF
--- a/infra/cloud-functions/submit-new-page/helpers.js
+++ b/infra/cloud-functions/submit-new-page/helpers.js
@@ -66,3 +66,29 @@ export async function findExistingOption(db, info) {
   }
   return optionsSnap.docs[0].ref.path;
 }
+
+/**
+ * Resolve a page document that already has at least one variant.
+ * @param {object} db Firestore database instance.
+ * @param {number} pageNumber Page number to look up.
+ * @returns {Promise<string|null>} Page document path or null when not found.
+ */
+export async function findExistingPage(db, pageNumber) {
+  if (!db || !Number.isInteger(pageNumber)) {
+    return null;
+  }
+  const pageSnap = await db
+    .collectionGroup('pages')
+    .where('number', '==', pageNumber)
+    .limit(1)
+    .get();
+  if (pageSnap.empty) {
+    return null;
+  }
+  const pageRef = pageSnap.docs[0].ref;
+  const variantsSnap = await pageRef.collection('variants').limit(1).get();
+  if (variantsSnap.empty) {
+    return null;
+  }
+  return pageRef.path;
+}

--- a/infra/new-page.html
+++ b/infra/new-page.html
@@ -45,6 +45,7 @@
         enctype="application/x-www-form-urlencoded"
       >
         <input type="hidden" name="incoming_option" />
+        <input type="hidden" name="page" />
         <div>
           <label>Content <textarea name="content"></textarea></label>
         </div>
@@ -92,9 +93,21 @@
             input.value = incoming;
           }
         }
+        const page = params.get('page');
+        if (page) {
+          const input = document.querySelector('input[name="page"]');
+          if (input) {
+            input.value = page;
+          }
+        }
 
         const form = document.querySelector('form');
         const button = form.querySelector("button[type='submit']");
+        if ((incoming && page) || (!incoming && !page)) {
+          button.disabled = true;
+        } else {
+          button.disabled = false;
+        }
         const saving = document.getElementById('saving');
         const signin = document.getElementById('signinButton');
         const signoutWrap = document.getElementById('signoutWrap');


### PR DESCRIPTION
## Summary
- Support page-based submissions in submit-new-page function and page form
- Add helper and tests to validate existing pages with variants

## Testing
- `npm test`
- `npm run lint` *(warnings: 133)*

------
https://chatgpt.com/codex/tasks/task_e_68a57bdcd7ec832eb84df2b663222077