### PR TITLE
Remove bottom sheet link background and enhance close button contrast

### DIFF
--- a/infra/dendrite.css
+++ b/infra/dendrite.css
@@ -145,8 +145,9 @@ body {
   width: 40px;
   height: 40px;
   border-radius: 12px;
-  border: 1px solid var(--border);
-  background: var(--surface-700);
+  color: var(--text);
+  border: none;
+  background: none;
 }
 
 .menu-groups {
@@ -166,8 +167,8 @@ body {
   display: block;
   padding: 12px 8px;
   border-radius: 10px;
-  border: 1px solid var(--border);
-  background: var(--surface-800);
+  border: none;
+  background: none;
   color: inherit;
   width: 100%;
   text-align: left;


### PR DESCRIPTION
## Summary
- remove border and background from bottom sheet links for cleaner appearance
- increase menu close button contrast by using text color and dropping decoration

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a66f7cd1c0832e8fac2fa135dc2761