### PR TITLE
Use standard forest green hyperlinks

### DIFF
--- a/infra/404.html
+++ b/infra/404.html
@@ -51,7 +51,7 @@
             <h3>Account</h3>
             <div id="signinButton"></div>
             <div id="signoutWrap" style="display: none">
-              <button id="signoutBtn" type="button">Sign out</button>
+              <a id="signoutLink" href="#">Sign out</a>
             </div>
           </div>
         </nav>
@@ -69,7 +69,7 @@
       document.addEventListener('DOMContentLoaded', () => {
         const signin = document.getElementById('signinButton');
         const signoutWrap = document.getElementById('signoutWrap');
-        const signoutBtn = document.getElementById('signoutBtn');
+        const signoutLink = document.getElementById('signoutLink');
 
         initGoogleSignIn({
           onSignIn: () => {
@@ -79,7 +79,8 @@
           },
         });
 
-        signoutBtn.addEventListener('click', async () => {
+        signoutLink.addEventListener('click', async e => {
+          e.preventDefault();
           await signOut();
           document.body.classList.remove('authed');
           signoutWrap.style.display = 'none';

--- a/infra/cloud-functions/render-contents/htmlSnippets.js
+++ b/infra/cloud-functions/render-contents/htmlSnippets.js
@@ -51,7 +51,7 @@ export const PAGE_HTML = list => `<!doctype html>
             <h3>Account</h3>
             <div id="signinButton"></div>
             <div id="signoutWrap" style="display:none">
-              <button id="signoutBtn" type="button">Sign out</button>
+                <a id="signoutLink" href="#">Sign out</a>
             </div>
           </div>
         </nav>
@@ -64,20 +64,21 @@ export const PAGE_HTML = list => `<!doctype html>
     <script src="https://accounts.google.com/gsi/client" defer></script>
     <script type="module">
       import { initGoogleSignIn, signOut, getIdToken } from './googleAuth.js';
-      const sb = document.getElementById('signinButton');
-      const sw = document.getElementById('signoutWrap');
-      const so = document.getElementById('signoutBtn');
+        const sb = document.getElementById('signinButton');
+        const sw = document.getElementById('signoutWrap');
+        const so = document.getElementById('signoutLink');
       initGoogleSignIn({
         onSignIn: () => {
           sb.style.display = 'none';
           sw.style.display = '';
         },
       });
-      so.onclick = async () => {
-        await signOut();
-        sb.style.display = '';
-        sw.style.display = 'none';
-      };
+        so.addEventListener('click', async e => {
+          e.preventDefault();
+          await signOut();
+          sb.style.display = '';
+          sw.style.display = 'none';
+        });
       if (getIdToken()) {
         sb.style.display = 'none';
         sw.style.display = '';

--- a/infra/dendrite.css
+++ b/infra/dendrite.css
@@ -4,8 +4,8 @@
   --bg: #ffffff;
   --text: #0b0f14;
   --muted: #66707a;
-  --link: #0b63ce;
-  --link-hover: #2a7fe6;
+  --link: #228b22;
+  --link-hover: #196619;
   --border: #e5e7eb;
   --s1: 4px;
   --s2: 8px;
@@ -22,8 +22,8 @@
     --bg: #0c0f13;
     --text: #e7e7e7;
     --muted: #9aa3ad;
-    --link: #68c3ff;
-    --link-hover: #a8dcff;
+    --link: #228b22;
+    --link-hover: #196619;
     --border: #1a222b;
     --surface-700: #1a1f24;
     --surface-800: #14181d;
@@ -235,16 +235,10 @@ ol.contents li::marker {
 ol.contents a {
   display: block;
   padding-block: 6px;
-  text-decoration: underline;
-  text-underline-offset: 2px;
-  text-decoration-thickness: 0.06em;
-  text-decoration-skip-ink: auto;
-  color: var(--link);
 }
 
 ol.contents a:hover,
 ol.contents a:focus-visible {
-  color: var(--link-hover);
   outline: none;
 }
 
@@ -252,9 +246,19 @@ ol.contents li:nth-child(10n + 1) {
   margin-top: var(--s2);
 }
 
-/* Global link tone */
+/* Global link style */
 a {
   color: var(--link);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  text-decoration-thickness: 0.06em;
+  text-decoration-skip-ink: auto;
+}
+
+a:hover,
+a:focus-visible {
+  color: var(--link-hover);
+  outline: none;
 }
 
 /* Compact mode */

--- a/infra/mod.html
+++ b/infra/mod.html
@@ -55,7 +55,7 @@
             <h3>Account</h3>
             <div id="signinButton"></div>
             <div id="signoutWrap" style="display: none">
-              <button id="signoutBtn" type="button">Sign out</button>
+              <a id="signoutLink" href="#">Sign out</a>
             </div>
           </div>
         </nav>

--- a/infra/moderate.js
+++ b/infra/moderate.js
@@ -44,9 +44,10 @@ function startAnimation(id, text) {
  * Register the click handler for the sign-out button.
  */
 function wireSignOut() {
-  const signoutBtn = document.getElementById('signoutBtn');
-  if (!signoutBtn) return;
-  signoutBtn.onclick = async () => {
+  const signoutLink = document.getElementById('signoutLink');
+  if (!signoutLink) return;
+  signoutLink.addEventListener('click', async e => {
+    e.preventDefault();
     await signOut();
     const wrap = document.getElementById('signoutWrap');
     const signin = document.getElementById('signinButton');
@@ -59,7 +60,7 @@ function wireSignOut() {
     }
     toggleApproveReject(true);
     document.body.classList.remove('authed');
-  };
+  });
 }
 
 /**

--- a/infra/new-page.html
+++ b/infra/new-page.html
@@ -51,7 +51,7 @@
             <h3>Account</h3>
             <div id="signinButton"></div>
             <div id="signoutWrap" style="display: none">
-              <button id="signoutBtn" type="button">Sign out</button>
+              <a id="signoutLink" href="#">Sign out</a>
             </div>
           </div>
         </nav>
@@ -98,7 +98,7 @@
       document.addEventListener('DOMContentLoaded', () => {
         const signin = document.getElementById('signinButton');
         const signoutWrap = document.getElementById('signoutWrap');
-        const signoutBtn = document.getElementById('signoutBtn');
+        const signoutLink = document.getElementById('signoutLink');
 
         const params = new URLSearchParams(window.location.search);
         const incoming = params.get('option');
@@ -133,7 +133,8 @@
           },
         });
 
-        signoutBtn.addEventListener('click', async () => {
+        signoutLink.addEventListener('click', async e => {
+          e.preventDefault();
           await signOut();
           document.body.classList.remove('authed');
           signoutWrap.style.display = 'none';

--- a/infra/new-story.html
+++ b/infra/new-story.html
@@ -51,7 +51,7 @@
             <h3>Account</h3>
             <div id="signinButton"></div>
             <div id="signoutWrap" style="display: none">
-              <button id="signoutBtn" type="button">Sign out</button>
+              <a id="signoutLink" href="#">Sign out</a>
             </div>
           </div>
         </nav>
@@ -108,7 +108,7 @@
         const originalText = button.textContent;
         const signin = document.getElementById('signinButton');
         const signoutWrap = document.getElementById('signoutWrap');
-        const signoutBtn = document.getElementById('signoutBtn');
+        const signoutLink = document.getElementById('signoutLink');
 
         initGoogleSignIn({
           onSignIn: () => {
@@ -118,7 +118,8 @@
           },
         });
 
-        signoutBtn.addEventListener('click', async () => {
+        signoutLink.addEventListener('click', async e => {
+          e.preventDefault();
           await signOut();
           document.body.classList.remove('authed');
           signoutWrap.style.display = 'none';

--- a/test/cloud-functions/renderContentsHtmlSnippets.test.js
+++ b/test/cloud-functions/renderContentsHtmlSnippets.test.js
@@ -23,7 +23,7 @@ describe('PAGE_HTML', () => {
     const html = PAGE_HTML('');
     expect(html).toContain('<div id="signinButton"></div>');
     expect(html).toContain('<div id="signoutWrap"');
-    expect(html).toContain('id="signoutBtn"');
+    expect(html).toContain('id="signoutLink"');
     expect(html).toContain('https://accounts.google.com/gsi/client');
     expect(html).toContain(
       "import { initGoogleSignIn, signOut, getIdToken } from './googleAuth.js';"


### PR DESCRIPTION
## Summary
- Replace sign-out button with anchor elements and update handlers so all nav items share hyperlink styling
- Apply a global forest-green, underlined style to all links via dendrite.css

## Testing
- `npm test`
- `npm run lint` *(warnings: Ternary operator used; Identifier 'access_token' is not in camel case; Missing JSDoc @returns declaration; Missing JSDoc @param "optionData" description; Missing JSDoc @param "optionData" type)*

------
https://chatgpt.com/codex/tasks/task_e_68a6afe79b1c832e98422c401a73882f