### PR TITLE
Fix sign-in script path on 404 page

### DIFF
--- a/infra/404.html
+++ b/infra/404.html
@@ -63,7 +63,7 @@
     <!-- Google Identity Services -->
     <script src="https://accounts.google.com/gsi/client" defer></script>
     <script type="module">
-      import { initGoogleSignIn, getIdToken, signOut } from './googleAuth.js';
+      import { initGoogleSignIn, getIdToken, signOut } from '/googleAuth.js';
 
       document.addEventListener('DOMContentLoaded', () => {
         const signin = document.getElementById('signinButton');


### PR DESCRIPTION
## Summary
- load Google auth helper from an absolute path so the 404 page can initialize sign-in when served for nested URLs

## Testing
- `npm test`
- `npm run lint` *(warnings: Ternary operator used, missing JSDoc, camelcase)*

------
https://chatgpt.com/codex/tasks/task_e_68a689026e58832ebe676541a6a6b67a