### PR TITLE
feat: add bottom sheet mobile menu

### DIFF
--- a/infra/404.html
+++ b/infra/404.html
@@ -7,36 +7,52 @@
     <link rel="stylesheet" href="/dendrite.css" />
   </head>
   <body>
-    <header class="header">
-      <nav class="nav">
-        <a href="/">
-          <img
-            src="/img/logo.png"
-            alt="Dendrite logo"
-            style="height: 1em; vertical-align: middle; margin-right: 0.5em"
-          />
-          Dendrite
-        </a>
-        <div class="nav-links">
-          <a href="/new-story.html">New story</a>
-          <a href="/mod.html">Moderate</a>
-          <a href="/stats.html">Stats</a>
-          <div id="signinButton"></div>
-          <div id="signoutWrap" style="display: none">
-            <button id="signoutBtn" type="button">Sign out</button>
-          </div>
-        </div>
-        <button
-          id="menuButton"
-          class="menu-toggle"
-          type="button"
-          aria-label="Menu"
-          aria-expanded="false"
-        >
-          &#9776;
-        </button>
+    <header class="site-header">
+      <a class="brand" href="/">Dendrite</a>
+
+      <nav class="nav-inline" aria-label="Primary">
+        <a href="/new-story.html">New story</a>
+        <a href="/mod.html">Moderate</a>
+        <a href="/stats.html">Stats</a>
       </nav>
+
+      <button
+        class="menu-toggle"
+        aria-expanded="false"
+        aria-controls="mobile-menu"
+        aria-label="Open menu"
+      >
+        ☰
+      </button>
     </header>
+
+    <!-- Mobile menu -->
+    <div id="mobile-menu" class="menu-overlay" hidden aria-hidden="true">
+      <div class="menu-sheet" role="dialog" aria-modal="true">
+        <button class="menu-close" aria-label="Close menu">✕</button>
+
+        <nav class="menu-groups">
+          <div class="menu-group">
+            <h3>Write</h3>
+            <a href="/new-story.html">New story</a>
+          </div>
+
+          <div class="menu-group">
+            <h3>Moderation</h3>
+            <a href="/mod.html">Moderate</a>
+            <a href="/stats.html">Stats</a>
+          </div>
+
+          <div class="menu-group">
+            <h3>Account</h3>
+            <div id="signinButton"></div>
+            <div id="signoutWrap" style="display: none">
+              <button id="signoutBtn" type="button">Sign out</button>
+            </div>
+          </div>
+        </nav>
+      </div>
+    </div>
     <main>
       <h1>404 - Page Not Found</h1>
       <p>The requested content could not be found.</p>
@@ -47,15 +63,6 @@
       import { initGoogleSignIn, getIdToken, signOut } from './googleAuth.js';
 
       document.addEventListener('DOMContentLoaded', () => {
-        const nav = document.querySelector('.nav');
-        const menuButton = document.getElementById('menuButton');
-
-        menuButton.addEventListener('click', () => {
-          const expanded = menuButton.getAttribute('aria-expanded') === 'true';
-          menuButton.setAttribute('aria-expanded', String(!expanded));
-          nav.classList.toggle('open');
-        });
-
         const signin = document.getElementById('signinButton');
         const signoutWrap = document.getElementById('signoutWrap');
         const signoutBtn = document.getElementById('signoutBtn');
@@ -81,6 +88,40 @@
           signoutWrap.style.display = '';
         }
       });
+    </script>
+    <script>
+      (function () {
+        const toggle = document.querySelector('.menu-toggle');
+        const overlay = document.getElementById('mobile-menu');
+        const sheet = overlay.querySelector('.menu-sheet');
+        const closeBtn = overlay.querySelector('.menu-close');
+
+        function openMenu() {
+          overlay.hidden = false;
+          overlay.setAttribute('aria-hidden', 'false');
+          toggle.setAttribute('aria-expanded', 'true');
+          document.body.style.overflow = 'hidden';
+          const first = sheet.querySelector('a,button,[tabindex="0"]');
+          if (first) first.focus();
+        }
+        function closeMenu() {
+          overlay.setAttribute('aria-hidden', 'true');
+          toggle.setAttribute('aria-expanded', 'false');
+          document.body.style.overflow = '';
+          setTimeout(() => (overlay.hidden = true), 180);
+          toggle.focus();
+        }
+        toggle.addEventListener('click', () =>
+          overlay.hidden ? openMenu() : closeMenu()
+        );
+        closeBtn.addEventListener('click', closeMenu);
+        overlay.addEventListener('click', e => {
+          if (e.target === overlay) closeMenu();
+        });
+        addEventListener('keydown', e => {
+          if (e.key === 'Escape' && !overlay.hidden) closeMenu();
+        });
+      })();
     </script>
   </body>
 </html>

--- a/infra/admin.html
+++ b/infra/admin.html
@@ -7,33 +7,49 @@
     <link rel="stylesheet" href="/dendrite.css" />
   </head>
   <body>
-    <header class="header">
-      <nav class="nav">
-        <a href="/">
-          <img
-            src="/img/logo.png"
-            alt="Dendrite logo"
-            style="height: 1em; vertical-align: middle; margin-right: 0.5em"
-          />
-          Dendrite
-        </a>
-        <div class="nav-links">
-          <a href="/new-story.html">New story</a>
-          <a href="/mod.html">Moderate</a>
-          <a href="/stats.html">Stats</a>
-          <div id="signinButton"></div>
-        </div>
-        <button
-          id="menuButton"
-          class="menu-toggle"
-          type="button"
-          aria-label="Menu"
-          aria-expanded="false"
-        >
-          &#9776;
-        </button>
+    <header class="site-header">
+      <a class="brand" href="/">Dendrite</a>
+
+      <nav class="nav-inline" aria-label="Primary">
+        <a href="/new-story.html">New story</a>
+        <a href="/mod.html">Moderate</a>
+        <a href="/stats.html">Stats</a>
       </nav>
