### PR TITLE
Center menu close icon in bottom sheet

### DIFF
--- a/infra/dendrite.css
+++ b/infra/dendrite.css
@@ -149,6 +149,10 @@ body {
   color: var(--text);
   border: none;
   background: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
 }
 
 .menu-groups {


### PR DESCRIPTION
## Summary
- center bottom sheet close button's X by flex-aligning within its focus border

## Testing
- `npm test`
- `npm run lint` (warnings: 133)

------
https://chatgpt.com/codex/tasks/task_e_68a689ef2924832e87611b14357fad33