### PR TITLE
Add logo to header and simplify menu toggle

### DIFF
--- a/infra/404.html
+++ b/infra/404.html
@@ -8,7 +8,10 @@
   </head>
   <body>
     <header class="site-header">
-      <a class="brand" href="/">Dendrite</a>
+      <a class="brand" href="/">
+        <img src="/favicon-32x32.png" alt="" />
+        Dendrite
+      </a>
 
       <nav class="nav-inline" aria-label="Primary">
         <a href="/new-story.html">New story</a>

--- a/infra/admin.html
+++ b/infra/admin.html
@@ -8,7 +8,10 @@
   </head>
   <body>
     <header class="site-header">
-      <a class="brand" href="/">Dendrite</a>
+      <a class="brand" href="/">
+        <img src="/favicon-32x32.png" alt="" />
+        Dendrite
+      </a>
 
       <nav class="nav-inline" aria-label="Primary">
         <a href="/new-story.html">New story</a>

--- a/infra/cloud-functions/generate-stats/index.js
+++ b/infra/cloud-functions/generate-stats/index.js
@@ -55,7 +55,10 @@ function buildHtml(storyCount, pageCount, unmoderatedCount) {
   </head>
   <body>
     <header class="site-header">
-      <a class="brand" href="/">Dendrite</a>
+      <a class="brand" href="/">
+        <img src="/favicon-32x32.png" alt="" />
+        Dendrite
+      </a>
 
       <nav class="nav-inline" aria-label="Primary">
         <a href="/new-story.html">New story</a>

--- a/infra/cloud-functions/render-contents/htmlSnippets.js
+++ b/infra/cloud-functions/render-contents/htmlSnippets.js
@@ -15,7 +15,10 @@ export const PAGE_HTML = list => `<!doctype html>
   </head>
   <body>
     <header class="site-header">
-      <a class="brand" href="/">Dendrite</a>
+      <a class="brand" href="/">
+        <img src="/favicon-32x32.png" alt="" />
+        Dendrite
+      </a>
 
       <nav class="nav-inline" aria-label="Primary">
         <a href="/new-story.html">New story</a>

--- a/infra/cloud-functions/render-variant/buildAltsHtml.js
+++ b/infra/cloud-functions/render-variant/buildAltsHtml.js
@@ -42,7 +42,10 @@ export function buildAltsHtml(pageNumber, variants) {
   </head>
   <body>
     <header class="site-header">
-      <a class="brand" href="/">Dendrite</a>
+      <a class="brand" href="/">
+        <img src="/favicon-32x32.png" alt="" />
+        Dendrite
+      </a>
 
       <nav class="nav-inline" aria-label="Primary">
         <a href="/new-story.html">New story</a>

--- a/infra/cloud-functions/render-variant/buildHtml.js
+++ b/infra/cloud-functions/render-variant/buildHtml.js
@@ -92,7 +92,10 @@ export function buildHtml(
   </head>
   <body>
     <header class="site-header">
-      <a class="brand" href="/">Dendrite</a>
+      <a class="brand" href="/">
+        <img src="/favicon-32x32.png" alt="" />
+        Dendrite
+      </a>
 
       <nav class="nav-inline" aria-label="Primary">
         <a href="/new-story.html">New story</a>

--- a/infra/dendrite.css
+++ b/infra/dendrite.css
@@ -17,7 +17,7 @@
 }
 
 /* Respect system dark mode */
-  @media (prefers-color-scheme: dark) {
+@media (prefers-color-scheme: dark) {
   :root {
     --bg: #0c0f13;
     --text: #e7e7e7;
@@ -93,9 +93,8 @@ body {
 .menu-toggle {
   width: 44px;
   height: 44px;
-  border-radius: 12px;
-  border: 1px solid var(--border);
-  background: var(--surface-700);
+  border: none;
+  background: transparent;
   color: var(--text);
 }
 
@@ -132,7 +131,9 @@ body {
   overflow: auto;
   transform: translateY(6%);
   opacity: 0;
-  transition: transform 0.18s ease, opacity 0.18s ease;
+  transition:
+    transform 0.18s ease,
+    opacity 0.18s ease;
 }
 
 .menu-overlay[aria-hidden='false'] .menu-sheet {

--- a/infra/mod.html
+++ b/infra/mod.html
@@ -12,7 +12,10 @@
   </head>
   <body>
     <header class="site-header">
-      <a class="brand" href="/">Dendrite</a>
+      <a class="brand" href="/">
+        <img src="/favicon-32x32.png" alt="" />
+        Dendrite
+      </a>
 
       <nav class="nav-inline" aria-label="Primary">
         <a href="/new-story.html">New story</a>

--- a/infra/new-page.html
+++ b/infra/new-page.html
@@ -8,7 +8,10 @@
   </head>
   <body>
     <header class="site-header">
-      <a class="brand" href="/">Dendrite</a>
+      <a class="brand" href="/">
+        <img src="/favicon-32x32.png" alt="" />
+        Dendrite
+      </a>
 
       <nav class="nav-inline" aria-label="Primary">
         <a href="/new-story.html">New story</a>

--- a/infra/new-story.html
+++ b/infra/new-story.html
@@ -8,7 +8,10 @@
   </head>
   <body>
     <header class="site-header">
-      <a class="brand" href="/">Dendrite</a>
+      <a class="brand" href="/">
+        <img src="/favicon-32x32.png" alt="" />
+        Dendrite
+      </a>
 
       <nav class="nav-inline" aria-label="Primary">
         <a href="/new-story.html">New story</a>

--- a/test/cloud-functions/buildHtml.test.js
+++ b/test/cloud-functions/buildHtml.test.js
@@ -124,6 +124,8 @@ describe('buildHtml', () => {
 
   test('renders brand without leading whitespace', () => {
     const html = buildHtml(1, 'a', 'content', []);
-    expect(html).toContain('<a class="brand" href="/">Dendrite</a>');
+    expect(html).toMatch(
+      /<a class="brand" href="\/">\s*<img src="\/favicon-32x32.png" alt="" \/>\s*Dendrite\s*<\/a>/
+    );
   });
 });


### PR DESCRIPTION
## Summary
- add small Dendrite favicon before the site title in shared header templates
- remove background and border from the mobile menu toggle button
- update buildHtml test to match new header markup

## Testing
- `npm test`
- `npm run lint` *(warnings: Ternary operator used, Identifier 'access_token' is not in camel case, Missing JSDoc @returns declaration, Missing JSDoc @param "optionData" description, Missing JSDoc @param "optionData" type)*

------
https://chatgpt.com/codex/tasks/task_e_68a66f2a68c8832eb64f09cf1f476641