+
+      <button
+        class="menu-toggle"
+        aria-expanded="false"
+        aria-controls="mobile-menu"
+        aria-label="Open menu"
+      >
+        ☰
+      </button>
     </header>
+
+    <!-- Mobile menu -->
+    <div id="mobile-menu" class="menu-overlay" hidden aria-hidden="true">
+      <div class="menu-sheet" role="dialog" aria-modal="true">
+        <button class="menu-close" aria-label="Close menu">✕</button>
+
+        <nav class="menu-groups">
+          <div class="menu-group">
+            <h3>Write</h3>
+            <a href="/new-story.html">New story</a>
+          </div>
+
+          <div class="menu-group">
+            <h3>Moderation</h3>
+            <a href="/mod.html">Moderate</a>
+            <a href="/stats.html">Stats</a>
+          </div>
+
+          <div class="menu-group">
+            <h3>Account</h3>
+            <div id="signinButton"></div>
+          </div>
+        </nav>
+      </div>
+    </div>
     <main id="adminContent" style="display: none">
       <h1>Admin</h1>
       <p>Welcome.</p>
@@ -48,5 +64,39 @@
     </main>
     <script src="https://accounts.google.com/gsi/client" defer></script>
     <script type="module" src="./admin.js"></script>
+    <script>
+      (function () {
+        const toggle = document.querySelector('.menu-toggle');
+        const overlay = document.getElementById('mobile-menu');
+        const sheet = overlay.querySelector('.menu-sheet');
+        const closeBtn = overlay.querySelector('.menu-close');
+
+        function openMenu() {
+          overlay.hidden = false;
+          overlay.setAttribute('aria-hidden', 'false');
+          toggle.setAttribute('aria-expanded', 'true');
+          document.body.style.overflow = 'hidden';
+          const first = sheet.querySelector('a,button,[tabindex="0"]');
+          if (first) first.focus();
+        }
+        function closeMenu() {
+          overlay.setAttribute('aria-hidden', 'true');
+          toggle.setAttribute('aria-expanded', 'false');
+          document.body.style.overflow = '';
+          setTimeout(() => (overlay.hidden = true), 180);
+          toggle.focus();
+        }
+        toggle.addEventListener('click', () =>
+          overlay.hidden ? openMenu() : closeMenu()
+        );
+        closeBtn.addEventListener('click', closeMenu);
+        overlay.addEventListener('click', e => {
+          if (e.target === overlay) closeMenu();
+        });
+        addEventListener('keydown', e => {
+          if (e.key === 'Escape' && !overlay.hidden) closeMenu();
+        });
+      })();
+    </script>
   </body>
 </html>

--- a/infra/admin.js
+++ b/infra/admin.js
@@ -1,15 +1,6 @@
 import { initGoogleSignIn, getIdToken } from './googleAuth.js';
 import { getAuth } from 'https://www.gstatic.com/firebasejs/12.0.0/firebase-auth.js';
 
-const nav = document.querySelector('.nav');
-const menuButton = document.getElementById('menuButton');
-
-menuButton?.addEventListener('click', () => {
-  const expanded = menuButton.getAttribute('aria-expanded') === 'true';
-  menuButton.setAttribute('aria-expanded', String(!expanded));
-  nav?.classList.toggle('open');
-});
-
 const ADMIN_UID = 'qcYSrXTaj1MZUoFsAloBwT86GNM2';
 const RENDER_URL =
   'https://europe-west1-irien-465710.cloudfunctions.net/prod-trigger-render-contents';

