### PR TITLE
Show admin link to admin users

### DIFF
--- a/infra/404.html
+++ b/infra/404.html
@@ -45,6 +45,7 @@
             <h3>Moderation</h3>
             <a href="/mod.html">Moderate</a>
             <a href="/stats.html">Stats</a>
+            <a id="adminLink" href="/admin.html" style="display: none">Admin</a>
           </div>
 
           <div class="menu-group">
@@ -64,18 +65,25 @@
     <!-- Google Identity Services -->
     <script src="https://accounts.google.com/gsi/client" defer></script>
     <script type="module">
-      import { initGoogleSignIn, getIdToken, signOut } from '/googleAuth.js';
+      import {
+        initGoogleSignIn,
+        getIdToken,
+        signOut,
+        isAdmin,
+      } from '/googleAuth.js';
 
       document.addEventListener('DOMContentLoaded', () => {
         const signin = document.getElementById('signinButton');
         const signoutWrap = document.getElementById('signoutWrap');
         const signoutLink = document.getElementById('signoutLink');
+        const adminLink = document.getElementById('adminLink');
 
         initGoogleSignIn({
           onSignIn: () => {
             document.body.classList.add('authed');
             signin.style.display = 'none';
             signoutWrap.style.display = '';
+            if (isAdmin()) adminLink.style.display = '';
           },
         });
 
@@ -85,12 +93,14 @@
           document.body.classList.remove('authed');
           signoutWrap.style.display = 'none';
           signin.style.display = '';
+          if (adminLink) adminLink.style.display = 'none';
         });
 
         if (getIdToken()) {
           document.body.classList.add('authed');
           signin.style.display = 'none';
           signoutWrap.style.display = '';
+          if (isAdmin()) adminLink.style.display = '';
         }
       });
     </script>

