### PR TITLE
Align header title with menu

### DIFF
--- a/infra/cloud-functions/render-variant/buildHtml.js
+++ b/infra/cloud-functions/render-variant/buildHtml.js
@@ -93,13 +93,8 @@ export function buildHtml(
   <body>
     <header class="header">
       <nav class="nav">
-        <a href="/">
-          <img
-            src="/img/logo.png"
-            alt="Dendrite logo"
-            style="height:1em;vertical-align:middle;margin-right:0.5em;"
-          />
-          Dendrite
+        <a href="/" class="site-title">
+          <img src="/img/logo.png" alt="Dendrite logo" /><span>Dendrite</span>
         </a>
         <div class="nav-links">
           <a href="/new-story.html">New story</a>

--- a/infra/dendrite.css
+++ b/infra/dendrite.css
@@ -112,8 +112,20 @@ body {
   }
 }
 
-.header a:first-of-type {
+.site-title {
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
   font-weight: 600;
+  text-decoration: none;
+}
+
+.site-title span {
+  text-decoration: underline;
+}
+
+.site-title img {
+  height: 1em;
 }
 
 /* Main container */

--- a/test/cloud-functions/buildHtml.test.js
+++ b/test/cloud-functions/buildHtml.test.js
@@ -121,4 +121,13 @@ describe('buildHtml', () => {
       "import { initGoogleSignIn } from '../googleAuth.js'"
     );
   });
+
+  test('renders site title without leading whitespace', () => {
+    const html = buildHtml(1, 'a', 'content', []);
+    expect(html).toContain('<a href="/" class="site-title">');
+    expect(html).toContain(
+      '<img src="/img/logo.png" alt="Dendrite logo" /><span>Dendrite</span>'
+    );
+    expect(html).not.toContain('alt="Dendrite logo" /> Dendrite');
+  });
 });


### PR DESCRIPTION
## Summary
- Align "Dendrite" title with hamburger menu and remove leading underline
- Style header link with flex layout and add targeted underline to the title text
- Test header rendering to ensure no leading whitespace

## Testing
- ✅ `npm test`
- ✅ `npm run lint` (133 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68a5c9b4936c832e8d2a8e5659390470