### PR TITLE
feat: add dendrite logo to header

### DIFF
--- a/infra/404.html
+++ b/infra/404.html
@@ -9,7 +9,7 @@
   <body>
     <header class="site-header">
       <a class="brand" href="/">
-        <img src="/favicon-32x32.png" alt="" />
+        <img src="/img/logo.png" alt="Dendrite logo" />
         Dendrite
       </a>
 

--- a/infra/admin.html
+++ b/infra/admin.html
@@ -9,7 +9,7 @@
   <body>
     <header class="site-header">
       <a class="brand" href="/">
-        <img src="/favicon-32x32.png" alt="" />
+        <img src="/img/logo.png" alt="Dendrite logo" />
         Dendrite
       </a>
 

--- a/infra/cloud-functions/generate-stats/index.js
+++ b/infra/cloud-functions/generate-stats/index.js
@@ -56,7 +56,7 @@ function buildHtml(storyCount, pageCount, unmoderatedCount) {
   <body>
     <header class="site-header">
       <a class="brand" href="/">
-        <img src="/favicon-32x32.png" alt="" />
+        <img src="/img/logo.png" alt="Dendrite logo" />
         Dendrite
       </a>
 

--- a/infra/cloud-functions/render-contents/htmlSnippets.js
+++ b/infra/cloud-functions/render-contents/htmlSnippets.js
@@ -16,7 +16,7 @@ export const PAGE_HTML = list => `<!doctype html>
   <body>
     <header class="site-header">
       <a class="brand" href="/">
-        <img src="/favicon-32x32.png" alt="" />
+        <img src="/img/logo.png" alt="Dendrite logo" />
         Dendrite
       </a>
 

--- a/infra/cloud-functions/render-variant/buildAltsHtml.js
+++ b/infra/cloud-functions/render-variant/buildAltsHtml.js
@@ -43,7 +43,7 @@ export function buildAltsHtml(pageNumber, variants) {
   <body>
     <header class="site-header">
       <a class="brand" href="/">
-        <img src="/favicon-32x32.png" alt="" />
+        <img src="/img/logo.png" alt="Dendrite logo" />
         Dendrite
       </a>
 

--- a/infra/cloud-functions/render-variant/buildHtml.js
+++ b/infra/cloud-functions/render-variant/buildHtml.js
@@ -93,7 +93,7 @@ export function buildHtml(
   <body>
     <header class="site-header">
       <a class="brand" href="/">
-        <img src="/favicon-32x32.png" alt="" />
+        <img src="/img/logo.png" alt="Dendrite logo" />
         Dendrite
       </a>
 

--- a/infra/mod.html
+++ b/infra/mod.html
@@ -13,7 +13,7 @@
   <body>
     <header class="site-header">
       <a class="brand" href="/">
-        <img src="/favicon-32x32.png" alt="" />
+        <img src="/img/logo.png" alt="Dendrite logo" />
         Dendrite
       </a>
 

--- a/infra/new-page.html
+++ b/infra/new-page.html
@@ -9,7 +9,7 @@
   <body>
     <header class="site-header">
       <a class="brand" href="/">
-        <img src="/favicon-32x32.png" alt="" />
+        <img src="/img/logo.png" alt="Dendrite logo" />
         Dendrite
       </a>
 

--- a/infra/new-story.html
+++ b/infra/new-story.html
@@ -9,7 +9,7 @@
   <body>
     <header class="site-header">
       <a class="brand" href="/">
-        <img src="/favicon-32x32.png" alt="" />
+        <img src="/img/logo.png" alt="Dendrite logo" />
         Dendrite
       </a>
 

--- a/test/cloud-functions/buildHtml.test.js
+++ b/test/cloud-functions/buildHtml.test.js
@@ -125,7 +125,7 @@ describe('buildHtml', () => {
   test('renders brand without leading whitespace', () => {
     const html = buildHtml(1, 'a', 'content', []);
     expect(html).toMatch(
-      /<a class="brand" href="\/">\s*<img src="\/favicon-32x32.png" alt="" \/>\s*Dendrite\s*<\/a>/
+      /<a class="brand" href="\/">\s*<img src="\/img\/logo.png" alt="Dendrite logo" \/>\s*Dendrite\s*<\/a>/
     );
   });
 });


### PR DESCRIPTION
## Summary
- display the Dendrite logo in site headers
- reference `/img/logo.png` for the header image
- remove bundled `logo.png` asset now that the image is served from the bucket

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a688cb8e5c832ebbb993e20aefaa93