### PR TITLE
feat: add admin link to bottom sheet

### DIFF
--- a/infra/404.html
+++ b/infra/404.html
@@ -45,6 +45,7 @@
             <h3>Moderation</h3>
             <a href="/mod.html">Moderate</a>
             <a href="/stats.html">Stats</a>
+            <a id="adminLink" href="/admin.html" style="display: none">Admin</a>
           </div>
 
           <div class="menu-group">
@@ -64,18 +65,28 @@
     <!-- Google Identity Services -->
     <script src="https://accounts.google.com/gsi/client" defer></script>
     <script type="module">
-      import { initGoogleSignIn, getIdToken, signOut } from '/googleAuth.js';
+      import {
+        initGoogleSignIn,
+        getIdToken,
+        signOut,
+      } from '/googleAuth.js';
+      import { getAuth } from 'https://www.gstatic.com/firebasejs/12.0.0/firebase-auth.js';
+      const ADMIN_UID = 'qcYSrXTaj1MZUoFsAloBwT86GNM2';
 
       document.addEventListener('DOMContentLoaded', () => {
         const signin = document.getElementById('signinButton');
         const signoutWrap = document.getElementById('signoutWrap');
         const signoutBtn = document.getElementById('signoutBtn');
+        const adminLink = document.getElementById('adminLink');
 
         initGoogleSignIn({
           onSignIn: () => {
             document.body.classList.add('authed');
             signin.style.display = 'none';
             signoutWrap.style.display = '';
+            if (getAuth().currentUser?.uid === ADMIN_UID && adminLink) {
+              adminLink.style.display = '';
+            }
           },
         });
 
@@ -84,12 +95,16 @@
           document.body.classList.remove('authed');
           signoutWrap.style.display = 'none';
           signin.style.display = '';
+          if (adminLink) adminLink.style.display = 'none';
         });
 
         if (getIdToken()) {
           document.body.classList.add('authed');
           signin.style.display = 'none';
           signoutWrap.style.display = '';
+          if (getAuth().currentUser?.uid === ADMIN_UID && adminLink) {
+            adminLink.style.display = '';
+          }
         }
       });
     </script>

