### PR TITLE
feat: link rewrite to page query

### DIFF
--- a/infra/cloud-functions/render-variant/buildHtml.js
+++ b/infra/cloud-functions/render-variant/buildHtml.js
@@ -26,7 +26,6 @@ function renderInlineMarkdown(text) {
  * @param {string} [author] Author name.
  * @param parentUrl
  * @param firstPageUrl
- * @param incomingOptionSlug
  * @returns {string} HTML page.
  */
 export function buildHtml(
@@ -37,8 +36,7 @@ export function buildHtml(
   storyTitle = '',
   author = '',
   parentUrl = '',
-  firstPageUrl = '',
-  incomingOptionSlug = ''
+  firstPageUrl = ''
 ) {
   const items = options
     .map(opt => {
@@ -60,9 +58,7 @@ export function buildHtml(
   const firstHtml = firstPageUrl
     ? `<p><a href="${firstPageUrl}">First page</a></p>`
     : '';
-  const rewriteLink = incomingOptionSlug
-    ? `<a href="../new-page.html?option=${incomingOptionSlug}">Rewrite</a> `
-    : '';
+  const rewriteLink = `<a href="../new-page.html?page=${pageNumber}">Rewrite</a> `;
   const variantSlug = `${pageNumber}${variantName}`;
   const reportHtml =
     '<p><a id="reportLink" href="#">⚑ Report</a></p>' +

--- a/infra/cloud-functions/render-variant/index.js
+++ b/infra/cloud-functions/render-variant/index.js
@@ -176,28 +176,22 @@ async function render(snap, ctx) {
 
   const authorName = variant.authorName || variant.author || '';
   let parentUrl;
-  let incomingOptionSlug;
   if (variant.incomingOption) {
     try {
       const optionRef = db.doc(variant.incomingOption);
       const parentVariantRef = optionRef.parent.parent;
       const parentPageRef = parentVariantRef.parent.parent;
 
-      const [optionSnap, parentVariantSnap, parentPageSnap] = await Promise.all(
-        [optionRef.get(), parentVariantRef.get(), parentPageRef.get()]
-      );
+      const [parentVariantSnap, parentPageSnap] = await Promise.all([
+        parentVariantRef.get(),
+        parentPageRef.get(),
+      ]);
 
       if (parentVariantSnap.exists && parentPageSnap.exists) {
         const parentName = parentVariantSnap.data().name;
         if (parentName) {
           const parentNumber = parentPageSnap.data().number;
           parentUrl = `/p/${parentNumber}${parentName}.html`;
-          if (optionSnap.exists) {
-            const position = optionSnap.data().position;
-            if (position !== undefined) {
-              incomingOptionSlug = `${parentNumber}-${parentName}-${position}`;
-            }
-          }
         }
       }
     } catch (e) {
@@ -213,8 +207,7 @@ async function render(snap, ctx) {
     storyTitle,
     authorName,
     parentUrl,
-    firstPageUrl,
-    incomingOptionSlug
+    firstPageUrl
   );
   const filePath = `p/${page.number}${variant.name}.html`;
   const openVariant = options.some(opt => opt.targetPageNumber === undefined);

--- a/test/cloud-functions/buildHtml.test.js
+++ b/test/cloud-functions/buildHtml.test.js
@@ -58,10 +58,10 @@ describe('buildHtml', () => {
     expect(html).toContain('<a href="./1-alts.html">Other variants</a>');
   });
 
-  test('includes rewrite link when incoming option slug provided', () => {
-    const html = buildHtml(2, 'b', 'content', [], '', '', '', '', '1-a-0');
+  test('includes rewrite link with page parameter', () => {
+    const html = buildHtml(2, 'b', 'content', []);
     expect(html).toContain(
-      '<a href="../new-page.html?option=1-a-0">Rewrite</a> <a href="./2-alts.html">Other variants</a>'
+      '<a href="../new-page.html?page=2">Rewrite</a> <a href="./2-alts.html">Other variants</a>'
     );
   });
 

--- a/test/cloud-functions/renderVariant.test.js
+++ b/test/cloud-functions/renderVariant.test.js
@@ -176,38 +176,12 @@ describe('render', () => {
     expect(html).toContain('<a href="/p/1a.html">First page</a>');
   });
 
-  test('includes rewrite link when incoming option provided', async () => {
+  test('includes rewrite link with page parameter', async () => {
     const snap = createSnap([{ content: 'Go', position: 0 }]);
-    snap.data = () => ({
-      name: 'a',
-      content: 'content',
-      incomingOption: 'stories/s1/pages/p1/variants/pv/options/o1',
-    });
-
-    const parentPageRef = {
-      get: jest.fn().mockResolvedValue({
-        exists: true,
-        data: () => ({ number: 7 }),
-      }),
-    };
-    const parentVariantRef = {
-      get: jest.fn().mockResolvedValue({
-        exists: true,
-        data: () => ({ name: 'b' }),
-      }),
-      parent: { parent: parentPageRef },
-    };
-    mockDoc.mockReturnValue({
-      parent: { parent: parentVariantRef },
-      get: jest
-        .fn()
-        .mockResolvedValue({ exists: true, data: () => ({ position: 3 }) }),
-    });
-
     await render(snap, { params: { storyId: 's1', variantId: 'v1' } });
     const html = mockSave.mock.calls[0][0];
     expect(html).toContain(
-      '<a href="../new-page.html?option=7-b-3">Rewrite</a> <a href="./5-alts.html">Other variants</a>'
+      '<a href="../new-page.html?page=5">Rewrite</a> <a href="./5-alts.html">Other variants</a>'
     );
   });
 });


### PR DESCRIPTION
## Summary
- always render rewrite link to new page form using the page query parameter
- simplify variant rendering by removing incoming option slug logic
- update tests for new rewrite link behavior

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a6b29a9f08832ebaf9a277358782a3