--- a/infra/cloud-functions/generate-stats/index.js
+++ b/infra/cloud-functions/generate-stats/index.js
@@ -54,33 +54,42 @@ function buildHtml(storyCount, pageCount, unmoderatedCount) {
     <link rel="stylesheet" href="/dendrite.css" />
   </head>
   <body>
-    <header class="header">
-      <nav class="nav">
-        <a href="/">
-          <img
-            src="/img/logo.png"
-            alt="Dendrite logo"
-            style="height:1em;vertical-align:middle;margin-right:0.5em"
-          />
-          Dendrite
-        </a>
-        <div class="nav-links">
-          <a href="/new-story.html">New story</a>
-          <a href="/mod.html">Moderate</a>
-          <a href="/stats.html">Stats</a>
-          <div id="signinButton"></div>
-        </div>
-        <button
-          id="menuButton"
-          class="menu-toggle"
-          type="button"
-          aria-label="Menu"
-          aria-expanded="false"
-        >
-          &#9776;
-        </button>
+    <header class="site-header">
+      <a class="brand" href="/">Dendrite</a>
+
+      <nav class="nav-inline" aria-label="Primary">
+        <a href="/new-story.html">New story</a>
+        <a href="/mod.html">Moderate</a>
+        <a href="/stats.html">Stats</a>
       </nav>
+
+      <button class="menu-toggle" aria-expanded="false" aria-controls="mobile-menu" aria-label="Open menu">☰</button>
     </header>
+
+    <!-- Mobile menu -->
+    <div id="mobile-menu" class="menu-overlay" hidden aria-hidden="true">
+      <div class="menu-sheet" role="dialog" aria-modal="true">
+        <button class="menu-close" aria-label="Close menu">✕</button>
+
+        <nav class="menu-groups">
+          <div class="menu-group">
+            <h3>Write</h3>
+            <a href="/new-story.html">New story</a>
+          </div>
+
+          <div class="menu-group">
+            <h3>Moderation</h3>
+            <a href="/mod.html">Moderate</a>
+            <a href="/stats.html">Stats</a>
+          </div>
+
+          <div class="menu-group">
+            <h3>Account</h3>
+            <div id="signinButton"></div>
+          </div>
+        </nav>
+      </div>
+    </div>
     <main>
       <h1>Stats</h1>
       <p>Number of stories: ${storyCount}</p>
@@ -90,14 +99,41 @@ function buildHtml(storyCount, pageCount, unmoderatedCount) {
     <script src="https://accounts.google.com/gsi/client" defer></script>
     <script type="module">
       import { initGoogleSignIn } from './googleAuth.js';
-      const nav = document.querySelector('.nav');
-      const menuButton = document.getElementById('menuButton');
-      menuButton.addEventListener('click', () => {
-        const expanded = menuButton.getAttribute('aria-expanded') === 'true';
-        menuButton.setAttribute('aria-expanded', String(!expanded));
-        nav.classList.toggle('open');
-      });
       initGoogleSignIn();
+    </script>
+    <script>
+      (function () {
+        const toggle = document.querySelector('.menu-toggle');
+        const overlay = document.getElementById('mobile-menu');
+        const sheet = overlay.querySelector('.menu-sheet');
+        const closeBtn = overlay.querySelector('.menu-close');
+
+        function openMenu() {
+          overlay.hidden = false;
+          overlay.setAttribute('aria-hidden', 'false');
+          toggle.setAttribute('aria-expanded', 'true');
+          document.body.style.overflow = 'hidden';
+          const first = sheet.querySelector('a,button,[tabindex="0"]');
+          if (first) first.focus();
+        }
+        function closeMenu() {
+          overlay.setAttribute('aria-hidden', 'true');
+          toggle.setAttribute('aria-expanded', 'false');
+          document.body.style.overflow = '';
+          setTimeout(() => (overlay.hidden = true), 180);
+          toggle.focus();
+        }
+        toggle.addEventListener('click', () =>
+          overlay.hidden ? openMenu() : closeMenu()
+        );
+        closeBtn.addEventListener('click', closeMenu);
+        overlay.addEventListener('click', e => {
+          if (e.target === overlay) closeMenu();
+        });
+        addEventListener('keydown', e => {
+          if (e.key === 'Escape' && !overlay.hidden) closeMenu();
+        });
+      })();
     </script>
   </body>
 </html>`;

--- a/infra/cloud-functions/render-contents/htmlSnippets.js
+++ b/infra/cloud-functions/render-contents/htmlSnippets.js
@@ -14,36 +14,45 @@ export const PAGE_HTML = list => `<!doctype html>
     <link rel="stylesheet" href="/dendrite.css" />
   </head>
   <body>
-    <header class="header">
-      <nav class="nav">
-        <a href="/">
-          <img
-            src="/img/logo.png"
-            alt="Dendrite logo"
-            style="height:1em;vertical-align:middle;margin-right:0.5em;"
-          />
-          Dendrite
-        </a>
-        <div class="nav-links">
-          <a href="/new-story.html">New story</a>
-          <a href="/mod.html">Moderate</a>
-          <a href="/stats.html">Stats</a>
-          <div id="signinButton"></div>
-          <div id="signoutWrap" style="display:none">
-            <button id="signoutBtn" type="button">Sign out</button>
-          </div>
-        </div>
-        <button
-          id="menuButton"
-          class="menu-toggle"
-          type="button"
-          aria-label="Menu"
-          aria-expanded="false"
-        >
-          &#9776;
-        </button>
+    <header class="site-header">
+      <a class="brand" href="/">Dendrite</a>
+
+      <nav class="nav-inline" aria-label="Primary">
+        <a href="/new-story.html">New story</a>
+        <a href="/mod.html">Moderate</a>
+        <a href="/stats.html">Stats</a>
       </nav>
+
+      <button class="menu-toggle" aria-expanded="false" aria-controls="mobile-menu" aria-label="Open menu">☰</button>
     </header>
+
+    <!-- Mobile menu -->
+    <div id="mobile-menu" class="menu-overlay" hidden aria-hidden="true">
+      <div class="menu-sheet" role="dialog" aria-modal="true">
+        <button class="menu-close" aria-label="Close menu">✕</button>
+
+        <nav class="menu-groups">
+          <div class="menu-group">
+            <h3>Write</h3>
+            <a href="/new-story.html">New story</a>
+          </div>
+
+          <div class="menu-group">
+            <h3>Moderation</h3>
+            <a href="/mod.html">Moderate</a>
+            <a href="/stats.html">Stats</a>
+          </div>
+
+          <div class="menu-group">
+            <h3>Account</h3>
+            <div id="signinButton"></div>
+            <div id="signoutWrap" style="display:none">
+              <button id="signoutBtn" type="button">Sign out</button>
+            </div>
+          </div>
+        </nav>
+      </div>
+    </div>
     <main>
       <h1>Contents</h1>
       <ol class="contents">${list}</ol>
@@ -51,13 +60,6 @@ export const PAGE_HTML = list => `<!doctype html>
     <script src="https://accounts.google.com/gsi/client" defer></script>
     <script type="module">
       import { initGoogleSignIn, signOut, getIdToken } from './googleAuth.js';
-      const nav = document.querySelector('.nav');
-      const menuButton = document.getElementById('menuButton');
-      menuButton.addEventListener('click', () => {
-        const expanded = menuButton.getAttribute('aria-expanded') === 'true';
-        menuButton.setAttribute('aria-expanded', String(!expanded));
-        nav.classList.toggle('open');
-      });
       const sb = document.getElementById('signinButton');
       const sw = document.getElementById('signoutWrap');
       const so = document.getElementById('signoutBtn');
@@ -76,6 +78,40 @@ export const PAGE_HTML = list => `<!doctype html>
         sb.style.display = 'none';
         sw.style.display = '';
       }
+    </script>
+    <script>
+      (function () {
+        const toggle = document.querySelector('.menu-toggle');
+        const overlay = document.getElementById('mobile-menu');
+        const sheet = overlay.querySelector('.menu-sheet');
+        const closeBtn = overlay.querySelector('.menu-close');
+
+        function openMenu() {
+          overlay.hidden = false;
+          overlay.setAttribute('aria-hidden', 'false');
+          toggle.setAttribute('aria-expanded', 'true');
+          document.body.style.overflow = 'hidden';
+          const first = sheet.querySelector('a,button,[tabindex="0"]');
+          if (first) first.focus();
+        }
+        function closeMenu() {
+          overlay.setAttribute('aria-hidden', 'true');
+          toggle.setAttribute('aria-expanded', 'false');
+          document.body.style.overflow = '';
+          setTimeout(() => (overlay.hidden = true), 180);
+          toggle.focus();
+        }
+        toggle.addEventListener('click', () =>
+          overlay.hidden ? openMenu() : closeMenu()
+        );
+        closeBtn.addEventListener('click', closeMenu);
+        overlay.addEventListener('click', e => {
+          if (e.target === overlay) closeMenu();
+        });
+        addEventListener('keydown', e => {
+          if (e.key === 'Escape' && !overlay.hidden) closeMenu();
+        });
+      })();
     </script>
   </body>
 </html>`;

--- a/infra/cloud-functions/render-variant/buildAltsHtml.js
+++ b/infra/cloud-functions/render-variant/buildAltsHtml.js
@@ -41,45 +41,81 @@ export function buildAltsHtml(pageNumber, variants) {
     <link rel="stylesheet" href="/dendrite.css" />
   </head>
   <body>
-    <header class="header">
-      <nav class="nav">
-        <a href="/">
-          <img
-            src="/img/logo.png"
-            alt="Dendrite logo"
-            style="height:1em;vertical-align:middle;margin-right:0.5em;"
-          />
-          Dendrite
-        </a>
-        <div class="nav-links">
-          <a href="/new-story.html">New story</a>
-          <a href="/mod.html">Moderate</a>
-          <a href="/stats.html">Stats</a>
-          <div id="signinButton"></div>
-        </div>
-        <button
-          id="menuButton"
-          class="menu-toggle"
-          type="button"
-          aria-label="Menu"
-          aria-expanded="false"
-        >
-          &#9776;
-        </button>
+    <header class="site-header">
+      <a class="brand" href="/">Dendrite</a>
+
+      <nav class="nav-inline" aria-label="Primary">
+        <a href="/new-story.html">New story</a>
+        <a href="/mod.html">Moderate</a>
+        <a href="/stats.html">Stats</a>
       </nav>
+
+      <button class="menu-toggle" aria-expanded="false" aria-controls="mobile-menu" aria-label="Open menu">☰</button>
     </header>
+
+    <!-- Mobile menu -->
+    <div id="mobile-menu" class="menu-overlay" hidden aria-hidden="true">
+      <div class="menu-sheet" role="dialog" aria-modal="true">
+        <button class="menu-close" aria-label="Close menu">✕</button>
+
+        <nav class="menu-groups">
+          <div class="menu-group">
+            <h3>Write</h3>
+            <a href="/new-story.html">New story</a>
+          </div>
+
+          <div class="menu-group">
+            <h3>Moderation</h3>
+            <a href="/mod.html">Moderate</a>
+            <a href="/stats.html">Stats</a>
+          </div>
+
+          <div class="menu-group">
+            <h3>Account</h3>
+            <div id="signinButton"></div>
+          </div>
+        </nav>
+      </div>
+    </div>
     <main><ol>${items}</ol></main>
     <script src="https://accounts.google.com/gsi/client" defer></script>
     <script type="module">
       import { initGoogleSignIn } from '../googleAuth.js';
-      const nav = document.querySelector('.nav');
-      const menuButton = document.getElementById('menuButton');
-      menuButton.addEventListener('click', () => {
-        const expanded = menuButton.getAttribute('aria-expanded') === 'true';
-        menuButton.setAttribute('aria-expanded', String(!expanded));
-        nav.classList.toggle('open');
-      });
       initGoogleSignIn();
+    </script>
+    <script>
+      (function () {
+        const toggle = document.querySelector('.menu-toggle');
+        const overlay = document.getElementById('mobile-menu');
+        const sheet = overlay.querySelector('.menu-sheet');
+        const closeBtn = overlay.querySelector('.menu-close');
+
+        function openMenu() {
+          overlay.hidden = false;
+          overlay.setAttribute('aria-hidden', 'false');
+          toggle.setAttribute('aria-expanded', 'true');
+          document.body.style.overflow = 'hidden';
+          const first = sheet.querySelector('a,button,[tabindex="0"]');
+          if (first) first.focus();
+        }
+        function closeMenu() {
+          overlay.setAttribute('aria-hidden', 'true');
+          toggle.setAttribute('aria-expanded', 'false');
+          document.body.style.overflow = '';
+          setTimeout(() => (overlay.hidden = true), 180);
+          toggle.focus();
+        }
+        toggle.addEventListener('click', () =>
+          overlay.hidden ? openMenu() : closeMenu()
+        );
+        closeBtn.addEventListener('click', closeMenu);
+        overlay.addEventListener('click', e => {
+          if (e.target === overlay) closeMenu();
+        });
+        addEventListener('keydown', e => {
+          if (e.key === 'Escape' && !overlay.hidden) closeMenu();
+        });
+      })();
     </script>
   </body>
 </html>`;

--- a/infra/cloud-functions/render-variant/buildHtml.js
+++ b/infra/cloud-functions/render-variant/buildHtml.js
@@ -91,40 +91,81 @@ export function buildHtml(
     <link rel="stylesheet" href="/dendrite.css" />
   </head>
   <body>
-    <header class="header">
-      <nav class="nav">
-        <a href="/" class="site-title">
-          <img src="/img/logo.png" alt="Dendrite logo" /><span>Dendrite</span>
-        </a>
-        <div class="nav-links">
-          <a href="/new-story.html">New story</a>
-          <a href="/mod.html">Moderate</a>
-          <a href="/stats.html">Stats</a>
-          <div id="signinButton"></div>
-        </div>
-        <button
-          id="menuButton"
-          class="menu-toggle"
-          type="button"
-          aria-label="Menu"
-          aria-expanded="false"
-        >
-          &#9776;
-        </button>
+    <header class="site-header">
+      <a class="brand" href="/">Dendrite</a>
+
+      <nav class="nav-inline" aria-label="Primary">
+        <a href="/new-story.html">New story</a>
+        <a href="/mod.html">Moderate</a>
+        <a href="/stats.html">Stats</a>
       </nav>
+
+      <button class="menu-toggle" aria-expanded="false" aria-controls="mobile-menu" aria-label="Open menu">☰</button>
     </header>
+
+    <!-- Mobile menu -->
+    <div id="mobile-menu" class="menu-overlay" hidden aria-hidden="true">
+      <div class="menu-sheet" role="dialog" aria-modal="true">
+        <button class="menu-close" aria-label="Close menu">✕</button>
+
+        <nav class="menu-groups">
+          <div class="menu-group">
+            <h3>Write</h3>
+            <a href="/new-story.html">New story</a>
+          </div>
+
+          <div class="menu-group">
+            <h3>Moderation</h3>
+            <a href="/mod.html">Moderate</a>
+            <a href="/stats.html">Stats</a>
+          </div>
+
+          <div class="menu-group">
+            <h3>Account</h3>
+            <div id="signinButton"></div>
+          </div>
+        </nav>
+      </div>
+    </div>
     <main>${title}${paragraphs}<ol>${items}</ol>${authorHtml}${parentHtml}${firstHtml}<p>${rewriteLink}<a href="./${pageNumber}-alts.html">Other variants</a></p>${pageNumberHtml}${reportHtml}</main>
     <script src="https://accounts.google.com/gsi/client" defer></script>
     <script type="module">
       import { initGoogleSignIn } from '../googleAuth.js';
-      const nav = document.querySelector('.nav');
-      const menuButton = document.getElementById('menuButton');
-      menuButton.addEventListener('click', () => {
-        const expanded = menuButton.getAttribute('aria-expanded') === 'true';
-        menuButton.setAttribute('aria-expanded', String(!expanded));
-        nav.classList.toggle('open');
-      });
       initGoogleSignIn();
+    </script>
+    <script>
+      (function () {
+        const toggle = document.querySelector('.menu-toggle');
+        const overlay = document.getElementById('mobile-menu');
+        const sheet = overlay.querySelector('.menu-sheet');
+        const closeBtn = overlay.querySelector('.menu-close');
+
+        function openMenu() {
+          overlay.hidden = false;
+          overlay.setAttribute('aria-hidden', 'false');
+          toggle.setAttribute('aria-expanded', 'true');
+          document.body.style.overflow = 'hidden';
+          const first = sheet.querySelector('a,button,[tabindex="0"]');
+          if (first) first.focus();
+        }
+        function closeMenu() {
+          overlay.setAttribute('aria-hidden', 'true');
+          toggle.setAttribute('aria-expanded', 'false');
+          document.body.style.overflow = '';
+          setTimeout(() => (overlay.hidden = true), 180);
+          toggle.focus();
+        }
+        toggle.addEventListener('click', () =>
+          overlay.hidden ? openMenu() : closeMenu()
+        );
+        closeBtn.addEventListener('click', closeMenu);
+        overlay.addEventListener('click', e => {
+          if (e.target === overlay) closeMenu();
+        });
+        addEventListener('keydown', e => {
+          if (e.key === 'Escape' && !overlay.hidden) closeMenu();
+        });
+      })();
     </script>
   </body>
 </html>`;

--- a/infra/dendrite.css
+++ b/infra/dendrite.css
@@ -12,10 +12,12 @@
   --s3: 12px;
   --s4: 16px;
   --s6: 24px;
+  --surface-700: #f3f4f6;
+  --surface-800: #eef0f2;
 }
 
 /* Respect system dark mode */
-@media (prefers-color-scheme: dark) {
+  @media (prefers-color-scheme: dark) {
   :root {
     --bg: #0c0f13;
     --text: #e7e7e7;
@@ -23,6 +25,8 @@
     --link: #68c3ff;
     --link-hover: #a8dcff;
     --border: #1a222b;
+    --surface-700: #1a1f24;
+    --surface-800: #14181d;
   }
 }
 
@@ -53,79 +57,144 @@ body {
   line-height: 1.35;
 }
 
-/* Header/nav */
-.header {
+/* Header */
+.site-header {
   position: sticky;
   top: 0;
   z-index: 10;
-  padding: var(--s3) 0; /* vertical only */
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  max-width: 72ch;
+  margin-inline: auto;
+  padding: 8px 12px;
   border-bottom: 1px solid var(--border);
   background: var(--bg);
 }
 
-/* Constrain header content to match main's width */
-.header .nav {
-  display: flex;
-  align-items: center;
-  gap: var(--s3);
-  max-width: 72ch;
-  margin: 0 auto;
-  padding: 0 var(--s4); /* same horizontal padding as main */
-}
-
-.nav-links {
-  display: flex;
-  gap: var(--s3);
-  align-items: center;
-}
-
-.menu-toggle {
-  display: block;
-  margin-left: auto;
-  background: none;
-  border: none;
-  font: inherit;
-  cursor: pointer;
-}
-
-#signinButton,
-#signoutWrap {
-  display: none;
-}
-
-.nav.open #signinButton,
-.nav.open #signoutWrap {
-  display: block;
-}
-
-@media (max-width: 600px) {
-  .nav-links {
-    display: none;
-    flex-direction: column;
-    gap: var(--s3);
-    width: 100%;
-    margin: var(--s2) 0 0 0;
-  }
-
-  .nav.open .nav-links {
-    display: flex;
-  }
-}
-
-.site-title {
+.brand {
   display: flex;
   align-items: center;
   gap: 0.5em;
   font-weight: 600;
   text-decoration: none;
+  color: inherit;
 }
 
-.site-title span {
-  text-decoration: underline;
-}
-
-.site-title img {
+.brand img {
   height: 1em;
+}
+
+.nav-inline {
+  display: none;
+  gap: 16px;
+}
+
+.menu-toggle {
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: var(--surface-700);
+  color: var(--text);
+}
+
+/* Desktop: show inline nav, hide burger */
+@media (min-width: 768px) {
+  .nav-inline {
+    display: flex;
+  }
+
+  .menu-toggle {
+    display: none;
+  }
+}
+
+/* Overlay + bottom sheet */
+.menu-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(2px);
+}
+
+.menu-sheet {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: var(--bg);
+  color: var(--text);
+  border-top: 1px solid var(--border);
+  border-radius: 16px 16px 0 0;
+  padding: 12px 16px calc(16px + env(safe-area-inset-bottom));
+  max-height: 85vh;
+  overflow: auto;
+  transform: translateY(6%);
+  opacity: 0;
+  transition: transform 0.18s ease, opacity 0.18s ease;
+}
+
+.menu-overlay[aria-hidden='false'] .menu-sheet {
+  transform: translateY(0);
+  opacity: 1;
+}
+
+.menu-close {
+  float: right;
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: var(--surface-700);
+}
+
+.menu-groups {
+  display: grid;
+  gap: 24px;
+  margin-top: 8px;
+}
+
+.menu-group h3 {
+  font-size: 0.85rem;
+  opacity: 0.7;
+  margin: 0 0 6px;
+}
+
+.menu-group a,
+.menu-group button {
+  display: block;
+  padding: 12px 8px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: var(--surface-800);
+  color: inherit;
+  width: 100%;
+  text-align: left;
+}
+
+.menu-group a:active,
+.menu-group button:active {
+  transform: translateY(1px);
+}
+
+/* Touch target guarantee */
+.menu-group a,
+.menu-group button,
+.menu-close,
+.menu-toggle {
+  min-height: 44px;
+}
+
+/* Reduce motion respect */
+@media (prefers-reduced-motion: reduce) {
+  .menu-sheet {
+    transition: none;
+  }
+}
+
+#signinButton > div {
+  background: transparent !important;
 }
 
 /* Main container */

--- a/infra/mod.html
+++ b/infra/mod.html
@@ -11,36 +11,52 @@
     <link rel="stylesheet" href="/dendrite.css" />
   </head>
   <body>
-    <header class="header">
-      <nav class="nav">
-        <a href="/">
-          <img
-            src="/img/logo.png"
-            alt="Dendrite logo"
-            style="height: 1em; vertical-align: middle; margin-right: 0.5em"
-          />
-          Dendrite
-        </a>
-        <div class="nav-links">
-          <a href="/new-story.html">New story</a>
-          <a href="/mod.html">Moderate</a>
-          <a href="/stats.html">Stats</a>
-          <div id="signinButton"></div>
-          <div id="signoutWrap" style="display: none">
-            <button id="signoutBtn" type="button">Sign out</button>
-          </div>
-        </div>
-        <button
-          id="menuButton"
-          class="menu-toggle"
-          type="button"
-          aria-label="Menu"
-          aria-expanded="false"
-        >
-          &#9776;
-        </button>
+    <header class="site-header">
+      <a class="brand" href="/">Dendrite</a>
+
+      <nav class="nav-inline" aria-label="Primary">
+        <a href="/new-story.html">New story</a>
+        <a href="/mod.html">Moderate</a>
+        <a href="/stats.html">Stats</a>
       </nav>
+
+      <button
+        class="menu-toggle"
+        aria-expanded="false"
+        aria-controls="mobile-menu"
+        aria-label="Open menu"
+      >
+        ☰
+      </button>
     </header>
+
+    <!-- Mobile menu -->
+    <div id="mobile-menu" class="menu-overlay" hidden aria-hidden="true">
+      <div class="menu-sheet" role="dialog" aria-modal="true">
+        <button class="menu-close" aria-label="Close menu">✕</button>
+
+        <nav class="menu-groups">
+          <div class="menu-group">
+            <h3>Write</h3>
+            <a href="/new-story.html">New story</a>
+          </div>
+
+          <div class="menu-group">
+            <h3>Moderation</h3>
+            <a href="/mod.html">Moderate</a>
+            <a href="/stats.html">Stats</a>
+          </div>
+
+          <div class="menu-group">
+            <h3>Account</h3>
+            <div id="signinButton"></div>
+            <div id="signoutWrap" style="display: none">
+              <button id="signoutBtn" type="button">Sign out</button>
+            </div>
+          </div>
+        </nav>
+      </div>
+    </div>
     <main>
       <h1>Moderate a story page</h1>
       <p>
@@ -65,5 +81,39 @@
 
     <!-- Moderate tools -->
     <script type="module" src="./moderate.js"></script>
+    <script>
+      (function () {
+        const toggle = document.querySelector('.menu-toggle');
+        const overlay = document.getElementById('mobile-menu');
+        const sheet = overlay.querySelector('.menu-sheet');
+        const closeBtn = overlay.querySelector('.menu-close');
+
+        function openMenu() {
+          overlay.hidden = false;
+          overlay.setAttribute('aria-hidden', 'false');
+          toggle.setAttribute('aria-expanded', 'true');
+          document.body.style.overflow = 'hidden';
+          const first = sheet.querySelector('a,button,[tabindex="0"]');
+          if (first) first.focus();
+        }
+        function closeMenu() {
+          overlay.setAttribute('aria-hidden', 'true');
+          toggle.setAttribute('aria-expanded', 'false');
+          document.body.style.overflow = '';
+          setTimeout(() => (overlay.hidden = true), 180);
+          toggle.focus();
+        }
+        toggle.addEventListener('click', () =>
+          overlay.hidden ? openMenu() : closeMenu()
+        );
+        closeBtn.addEventListener('click', closeMenu);
+        overlay.addEventListener('click', e => {
+          if (e.target === overlay) closeMenu();
+        });
+        addEventListener('keydown', e => {
+          if (e.key === 'Escape' && !overlay.hidden) closeMenu();
+        });
+      })();
+    </script>
   </body>
 </html>

--- a/infra/moderate.js
+++ b/infra/moderate.js
@@ -1,20 +1,5 @@
 import { initGoogleSignIn, getIdToken, signOut } from './googleAuth.js';
 
-if (
-  typeof document !== 'undefined' &&
-  typeof document.querySelector === 'function' &&
-  typeof document.getElementById === 'function'
-) {
-  const nav = document.querySelector('.nav');
-  const menuButton = document.getElementById('menuButton');
-
-  menuButton?.addEventListener('click', () => {
-    const expanded = menuButton.getAttribute('aria-expanded') === 'true';
-    menuButton.setAttribute('aria-expanded', String(!expanded));
-    nav?.classList.toggle('open');
-  });
-}
-
 const GET_VARIANT_URL =
   'https://europe-west1-irien-465710.cloudfunctions.net/prod-get-moderation-variant';
 const ASSIGN_JOB_URL =

--- a/infra/new-page.html
+++ b/infra/new-page.html
@@ -7,36 +7,52 @@
     <link rel="stylesheet" href="/dendrite.css" />
   </head>
   <body>
-    <header class="header">
-      <nav class="nav">
-        <a href="/">
-          <img
-            src="/img/logo.png"
-            alt="Dendrite logo"
-            style="height: 1em; vertical-align: middle; margin-right: 0.5em"
-          />
-          Dendrite
-        </a>
-        <div class="nav-links">
-          <a href="/new-story.html">New story</a>
-          <a href="/mod.html">Moderate</a>
-          <a href="/stats.html">Stats</a>
-          <div id="signinButton"></div>
-          <div id="signoutWrap" style="display: none">
-            <button id="signoutBtn" type="button">Sign out</button>
-          </div>
-        </div>
-        <button
-          id="menuButton"
-          class="menu-toggle"
-          type="button"
-          aria-label="Menu"
-          aria-expanded="false"
-        >
-          &#9776;
-        </button>
+    <header class="site-header">
+      <a class="brand" href="/">Dendrite</a>
+
+      <nav class="nav-inline" aria-label="Primary">
+        <a href="/new-story.html">New story</a>
+        <a href="/mod.html">Moderate</a>
+        <a href="/stats.html">Stats</a>
       </nav>
+
+      <button
+        class="menu-toggle"
+        aria-expanded="false"
+        aria-controls="mobile-menu"
+        aria-label="Open menu"
+      >
+        ☰
+      </button>
     </header>
+
+    <!-- Mobile menu -->
+    <div id="mobile-menu" class="menu-overlay" hidden aria-hidden="true">
+      <div class="menu-sheet" role="dialog" aria-modal="true">
+        <button class="menu-close" aria-label="Close menu">✕</button>
+
+        <nav class="menu-groups">
+          <div class="menu-group">
+            <h3>Write</h3>
+            <a href="/new-story.html">New story</a>
+          </div>
+
+          <div class="menu-group">
+            <h3>Moderation</h3>
+            <a href="/mod.html">Moderate</a>
+            <a href="/stats.html">Stats</a>
+          </div>
+
+          <div class="menu-group">
+            <h3>Account</h3>
+            <div id="signinButton"></div>
+            <div id="signoutWrap" style="display: none">
+              <button id="signoutBtn" type="button">Sign out</button>
+            </div>
+          </div>
+        </nav>
+      </div>
+    </div>
     <main>
       <h1>New page</h1>
       <form
@@ -76,14 +92,9 @@
       import { initGoogleSignIn, getIdToken, signOut } from './googleAuth.js';
 
       document.addEventListener('DOMContentLoaded', () => {
-        const nav = document.querySelector('.nav');
-        const menuButton = document.getElementById('menuButton');
-
-        menuButton.addEventListener('click', () => {
-          const expanded = menuButton.getAttribute('aria-expanded') === 'true';
-          menuButton.setAttribute('aria-expanded', String(!expanded));
-          nav.classList.toggle('open');
-        });
+        const signin = document.getElementById('signinButton');
+        const signoutWrap = document.getElementById('signoutWrap');
+        const signoutBtn = document.getElementById('signoutBtn');
 
         const params = new URLSearchParams(window.location.search);
         const incoming = params.get('option');
@@ -109,9 +120,6 @@
           button.disabled = false;
         }
         const saving = document.getElementById('saving');
-        const signin = document.getElementById('signinButton');
-        const signoutWrap = document.getElementById('signoutWrap');
-        const signoutBtn = document.getElementById('signoutBtn');
 
         initGoogleSignIn({
           onSignIn: () => {
@@ -181,6 +189,40 @@
           }
         });
       });
+    </script>
+    <script>
+      (function () {
+        const toggle = document.querySelector('.menu-toggle');
+        const overlay = document.getElementById('mobile-menu');
+        const sheet = overlay.querySelector('.menu-sheet');
+        const closeBtn = overlay.querySelector('.menu-close');
+
+        function openMenu() {
+          overlay.hidden = false;
+          overlay.setAttribute('aria-hidden', 'false');
+          toggle.setAttribute('aria-expanded', 'true');
+          document.body.style.overflow = 'hidden';
+          const first = sheet.querySelector('a,button,[tabindex="0"]');
+          if (first) first.focus();
+        }
+        function closeMenu() {
+          overlay.setAttribute('aria-hidden', 'true');
+          toggle.setAttribute('aria-expanded', 'false');
+          document.body.style.overflow = '';
+          setTimeout(() => (overlay.hidden = true), 180);
+          toggle.focus();
+        }
+        toggle.addEventListener('click', () =>
+          overlay.hidden ? openMenu() : closeMenu()
+        );
+        closeBtn.addEventListener('click', closeMenu);
+        overlay.addEventListener('click', e => {
+          if (e.target === overlay) closeMenu();
+        });
+        addEventListener('keydown', e => {
+          if (e.key === 'Escape' && !overlay.hidden) closeMenu();
+        });
+      })();
     </script>
   </body>
 </html>

--- a/infra/new-story.html
+++ b/infra/new-story.html
@@ -7,36 +7,52 @@
     <link rel="stylesheet" href="/dendrite.css" />
   </head>
   <body>
-    <header class="header">
-      <nav class="nav">
-        <a href="/">
-          <img
-            src="/img/logo.png"
-            alt="Dendrite logo"
-            style="height: 1em; vertical-align: middle; margin-right: 0.5em"
-          />
-          Dendrite
-        </a>
-        <div class="nav-links">
-          <a href="/new-story.html">New story</a>
-          <a href="/mod.html">Moderate</a>
-          <a href="/stats.html">Stats</a>
-          <div id="signinButton"></div>
-          <div id="signoutWrap" style="display: none">
-            <button id="signoutBtn" type="button">Sign out</button>
-          </div>
-        </div>
-        <button
-          id="menuButton"
-          class="menu-toggle"
-          type="button"
-          aria-label="Menu"
-          aria-expanded="false"
-        >
-          &#9776;
-        </button>
+    <header class="site-header">
+      <a class="brand" href="/">Dendrite</a>
+
+      <nav class="nav-inline" aria-label="Primary">
+        <a href="/new-story.html">New story</a>
+        <a href="/mod.html">Moderate</a>
+        <a href="/stats.html">Stats</a>
       </nav>
+
+      <button
+        class="menu-toggle"
+        aria-expanded="false"
+        aria-controls="mobile-menu"
+        aria-label="Open menu"
+      >
+        ☰
+      </button>
     </header>
+
+    <!-- Mobile menu -->
+    <div id="mobile-menu" class="menu-overlay" hidden aria-hidden="true">
+      <div class="menu-sheet" role="dialog" aria-modal="true">
+        <button class="menu-close" aria-label="Close menu">✕</button>
+
+        <nav class="menu-groups">
+          <div class="menu-group">
+            <h3>Write</h3>
+            <a href="/new-story.html">New story</a>
+          </div>
+
+          <div class="menu-group">
+            <h3>Moderation</h3>
+            <a href="/mod.html">Moderate</a>
+            <a href="/stats.html">Stats</a>
+          </div>
+
+          <div class="menu-group">
+            <h3>Account</h3>
+            <div id="signinButton"></div>
+            <div id="signoutWrap" style="display: none">
+              <button id="signoutBtn" type="button">Sign out</button>
+            </div>
+          </div>
+        </nav>
+      </div>
+    </div>
     <main>
       <h1>New story</h1>
       <form
@@ -89,14 +105,6 @@
         const signin = document.getElementById('signinButton');
         const signoutWrap = document.getElementById('signoutWrap');
         const signoutBtn = document.getElementById('signoutBtn');
-        const nav = document.querySelector('.nav');
-        const menuButton = document.getElementById('menuButton');
-
-        menuButton.addEventListener('click', () => {
-          const expanded = menuButton.getAttribute('aria-expanded') === 'true';
-          menuButton.setAttribute('aria-expanded', String(!expanded));
-          nav.classList.toggle('open');
-        });
 
         initGoogleSignIn({
           onSignIn: () => {
@@ -168,6 +176,40 @@
           }
         });
       });
+    </script>
+    <script>
+      (function () {
+        const toggle = document.querySelector('.menu-toggle');
+        const overlay = document.getElementById('mobile-menu');
+        const sheet = overlay.querySelector('.menu-sheet');
+        const closeBtn = overlay.querySelector('.menu-close');
+
+        function openMenu() {
+          overlay.hidden = false;
+          overlay.setAttribute('aria-hidden', 'false');
+          toggle.setAttribute('aria-expanded', 'true');
+          document.body.style.overflow = 'hidden';
+          const first = sheet.querySelector('a,button,[tabindex="0"]');
+          if (first) first.focus();
+        }
+        function closeMenu() {
+          overlay.setAttribute('aria-hidden', 'true');
+          toggle.setAttribute('aria-expanded', 'false');
+          document.body.style.overflow = '';
+          setTimeout(() => (overlay.hidden = true), 180);
+          toggle.focus();
+        }
+        toggle.addEventListener('click', () =>
+          overlay.hidden ? openMenu() : closeMenu()
+        );
+        closeBtn.addEventListener('click', closeMenu);
+        overlay.addEventListener('click', e => {
+          if (e.target === overlay) closeMenu();
+        });
+        addEventListener('keydown', e => {
+          if (e.key === 'Escape' && !overlay.hidden) closeMenu();
+        });
+      })();
     </script>
   </body>
 </html>

--- a/test/cloud-functions/buildAltsHtml.test.js
+++ b/test/cloud-functions/buildAltsHtml.test.js
@@ -9,7 +9,7 @@ describe('buildAltsHtml', () => {
 
   test('includes navigation header', () => {
     const html = buildAltsHtml(1, []);
-    expect(html).toContain('<nav class="nav">');
+    expect(html).toContain('<nav class="nav-inline"');
     expect(html).toContain('id="signinButton"');
   });
 });

--- a/test/cloud-functions/buildHtml.test.js
+++ b/test/cloud-functions/buildHtml.test.js
@@ -115,19 +115,15 @@ describe('buildHtml', () => {
 
   test('includes navigation header and sign-in script', () => {
     const html = buildHtml(1, 'a', 'content', []);
-    expect(html).toContain('<nav class="nav">');
+    expect(html).toContain('<nav class="nav-inline"');
     expect(html).toContain('id="signinButton"');
     expect(html).toContain(
       "import { initGoogleSignIn } from '../googleAuth.js'"
     );
   });
 
-  test('renders site title without leading whitespace', () => {
+  test('renders brand without leading whitespace', () => {
     const html = buildHtml(1, 'a', 'content', []);
-    expect(html).toContain('<a href="/" class="site-title">');
-    expect(html).toContain(
-      '<img src="/img/logo.png" alt="Dendrite logo" /><span>Dendrite</span>'
-    );
-    expect(html).not.toContain('alt="Dendrite logo" /> Dendrite');
+    expect(html).toContain('<a class="brand" href="/">Dendrite</a>');
   });
 });


### PR DESCRIPTION
## Summary
- replace legacy header with a responsive brand bar and bottom-sheet menu
- move sign-in into an Account group and wire up new menu script
- update cloud-function tests for the new navigation markup

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a5cd4ca250832e93bf7fdb43cf5d93