--- a/infra/cloud-functions/generate-stats/index.js
+++ b/infra/cloud-functions/generate-stats/index.js
@@ -85,6 +85,7 @@ function buildHtml(storyCount, pageCount, unmoderatedCount) {
             <h3>Moderation</h3>
             <a href="/mod.html">Moderate</a>
             <a href="/stats.html">Stats</a>
+            <a id="adminLink" href="/admin.html" style="display:none">Admin</a>
           </div>
 
           <div class="menu-group">
@@ -102,8 +103,20 @@ function buildHtml(storyCount, pageCount, unmoderatedCount) {
     </main>
     <script src="https://accounts.google.com/gsi/client" defer></script>
     <script type="module">
-      import { initGoogleSignIn } from './googleAuth.js';
-      initGoogleSignIn();
+      import { initGoogleSignIn, getIdToken } from './googleAuth.js';
+      import { getAuth } from 'https://www.gstatic.com/firebasejs/12.0.0/firebase-auth.js';
+      const ADMIN_UID = 'qcYSrXTaj1MZUoFsAloBwT86GNM2';
+      const al = document.getElementById('adminLink');
+      initGoogleSignIn({
+        onSignIn: () => {
+          if (getAuth().currentUser?.uid === ADMIN_UID && al) {
+            al.style.display = '';
+          }
+        },
+      });
+      if (getIdToken() && getAuth().currentUser?.uid === ADMIN_UID && al) {
+        al.style.display = '';
+      }
     </script>
     <script>
       (function () {

--- a/infra/cloud-functions/render-contents/htmlSnippets.js
+++ b/infra/cloud-functions/render-contents/htmlSnippets.js
@@ -45,6 +45,7 @@ export const PAGE_HTML = list => `<!doctype html>
             <h3>Moderation</h3>
             <a href="/mod.html">Moderate</a>
             <a href="/stats.html">Stats</a>
+            <a id="adminLink" href="/admin.html" style="display:none">Admin</a>
           </div>
 
           <div class="menu-group">
@@ -64,23 +65,33 @@ export const PAGE_HTML = list => `<!doctype html>
     <script src="https://accounts.google.com/gsi/client" defer></script>
     <script type="module">
       import { initGoogleSignIn, signOut, getIdToken } from './googleAuth.js';
+      import { getAuth } from 'https://www.gstatic.com/firebasejs/12.0.0/firebase-auth.js';
+      const ADMIN_UID = 'qcYSrXTaj1MZUoFsAloBwT86GNM2';
       const sb = document.getElementById('signinButton');
       const sw = document.getElementById('signoutWrap');
       const so = document.getElementById('signoutBtn');
+      const al = document.getElementById('adminLink');
       initGoogleSignIn({
         onSignIn: () => {
           sb.style.display = 'none';
           sw.style.display = '';
+          if (getAuth().currentUser?.uid === ADMIN_UID && al) {
+            al.style.display = '';
+          }
         },
       });
       so.onclick = async () => {
         await signOut();
         sb.style.display = '';
         sw.style.display = 'none';
+        if (al) al.style.display = 'none';
       };
       if (getIdToken()) {
         sb.style.display = 'none';
         sw.style.display = '';
+        if (getAuth().currentUser?.uid === ADMIN_UID && al) {
+          al.style.display = '';
+        }
       }
     </script>
     <script>

--- a/infra/cloud-functions/render-variant/buildAltsHtml.js
+++ b/infra/cloud-functions/render-variant/buildAltsHtml.js
@@ -72,6 +72,7 @@ export function buildAltsHtml(pageNumber, variants) {
             <h3>Moderation</h3>
             <a href="/mod.html">Moderate</a>
             <a href="/stats.html">Stats</a>
+            <a id="adminLink" href="/admin.html" style="display:none">Admin</a>
           </div>
 
           <div class="menu-group">
@@ -84,8 +85,20 @@ export function buildAltsHtml(pageNumber, variants) {
     <main><ol>${items}</ol></main>
     <script src="https://accounts.google.com/gsi/client" defer></script>
     <script type="module">
-      import { initGoogleSignIn } from '../googleAuth.js';
-      initGoogleSignIn();
+      import { initGoogleSignIn, getIdToken } from '../googleAuth.js';
+      import { getAuth } from 'https://www.gstatic.com/firebasejs/12.0.0/firebase-auth.js';
+      const ADMIN_UID = 'qcYSrXTaj1MZUoFsAloBwT86GNM2';
+      const al = document.getElementById('adminLink');
+      initGoogleSignIn({
+        onSignIn: () => {
+          if (getAuth().currentUser?.uid === ADMIN_UID && al) {
+            al.style.display = '';
+          }
+        },
+      });
+      if (getIdToken() && getAuth().currentUser?.uid === ADMIN_UID && al) {
+        al.style.display = '';
+      }
     </script>
     <script>
       (function () {

--- a/infra/cloud-functions/render-variant/buildHtml.js
+++ b/infra/cloud-functions/render-variant/buildHtml.js
@@ -122,6 +122,7 @@ export function buildHtml(
             <h3>Moderation</h3>
             <a href="/mod.html">Moderate</a>
             <a href="/stats.html">Stats</a>
+            <a id="adminLink" href="/admin.html" style="display:none">Admin</a>
           </div>
 
           <div class="menu-group">
@@ -134,8 +135,20 @@ export function buildHtml(
     <main>${title}${paragraphs}<ol>${items}</ol>${authorHtml}${parentHtml}${firstHtml}<p>${rewriteLink}<a href="./${pageNumber}-alts.html">Other variants</a></p>${pageNumberHtml}${reportHtml}</main>
     <script src="https://accounts.google.com/gsi/client" defer></script>
     <script type="module">
-      import { initGoogleSignIn } from '../googleAuth.js';
-      initGoogleSignIn();
+      import { initGoogleSignIn, getIdToken } from '../googleAuth.js';
+      import { getAuth } from 'https://www.gstatic.com/firebasejs/12.0.0/firebase-auth.js';
+      const ADMIN_UID = 'qcYSrXTaj1MZUoFsAloBwT86GNM2';
+      const al = document.getElementById('adminLink');
+      initGoogleSignIn({
+        onSignIn: () => {
+          if (getAuth().currentUser?.uid === ADMIN_UID && al) {
+            al.style.display = '';
+          }
+        },
+      });
+      if (getIdToken() && getAuth().currentUser?.uid === ADMIN_UID && al) {
+        al.style.display = '';
+      }
     </script>
     <script>
       (function () {

--- a/infra/mod.html
+++ b/infra/mod.html
@@ -49,6 +49,7 @@
             <h3>Moderation</h3>
             <a href="/mod.html">Moderate</a>
             <a href="/stats.html">Stats</a>
+            <a id="adminLink" href="/admin.html" style="display: none">Admin</a>
           </div>
 
           <div class="menu-group">

--- a/infra/moderate.js
+++ b/infra/moderate.js
@@ -1,4 +1,7 @@
 import { initGoogleSignIn, getIdToken, signOut } from './googleAuth.js';
+import { getAuth } from 'https://www.gstatic.com/firebasejs/12.0.0/firebase-auth.js';
+
+const ADMIN_UID = 'qcYSrXTaj1MZUoFsAloBwT86GNM2';
 
 const GET_VARIANT_URL =
   'https://europe-west1-irien-465710.cloudfunctions.net/prod-get-moderation-variant';
@@ -46,12 +49,14 @@ function startAnimation(id, text) {
 function wireSignOut() {
   const signoutBtn = document.getElementById('signoutBtn');
   if (!signoutBtn) return;
+  const adminLink = document.getElementById('adminLink');
   signoutBtn.onclick = async () => {
     await signOut();
     const wrap = document.getElementById('signoutWrap');
     const signin = document.getElementById('signinButton');
     if (wrap) wrap.style.display = 'none';
     if (signin) signin.style.display = '';
+    if (adminLink) adminLink.style.display = 'none';
     const content = document.getElementById('pageContent');
     if (content) {
       content.innerHTML = '';
@@ -169,8 +174,12 @@ initGoogleSignIn({
     document.body.classList.add('authed');
     const signin = document.getElementById('signinButton');
     const wrap = document.getElementById('signoutWrap');
+    const adminLink = document.getElementById('adminLink');
     signin.style.display = 'none';
     wrap.style.display = '';
+    if (getAuth().currentUser?.uid === ADMIN_UID && adminLink) {
+      adminLink.style.display = '';
+    }
     wireSignOut();
     loadVariant();
   },
@@ -195,7 +204,12 @@ export const authedFetch = async (url, opts = {}) => {
 if (getIdToken()) {
   document.body.classList.add('authed');
   document.getElementById('signinButton').style.display = 'none';
-  document.getElementById('signoutWrap').style.display = '';
+  const wrap = document.getElementById('signoutWrap');
+  wrap.style.display = '';
+  const adminLink = document.getElementById('adminLink');
+  if (getAuth().currentUser?.uid === ADMIN_UID && adminLink) {
+    adminLink.style.display = '';
+  }
   wireSignOut();
   loadVariant();
 }

--- a/infra/new-page.html
+++ b/infra/new-page.html
@@ -45,6 +45,7 @@
             <h3>Moderation</h3>
             <a href="/mod.html">Moderate</a>
             <a href="/stats.html">Stats</a>
+            <a id="adminLink" href="/admin.html" style="display: none">Admin</a>
           </div>
 
           <div class="menu-group">
@@ -93,12 +94,19 @@
     <!-- Google Identity Services -->
     <script src="https://accounts.google.com/gsi/client" defer></script>
     <script type="module">
-      import { initGoogleSignIn, getIdToken, signOut } from './googleAuth.js';
+      import {
+        initGoogleSignIn,
+        getIdToken,
+        signOut,
+      } from './googleAuth.js';
+      import { getAuth } from 'https://www.gstatic.com/firebasejs/12.0.0/firebase-auth.js';
+      const ADMIN_UID = 'qcYSrXTaj1MZUoFsAloBwT86GNM2';
 
       document.addEventListener('DOMContentLoaded', () => {
         const signin = document.getElementById('signinButton');
         const signoutWrap = document.getElementById('signoutWrap');
         const signoutBtn = document.getElementById('signoutBtn');
+        const adminLink = document.getElementById('adminLink');
 
         const params = new URLSearchParams(window.location.search);
         const incoming = params.get('option');
@@ -130,6 +138,9 @@
             document.body.classList.add('authed');
             signin.style.display = 'none';
             signoutWrap.style.display = '';
+            if (getAuth().currentUser?.uid === ADMIN_UID && adminLink) {
+              adminLink.style.display = '';
+            }
           },
         });
 
@@ -138,12 +149,16 @@
           document.body.classList.remove('authed');
           signoutWrap.style.display = 'none';
           signin.style.display = '';
+          if (adminLink) adminLink.style.display = 'none';
         });
 
         if (getIdToken()) {
           document.body.classList.add('authed');
           signin.style.display = 'none';
           signoutWrap.style.display = '';
+          if (getAuth().currentUser?.uid === ADMIN_UID && adminLink) {
+            adminLink.style.display = '';
+          }
         }
 
         form.addEventListener('submit', async event => {

--- a/infra/new-story.html
+++ b/infra/new-story.html
@@ -45,6 +45,7 @@
             <h3>Moderation</h3>
             <a href="/mod.html">Moderate</a>
             <a href="/stats.html">Stats</a>
+            <a id="adminLink" href="/admin.html" style="display: none">Admin</a>
           </div>
 
           <div class="menu-group">
@@ -100,7 +101,13 @@
     <!-- Google Identity Services -->
     <script src="https://accounts.google.com/gsi/client" defer></script>
     <script type="module">
-      import { initGoogleSignIn, getIdToken, signOut } from './googleAuth.js';
+      import {
+        initGoogleSignIn,
+        getIdToken,
+        signOut,
+      } from './googleAuth.js';
+      import { getAuth } from 'https://www.gstatic.com/firebasejs/12.0.0/firebase-auth.js';
+      const ADMIN_UID = 'qcYSrXTaj1MZUoFsAloBwT86GNM2';
 
       document.addEventListener('DOMContentLoaded', () => {
         const form = document.querySelector('form');
@@ -109,12 +116,16 @@
         const signin = document.getElementById('signinButton');
         const signoutWrap = document.getElementById('signoutWrap');
         const signoutBtn = document.getElementById('signoutBtn');
+        const adminLink = document.getElementById('adminLink');
 
         initGoogleSignIn({
           onSignIn: () => {
             document.body.classList.add('authed');
             signin.style.display = 'none';
             signoutWrap.style.display = '';
+            if (getAuth().currentUser?.uid === ADMIN_UID && adminLink) {
+              adminLink.style.display = '';
+            }
           },
         });
 
@@ -123,12 +134,16 @@
           document.body.classList.remove('authed');
           signoutWrap.style.display = 'none';
           signin.style.display = '';
+          if (adminLink) adminLink.style.display = 'none';
         });
 
         if (getIdToken()) {
           document.body.classList.add('authed');
           signin.style.display = 'none';
           signoutWrap.style.display = '';
+          if (getAuth().currentUser?.uid === ADMIN_UID && adminLink) {
+            adminLink.style.display = '';
+          }
         }
 
         form.addEventListener('submit', async event => {

--- a/test/cloud-functions/buildHtml.test.js
+++ b/test/cloud-functions/buildHtml.test.js
@@ -118,7 +118,7 @@ describe('buildHtml', () => {
     expect(html).toContain('<nav class="nav-inline"');
     expect(html).toContain('id="signinButton"');
     expect(html).toContain(
-      "import { initGoogleSignIn } from '../googleAuth.js'"
+      "import { initGoogleSignIn, getIdToken } from '../googleAuth.js'"
     );
   });
 

--- a/test/cloud-functions/renderContentsHtmlSnippets.test.js
+++ b/test/cloud-functions/renderContentsHtmlSnippets.test.js
@@ -24,6 +24,7 @@ describe('PAGE_HTML', () => {
     expect(html).toContain('<div id="signinButton"></div>');
     expect(html).toContain('<div id="signoutWrap"');
     expect(html).toContain('id="signoutBtn"');
+    expect(html).toContain('id="adminLink"');
     expect(html).toContain('https://accounts.google.com/gsi/client');
     expect(html).toContain(
       "import { initGoogleSignIn, signOut, getIdToken } from './googleAuth.js';"


### PR DESCRIPTION
## Summary
- show hidden Admin link in bottom sheet
- reveal the link when the authenticated user's UID matches the admin UID
- update tests for new bottom-sheet content

## Testing
- `npm test`
- `npm run lint` (warnings)


------
https://chatgpt.com/codex/tasks/task_e_68a6b07db574832e82922da9d36efe15