### PR TITLE
Use shared favicon for dendrite pages

### DIFF
--- a/infra/404.html
+++ b/infra/404.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Page Not Found</title>
+    <link rel="icon" href="/favicon.ico" />
     <link rel="stylesheet" href="/dendrite.css" />
   </head>
   <body>

--- a/infra/admin.html
+++ b/infra/admin.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Admin</title>
+    <link rel="icon" href="/favicon.ico" />
     <link rel="stylesheet" href="/dendrite.css" />
   </head>
   <body>

--- a/infra/cloud-functions/generate-stats/index.js
+++ b/infra/cloud-functions/generate-stats/index.js
@@ -51,6 +51,7 @@ function buildHtml(storyCount, pageCount, unmoderatedCount) {
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Dendrite stats</title>
+    <link rel="icon" href="/favicon.ico" />
     <link rel="stylesheet" href="/dendrite.css" />
   </head>
   <body>

--- a/infra/cloud-functions/render-contents/htmlSnippets.js
+++ b/infra/cloud-functions/render-contents/htmlSnippets.js
@@ -7,6 +7,7 @@ export const PAGE_HTML = list => `<!doctype html>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Dendrite</title>
+    <link rel="icon" href="/favicon.ico" />
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.fluid.classless.min.css"

--- a/infra/cloud-functions/render-variant/buildAltsHtml.js
+++ b/infra/cloud-functions/render-variant/buildAltsHtml.js
@@ -34,6 +34,7 @@ export function buildAltsHtml(pageNumber, variants) {
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Dendrite</title>
+    <link rel="icon" href="/favicon.ico" />
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.fluid.classless.min.css"

--- a/infra/cloud-functions/render-variant/buildHtml.js
+++ b/infra/cloud-functions/render-variant/buildHtml.js
@@ -84,6 +84,7 @@ export function buildHtml(
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>${headTitle}</title>
+    <link rel="icon" href="/favicon.ico" />
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.fluid.classless.min.css"

--- a/infra/mod.html
+++ b/infra/mod.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Dendrite - Moderate a story page</title>
+    <link rel="icon" href="/favicon.ico" />
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.fluid.classless.min.css"

--- a/infra/new-page.html
+++ b/infra/new-page.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>New Page</title>
+    <link rel="icon" href="/favicon.ico" />
     <link rel="stylesheet" href="/dendrite.css" />
   </head>
   <body>

--- a/infra/new-story.html
+++ b/infra/new-story.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>New Story</title>
+    <link rel="icon" href="/favicon.ico" />
     <link rel="stylesheet" href="/dendrite.css" />
   </head>
   <body>

--- a/test/cloud-functions/buildAltsHtml.test.js
+++ b/test/cloud-functions/buildAltsHtml.test.js
@@ -12,4 +12,9 @@ describe('buildAltsHtml', () => {
     expect(html).toContain('<nav class="nav-inline"');
     expect(html).toContain('id="signinButton"');
   });
+
+  test('includes favicon link', () => {
+    const html = buildAltsHtml(1, []);
+    expect(html).toContain('<link rel="icon" href="/favicon.ico" />');
+  });
 });

--- a/test/cloud-functions/buildHtml.test.js
+++ b/test/cloud-functions/buildHtml.test.js
@@ -122,6 +122,11 @@ describe('buildHtml', () => {
     );
   });
 
+  test('includes favicon link', () => {
+    const html = buildHtml(1, 'a', 'content', []);
+    expect(html).toContain('<link rel="icon" href="/favicon.ico" />');
+  });
+
   test('renders brand without leading whitespace', () => {
     const html = buildHtml(1, 'a', 'content', []);
     expect(html).toMatch(

--- a/test/cloud-functions/generateStats.test.js
+++ b/test/cloud-functions/generateStats.test.js
@@ -12,6 +12,11 @@ describe('generate stats helpers', () => {
     expect(html).toContain('<p>Number of unmoderated pages: 3</p>');
   });
 
+  test('buildHtml includes favicon link', () => {
+    const html = buildHtml(0, 0, 0);
+    expect(html).toContain('<link rel="icon" href="/favicon.ico" />');
+  });
+
   test('getPageCount returns page count', async () => {
     const mockDb = {
       collectionGroup: () => ({

--- a/test/cloud-functions/renderContentsHtmlSnippets.test.js
+++ b/test/cloud-functions/renderContentsHtmlSnippets.test.js
@@ -40,4 +40,9 @@ describe('PAGE_HTML', () => {
     expect(localIndex).toBeGreaterThan(-1);
     expect(picoIndex).toBeLessThan(localIndex);
   });
+
+  test('includes favicon link', () => {
+    const html = PAGE_HTML('');
+    expect(html).toContain('<link rel="icon" href="/favicon.ico" />');
+  });
 });


### PR DESCRIPTION
## Summary
- Reference `/favicon.ico` in all dendrite static pages and HTML templates
- Verify favicon usage with new unit tests for cloud function templates

## Testing
- `npm test`
- `npm run lint` *(warnings: Ternary operator used, Identifier 'access_token' is not in camel case, Missing JSDoc annotations)*

------
https://chatgpt.com/codex/tasks/task_e_68a68dad1160832eb5a2f43344371657