--- a/infra/cloud-functions/generate-stats/index.js
+++ b/infra/cloud-functions/generate-stats/index.js
@@ -85,6 +85,7 @@ function buildHtml(storyCount, pageCount, unmoderatedCount) {
             <h3>Moderation</h3>
             <a href="/mod.html">Moderate</a>
             <a href="/stats.html">Stats</a>
+            <a id="adminLink" href="/admin.html" style="display:none">Admin</a>
           </div>
 
           <div class="menu-group">
@@ -102,8 +103,18 @@ function buildHtml(storyCount, pageCount, unmoderatedCount) {
     </main>
     <script src="https://accounts.google.com/gsi/client" defer></script>
     <script type="module">
-      import { initGoogleSignIn } from './googleAuth.js';
-      initGoogleSignIn();
+      import {
+        initGoogleSignIn,
+        getIdToken,
+        isAdmin,
+      } from './googleAuth.js';
+      const al = document.getElementById('adminLink');
+      initGoogleSignIn({
+        onSignIn: () => {
+          if (isAdmin()) al.style.display = '';
+        },
+      });
+      if (getIdToken() && isAdmin()) al.style.display = '';
     </script>
     <script>
       (function () {

--- a/infra/cloud-functions/render-contents/htmlSnippets.js
+++ b/infra/cloud-functions/render-contents/htmlSnippets.js
@@ -45,6 +45,7 @@ export const PAGE_HTML = list => `<!doctype html>
             <h3>Moderation</h3>
             <a href="/mod.html">Moderate</a>
             <a href="/stats.html">Stats</a>
+            <a id="adminLink" href="/admin.html" style="display:none">Admin</a>
           </div>
 
           <div class="menu-group">
@@ -63,14 +64,21 @@ export const PAGE_HTML = list => `<!doctype html>
     </main>
     <script src="https://accounts.google.com/gsi/client" defer></script>
     <script type="module">
-      import { initGoogleSignIn, signOut, getIdToken } from './googleAuth.js';
+      import {
+        initGoogleSignIn,
+        signOut,
+        getIdToken,
+        isAdmin,
+      } from './googleAuth.js';
         const sb = document.getElementById('signinButton');
         const sw = document.getElementById('signoutWrap');
         const so = document.getElementById('signoutLink');
+        const al = document.getElementById('adminLink');
       initGoogleSignIn({
         onSignIn: () => {
           sb.style.display = 'none';
           sw.style.display = '';
+          if (isAdmin()) al.style.display = '';
         },
       });
         so.addEventListener('click', async e => {
@@ -78,10 +86,12 @@ export const PAGE_HTML = list => `<!doctype html>
           await signOut();
           sb.style.display = '';
           sw.style.display = 'none';
+          if (al) al.style.display = 'none';
         });
       if (getIdToken()) {
         sb.style.display = 'none';
         sw.style.display = '';
+        if (isAdmin()) al.style.display = '';
       }
     </script>
     <script>

--- a/infra/cloud-functions/render-variant/buildAltsHtml.js
+++ b/infra/cloud-functions/render-variant/buildAltsHtml.js
@@ -72,6 +72,7 @@ export function buildAltsHtml(pageNumber, variants) {
             <h3>Moderation</h3>
             <a href="/mod.html">Moderate</a>
             <a href="/stats.html">Stats</a>
+            <a id="adminLink" href="/admin.html" style="display:none">Admin</a>
           </div>
 
           <div class="menu-group">
@@ -84,8 +85,18 @@ export function buildAltsHtml(pageNumber, variants) {
     <main><ol>${items}</ol></main>
     <script src="https://accounts.google.com/gsi/client" defer></script>
     <script type="module">
-      import { initGoogleSignIn } from '../googleAuth.js';
-      initGoogleSignIn();
+      import {
+        initGoogleSignIn,
+        getIdToken,
+        isAdmin,
+      } from '../googleAuth.js';
+      const al = document.getElementById('adminLink');
+      initGoogleSignIn({
+        onSignIn: () => {
+          if (isAdmin()) al.style.display = '';
+        },
+      });
+      if (getIdToken() && isAdmin()) al.style.display = '';
     </script>
     <script>
       (function () {

--- a/infra/cloud-functions/render-variant/buildHtml.js
+++ b/infra/cloud-functions/render-variant/buildHtml.js
@@ -122,6 +122,7 @@ export function buildHtml(
             <h3>Moderation</h3>
             <a href="/mod.html">Moderate</a>
             <a href="/stats.html">Stats</a>
+            <a id="adminLink" href="/admin.html" style="display:none">Admin</a>
           </div>
 
           <div class="menu-group">
@@ -134,8 +135,18 @@ export function buildHtml(
     <main>${title}${paragraphs}<ol>${items}</ol>${authorHtml}${parentHtml}${firstHtml}<p>${rewriteLink}<a href="./${pageNumber}-alts.html">Other variants</a></p>${pageNumberHtml}${reportHtml}</main>
     <script src="https://accounts.google.com/gsi/client" defer></script>
     <script type="module">
-      import { initGoogleSignIn } from '../googleAuth.js';
-      initGoogleSignIn();
+      import {
+        initGoogleSignIn,
+        getIdToken,
+        isAdmin,
+      } from '../googleAuth.js';
+      const al = document.getElementById('adminLink');
+      initGoogleSignIn({
+        onSignIn: () => {
+          if (isAdmin()) al.style.display = '';
+        },
+      });
+      if (getIdToken() && isAdmin()) al.style.display = '';
     </script>
     <script>
       (function () {

--- a/infra/googleAuth.js
+++ b/infra/googleAuth.js
@@ -13,6 +13,8 @@ initializeApp({
 
 const auth = getAuth();
 
+const ADMIN_UID = 'qcYSrXTaj1MZUoFsAloBwT86GNM2';
+
 export const initGoogleSignIn = ({ onSignIn } = {}) => {
   if (!window.google || !google.accounts?.id) {
     console.error('Google Identity script missing');
@@ -52,6 +54,20 @@ export const initGoogleSignIn = ({ onSignIn } = {}) => {
 };
 
 export const getIdToken = () => sessionStorage.getItem('id_token');
+
+export const isAdmin = () => {
+  const token = getIdToken();
+  if (!token) return false;
+  try {
+    const payload = token.split('.')[1];
+    const json = JSON.parse(
+      atob(payload.replace(/-/g, '+').replace(/_/g, '/'))
+    );
+    return json.sub === ADMIN_UID;
+  } catch {
+    return false;
+  }
+};
 
 export const signOut = async () => {
   await auth.signOut();

--- a/infra/mod.html
+++ b/infra/mod.html
@@ -49,6 +49,7 @@
             <h3>Moderation</h3>
             <a href="/mod.html">Moderate</a>
             <a href="/stats.html">Stats</a>
+            <a id="adminLink" href="/admin.html" style="display: none">Admin</a>
           </div>
 
           <div class="menu-group">

--- a/infra/moderate.js
+++ b/infra/moderate.js
@@ -1,4 +1,9 @@
-import { initGoogleSignIn, getIdToken, signOut } from './googleAuth.js';
+import {
+  initGoogleSignIn,
+  getIdToken,
+  signOut,
+  isAdmin,
+} from './googleAuth.js';
 
 const GET_VARIANT_URL =
   'https://europe-west1-irien-465710.cloudfunctions.net/prod-get-moderation-variant';
@@ -53,6 +58,8 @@ function wireSignOut() {
     const signin = document.getElementById('signinButton');
     if (wrap) wrap.style.display = 'none';
     if (signin) signin.style.display = '';
+    const adminLink = document.getElementById('adminLink');
+    if (adminLink) adminLink.style.display = 'none';
     const content = document.getElementById('pageContent');
     if (content) {
       content.innerHTML = '';
@@ -172,6 +179,8 @@ initGoogleSignIn({
     const wrap = document.getElementById('signoutWrap');
     signin.style.display = 'none';
     wrap.style.display = '';
+    const adminLink = document.getElementById('adminLink');
+    if (isAdmin()) adminLink.style.display = '';
     wireSignOut();
     loadVariant();
   },
@@ -197,6 +206,10 @@ if (getIdToken()) {
   document.body.classList.add('authed');
   document.getElementById('signinButton').style.display = 'none';
   document.getElementById('signoutWrap').style.display = '';
+  if (isAdmin()) {
+    const adminLink = document.getElementById('adminLink');
+    if (adminLink) adminLink.style.display = '';
+  }
   wireSignOut();
   loadVariant();
 }

--- a/infra/new-page.html
+++ b/infra/new-page.html
@@ -45,6 +45,7 @@
             <h3>Moderation</h3>
             <a href="/mod.html">Moderate</a>
             <a href="/stats.html">Stats</a>
+            <a id="adminLink" href="/admin.html" style="display: none">Admin</a>
           </div>
 
           <div class="menu-group">
@@ -93,12 +94,18 @@
     <!-- Google Identity Services -->
     <script src="https://accounts.google.com/gsi/client" defer></script>
     <script type="module">
-      import { initGoogleSignIn, getIdToken, signOut } from './googleAuth.js';
+      import {
+        initGoogleSignIn,
+        getIdToken,
+        signOut,
+        isAdmin,
+      } from './googleAuth.js';
 
       document.addEventListener('DOMContentLoaded', () => {
         const signin = document.getElementById('signinButton');
         const signoutWrap = document.getElementById('signoutWrap');
         const signoutLink = document.getElementById('signoutLink');
+        const adminLink = document.getElementById('adminLink');
 
         const params = new URLSearchParams(window.location.search);
         const incoming = params.get('option');
@@ -130,6 +137,7 @@
             document.body.classList.add('authed');
             signin.style.display = 'none';
             signoutWrap.style.display = '';
+            if (isAdmin()) adminLink.style.display = '';
           },
         });
 
@@ -139,12 +147,14 @@
           document.body.classList.remove('authed');
           signoutWrap.style.display = 'none';
           signin.style.display = '';
+          if (adminLink) adminLink.style.display = 'none';
         });
 
         if (getIdToken()) {
           document.body.classList.add('authed');
           signin.style.display = 'none';
           signoutWrap.style.display = '';
+          if (isAdmin()) adminLink.style.display = '';
         }
 
         form.addEventListener('submit', async event => {

--- a/infra/new-story.html
+++ b/infra/new-story.html
@@ -45,6 +45,7 @@
             <h3>Moderation</h3>
             <a href="/mod.html">Moderate</a>
             <a href="/stats.html">Stats</a>
+            <a id="adminLink" href="/admin.html" style="display: none">Admin</a>
           </div>
 
           <div class="menu-group">
@@ -100,7 +101,12 @@
     <!-- Google Identity Services -->
     <script src="https://accounts.google.com/gsi/client" defer></script>
     <script type="module">
-      import { initGoogleSignIn, getIdToken, signOut } from './googleAuth.js';
+      import {
+        initGoogleSignIn,
+        getIdToken,
+        signOut,
+        isAdmin,
+      } from './googleAuth.js';
 
       document.addEventListener('DOMContentLoaded', () => {
         const form = document.querySelector('form');
@@ -109,12 +115,14 @@
         const signin = document.getElementById('signinButton');
         const signoutWrap = document.getElementById('signoutWrap');
         const signoutLink = document.getElementById('signoutLink');
+        const adminLink = document.getElementById('adminLink');
 
         initGoogleSignIn({
           onSignIn: () => {
             document.body.classList.add('authed');
             signin.style.display = 'none';
             signoutWrap.style.display = '';
+            if (isAdmin()) adminLink.style.display = '';
           },
         });
 
@@ -124,12 +132,14 @@
           document.body.classList.remove('authed');
           signoutWrap.style.display = 'none';
           signin.style.display = '';
+          if (adminLink) adminLink.style.display = 'none';
         });
 
         if (getIdToken()) {
           document.body.classList.add('authed');
           signin.style.display = 'none';
           signoutWrap.style.display = '';
+          if (isAdmin()) adminLink.style.display = '';
         }
 
         form.addEventListener('submit', async event => {

--- a/test/cloud-functions/buildHtml.test.js
+++ b/test/cloud-functions/buildHtml.test.js
@@ -117,9 +117,11 @@ describe('buildHtml', () => {
     const html = buildHtml(1, 'a', 'content', []);
     expect(html).toContain('<nav class="nav-inline"');
     expect(html).toContain('id="signinButton"');
-    expect(html).toContain(
-      "import { initGoogleSignIn } from '../googleAuth.js'"
-    );
+    expect(html).toContain('import {');
+    expect(html).toContain('initGoogleSignIn');
+    expect(html).toContain('getIdToken');
+    expect(html).toContain('isAdmin');
+    expect(html).toContain("from '../googleAuth.js'");
   });
 
   test('includes favicon link', () => {

--- a/test/cloud-functions/renderContentsHtmlSnippets.test.js
+++ b/test/cloud-functions/renderContentsHtmlSnippets.test.js
@@ -25,9 +25,12 @@ describe('PAGE_HTML', () => {
     expect(html).toContain('<div id="signoutWrap"');
     expect(html).toContain('id="signoutLink"');
     expect(html).toContain('https://accounts.google.com/gsi/client');
-    expect(html).toContain(
-      "import { initGoogleSignIn, signOut, getIdToken } from './googleAuth.js';"
-    );
+    expect(html).toContain('import {');
+    expect(html).toContain('initGoogleSignIn');
+    expect(html).toContain('signOut');
+    expect(html).toContain('getIdToken');
+    expect(html).toContain('isAdmin');
+    expect(html).toContain("from './googleAuth.js'");
   });
 
   test('references Pico CSS before the local stylesheet', () => {


### PR DESCRIPTION
## Summary
- add `isAdmin` helper to detect the admin UID from the stored ID token
- expose an Admin link in mobile menus when the signed-in user is the admin

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a6c9b38f98832ebbb71515d069df7a