### PR TITLE
feat: show auth button in desktop header

### DIFF
--- a/infra/404.html
+++ b/infra/404.html
@@ -18,6 +18,10 @@
         <a href="/new-story.html">New story</a>
         <a href="/mod.html">Moderate</a>
         <a href="/stats.html">Stats</a>
+        <div id="signinButton"></div>
+        <div id="signoutWrap" style="display: none">
+          <a id="signoutLink" href="#">Sign out</a>
+        </div>
       </nav>
 
       <button
@@ -73,34 +77,37 @@
       } from '/googleAuth.js';
 
       document.addEventListener('DOMContentLoaded', () => {
-        const signin = document.getElementById('signinButton');
-        const signoutWrap = document.getElementById('signoutWrap');
-        const signoutLink = document.getElementById('signoutLink');
+        const signins = document.querySelectorAll('#signinButton');
+        const signoutWraps = document.querySelectorAll('#signoutWrap');
+        const signoutLinks = document.querySelectorAll('#signoutLink');
         const adminLink = document.getElementById('adminLink');
 
-        initGoogleSignIn({
-          onSignIn: () => {
-            document.body.classList.add('authed');
-            signin.style.display = 'none';
-            signoutWrap.style.display = '';
-            if (isAdmin()) adminLink.style.display = '';
-          },
-        });
+        function showSignedIn() {
+          document.body.classList.add('authed');
+          signins.forEach(el => (el.style.display = 'none'));
+          signoutWraps.forEach(el => (el.style.display = ''));
+          if (isAdmin()) adminLink.style.display = '';
+        }
 
-        signoutLink.addEventListener('click', async e => {
-          e.preventDefault();
-          await signOut();
+        function showSignedOut() {
           document.body.classList.remove('authed');
-          signoutWrap.style.display = 'none';
-          signin.style.display = '';
+          signoutWraps.forEach(el => (el.style.display = 'none'));
+          signins.forEach(el => (el.style.display = ''));
           if (adminLink) adminLink.style.display = 'none';
+        }
+
+        initGoogleSignIn({ onSignIn: showSignedIn });
+
+        signoutLinks.forEach(link => {
+          link.addEventListener('click', async e => {
+            e.preventDefault();
+            await signOut();
+            showSignedOut();
+          });
         });
 
         if (getIdToken()) {
-          document.body.classList.add('authed');
-          signin.style.display = 'none';
-          signoutWrap.style.display = '';
-          if (isAdmin()) adminLink.style.display = '';
+          showSignedIn();
         }
       });
     </script>

--- a/infra/admin.html
+++ b/infra/admin.html
@@ -18,6 +18,10 @@
         <a href="/new-story.html">New story</a>
         <a href="/mod.html">Moderate</a>
         <a href="/stats.html">Stats</a>
+        <div id="signinButton"></div>
+        <div id="signoutWrap" style="display: none">
+          <a id="signoutLink" href="#">Sign out</a>
+        </div>
       </nav>
 
       <button
@@ -50,6 +54,9 @@
           <div class="menu-group">
             <h3>Account</h3>
             <div id="signinButton"></div>
+            <div id="signoutWrap" style="display: none">
+              <a id="signoutLink" href="#">Sign out</a>
+            </div>
           </div>
         </nav>
       </div>

--- a/infra/admin.js
+++ b/infra/admin.js
@@ -1,4 +1,4 @@
-import { initGoogleSignIn, getIdToken } from './googleAuth.js';
+import { initGoogleSignIn, getIdToken, signOut } from './googleAuth.js';
 import { getAuth } from 'https://www.gstatic.com/firebasejs/12.0.0/firebase-auth.js';
 
 const ADMIN_UID = 'qcYSrXTaj1MZUoFsAloBwT86GNM2';
@@ -20,9 +20,11 @@ function checkAccess() {
     return;
   }
   const content = document.getElementById('adminContent');
-  const signin = document.getElementById('signinButton');
+  const signins = document.querySelectorAll('#signinButton');
+  const signouts = document.querySelectorAll('#signoutWrap');
   if (content) content.style.display = '';
-  if (signin) signin.style.display = 'none';
+  signins.forEach(el => (el.style.display = 'none'));
+  signouts.forEach(el => (el.style.display = ''));
 }
 
 /**
@@ -118,8 +120,32 @@ document
   .getElementById('regenForm')
   ?.addEventListener('submit', regenerateVariant);
 
-initGoogleSignIn({ onSignIn: checkAccess });
+/**
+ *
+ */
+function wireSignOut() {
+  document.querySelectorAll('#signoutLink').forEach(link => {
+    link.addEventListener('click', async e => {
+      e.preventDefault();
+      await signOut();
+      document
+        .querySelectorAll('#signoutWrap')
+        .forEach(el => (el.style.display = 'none'));
+      document
+        .querySelectorAll('#signinButton')
+        .forEach(el => (el.style.display = ''));
+    });
+  });
+}
+
+initGoogleSignIn({
+  onSignIn: () => {
+    checkAccess();
+    wireSignOut();
+  },
+});
 
 if (getIdToken()) {
   checkAccess();
+  wireSignOut();
 }

--- a/infra/cloud-functions/generate-stats/index.js
+++ b/infra/cloud-functions/generate-stats/index.js
@@ -65,6 +65,10 @@ function buildHtml(storyCount, pageCount, unmoderatedCount) {
         <a href="/new-story.html">New story</a>
         <a href="/mod.html">Moderate</a>
         <a href="/stats.html">Stats</a>
+        <div id="signinButton"></div>
+        <div id="signoutWrap" style="display:none">
+          <a id="signoutLink" href="#">Sign out</a>
+        </div>
       </nav>
 
       <button class="menu-toggle" aria-expanded="false" aria-controls="mobile-menu" aria-label="Open menu">☰</button>
@@ -91,6 +95,9 @@ function buildHtml(storyCount, pageCount, unmoderatedCount) {
           <div class="menu-group">
             <h3>Account</h3>
             <div id="signinButton"></div>
+            <div id="signoutWrap" style="display:none">
+              <a id="signoutLink" href="#">Sign out</a>
+            </div>
           </div>
         </nav>
       </div>
@@ -107,14 +114,33 @@ function buildHtml(storyCount, pageCount, unmoderatedCount) {
         initGoogleSignIn,
         getIdToken,
         isAdmin,
+        signOut,
       } from './googleAuth.js';
       const al = document.getElementById('adminLink');
-      initGoogleSignIn({
-        onSignIn: () => {
-          if (isAdmin()) al.style.display = '';
-        },
+      const sbs = document.querySelectorAll('#signinButton');
+      const sws = document.querySelectorAll('#signoutWrap');
+      const sos = document.querySelectorAll('#signoutLink');
+      function showSignedIn() {
+        sbs.forEach(el => (el.style.display = 'none'));
+        sws.forEach(el => (el.style.display = ''));
+        if (isAdmin()) al.style.display = '';
+      }
+      function showSignedOut() {
+        sbs.forEach(el => (el.style.display = ''));
+        sws.forEach(el => (el.style.display = 'none'));
+        if (al) al.style.display = 'none';
+      }
+      initGoogleSignIn({ onSignIn: showSignedIn });
+      sos.forEach(link => {
+        link.addEventListener('click', async e => {
+          e.preventDefault();
+          await signOut();
+          showSignedOut();
+        });
       });
-      if (getIdToken() && isAdmin()) al.style.display = '';
+      if (getIdToken()) {
+        showSignedIn();
+      }
     </script>
     <script>
       (function () {

--- a/infra/cloud-functions/render-contents/htmlSnippets.js
+++ b/infra/cloud-functions/render-contents/htmlSnippets.js
@@ -25,6 +25,10 @@ export const PAGE_HTML = list => `<!doctype html>
         <a href="/new-story.html">New story</a>
         <a href="/mod.html">Moderate</a>
         <a href="/stats.html">Stats</a>
+        <div id="signinButton"></div>
+        <div id="signoutWrap" style="display:none">
+            <a id="signoutLink" href="#">Sign out</a>
+        </div>
       </nav>
 
       <button class="menu-toggle" aria-expanded="false" aria-controls="mobile-menu" aria-label="Open menu">☰</button>
@@ -70,28 +74,32 @@ export const PAGE_HTML = list => `<!doctype html>
         getIdToken,
         isAdmin,
       } from './googleAuth.js';
-        const sb = document.getElementById('signinButton');
-        const sw = document.getElementById('signoutWrap');
-        const so = document.getElementById('signoutLink');
+        const sbs = document.querySelectorAll('#signinButton');
+        const sws = document.querySelectorAll('#signoutWrap');
+        const sos = document.querySelectorAll('#signoutLink');
         const al = document.getElementById('adminLink');
+      function showSignedIn() {
+        sbs.forEach(el => (el.style.display = 'none'));
+        sws.forEach(el => (el.style.display = ''));
+        if (isAdmin()) al.style.display = '';
+      }
+      function showSignedOut() {
+        sbs.forEach(el => (el.style.display = ''));
+        sws.forEach(el => (el.style.display = 'none'));
+        if (al) al.style.display = 'none';
+      }
       initGoogleSignIn({
-        onSignIn: () => {
-          sb.style.display = 'none';
-          sw.style.display = '';
-          if (isAdmin()) al.style.display = '';
-        },
+        onSignIn: showSignedIn,
       });
-        so.addEventListener('click', async e => {
+      sos.forEach(link => {
+        link.addEventListener('click', async e => {
           e.preventDefault();
           await signOut();
-          sb.style.display = '';
-          sw.style.display = 'none';
-          if (al) al.style.display = 'none';
+          showSignedOut();
         });
+      });
       if (getIdToken()) {
-        sb.style.display = 'none';
-        sw.style.display = '';
-        if (isAdmin()) al.style.display = '';
+        showSignedIn();
       }
     </script>
     <script>

--- a/infra/cloud-functions/render-variant/buildAltsHtml.js
+++ b/infra/cloud-functions/render-variant/buildAltsHtml.js
@@ -52,6 +52,10 @@ export function buildAltsHtml(pageNumber, variants) {
         <a href="/new-story.html">New story</a>
         <a href="/mod.html">Moderate</a>
         <a href="/stats.html">Stats</a>
+        <div id="signinButton"></div>
+        <div id="signoutWrap" style="display:none">
+          <a id="signoutLink" href="#">Sign out</a>
+        </div>
       </nav>
 
       <button class="menu-toggle" aria-expanded="false" aria-controls="mobile-menu" aria-label="Open menu">☰</button>
@@ -78,6 +82,9 @@ export function buildAltsHtml(pageNumber, variants) {
           <div class="menu-group">
             <h3>Account</h3>
             <div id="signinButton"></div>
+            <div id="signoutWrap" style="display:none">
+              <a id="signoutLink" href="#">Sign out</a>
+            </div>
           </div>
         </nav>
       </div>
@@ -89,14 +96,33 @@ export function buildAltsHtml(pageNumber, variants) {
         initGoogleSignIn,
         getIdToken,
         isAdmin,
+        signOut,
       } from '../googleAuth.js';
       const al = document.getElementById('adminLink');
-      initGoogleSignIn({
-        onSignIn: () => {
-          if (isAdmin()) al.style.display = '';
-        },
+      const sbs = document.querySelectorAll('#signinButton');
+      const sws = document.querySelectorAll('#signoutWrap');
+      const sos = document.querySelectorAll('#signoutLink');
+      function showSignedIn() {
+        sbs.forEach(el => (el.style.display = 'none'));
+        sws.forEach(el => (el.style.display = ''));
+        if (isAdmin()) al.style.display = '';
+      }
+      function showSignedOut() {
+        sbs.forEach(el => (el.style.display = ''));
+        sws.forEach(el => (el.style.display = 'none'));
+        if (al) al.style.display = 'none';
+      }
+      initGoogleSignIn({ onSignIn: showSignedIn });
+      sos.forEach(link => {
+        link.addEventListener('click', async e => {
+          e.preventDefault();
+          await signOut();
+          showSignedOut();
+        });
       });
-      if (getIdToken() && isAdmin()) al.style.display = '';
+      if (getIdToken()) {
+        showSignedIn();
+      }
     </script>
     <script>
       (function () {

--- a/infra/cloud-functions/render-variant/buildHtml.js
+++ b/infra/cloud-functions/render-variant/buildHtml.js
@@ -98,6 +98,10 @@ export function buildHtml(
         <a href="/new-story.html">New story</a>
         <a href="/mod.html">Moderate</a>
         <a href="/stats.html">Stats</a>
+        <div id="signinButton"></div>
+        <div id="signoutWrap" style="display:none">
+          <a id="signoutLink" href="#">Sign out</a>
+        </div>
       </nav>
 
       <button class="menu-toggle" aria-expanded="false" aria-controls="mobile-menu" aria-label="Open menu">☰</button>
@@ -124,6 +128,9 @@ export function buildHtml(
           <div class="menu-group">
             <h3>Account</h3>
             <div id="signinButton"></div>
+            <div id="signoutWrap" style="display:none">
+              <a id="signoutLink" href="#">Sign out</a>
+            </div>
           </div>
         </nav>
       </div>
@@ -135,14 +142,33 @@ export function buildHtml(
         initGoogleSignIn,
         getIdToken,
         isAdmin,
+        signOut,
       } from '../googleAuth.js';
       const al = document.getElementById('adminLink');
-      initGoogleSignIn({
-        onSignIn: () => {
-          if (isAdmin()) al.style.display = '';
-        },
+      const sbs = document.querySelectorAll('#signinButton');
+      const sws = document.querySelectorAll('#signoutWrap');
+      const sos = document.querySelectorAll('#signoutLink');
+      function showSignedIn() {
+        sbs.forEach(el => (el.style.display = 'none'));
+        sws.forEach(el => (el.style.display = ''));
+        if (isAdmin()) al.style.display = '';
+      }
+      function showSignedOut() {
+        sbs.forEach(el => (el.style.display = ''));
+        sws.forEach(el => (el.style.display = 'none'));
+        if (al) al.style.display = 'none';
+      }
+      initGoogleSignIn({ onSignIn: showSignedIn });
+      sos.forEach(link => {
+        link.addEventListener('click', async e => {
+          e.preventDefault();
+          await signOut();
+          showSignedOut();
+        });
       });
-      if (getIdToken() && isAdmin()) al.style.display = '';
+      if (getIdToken()) {
+        showSignedIn();
+      }
     </script>
     <script>
       (function () {

--- a/infra/dendrite.css
+++ b/infra/dendrite.css
@@ -88,6 +88,7 @@ body {
 .nav-inline {
   display: none;
   gap: 16px;
+  align-items: center;
 }
 
 .menu-toggle {

--- a/infra/googleAuth.js
+++ b/infra/googleAuth.js
@@ -37,15 +37,13 @@ export const initGoogleSignIn = ({ onSignIn } = {}) => {
   const mql = window.matchMedia('(prefers-color-scheme: dark)');
 
   const renderButton = () => {
-    const el = document.getElementById('signinButton');
-    if (!el) {
-      return;
-    }
-    el.innerHTML = '';
-    google.accounts.id.renderButton(el, {
-      theme: mql.matches ? 'filled_black' : 'filled_blue',
-      size: 'large',
-      text: 'signin_with',
+    document.querySelectorAll('#signinButton').forEach(el => {
+      el.innerHTML = '';
+      google.accounts.id.renderButton(el, {
+        theme: mql.matches ? 'filled_black' : 'filled_blue',
+        size: 'large',
+        text: 'signin_with',
+      });
     });
   };
 

--- a/infra/mod.html
+++ b/infra/mod.html
@@ -22,6 +22,10 @@
         <a href="/new-story.html">New story</a>
         <a href="/mod.html">Moderate</a>
         <a href="/stats.html">Stats</a>
+        <div id="signinButton"></div>
+        <div id="signoutWrap" style="display: none">
+          <a id="signoutLink" href="#">Sign out</a>
+        </div>
       </nav>
 
       <button

--- a/infra/moderate.js
+++ b/infra/moderate.js
@@ -49,24 +49,26 @@ function startAnimation(id, text) {
  * Register the click handler for the sign-out button.
  */
 function wireSignOut() {
-  const signoutLink = document.getElementById('signoutLink');
-  if (!signoutLink) return;
-  signoutLink.addEventListener('click', async e => {
-    e.preventDefault();
-    await signOut();
-    const wrap = document.getElementById('signoutWrap');
-    const signin = document.getElementById('signinButton');
-    if (wrap) wrap.style.display = 'none';
-    if (signin) signin.style.display = '';
-    const adminLink = document.getElementById('adminLink');
-    if (adminLink) adminLink.style.display = 'none';
-    const content = document.getElementById('pageContent');
-    if (content) {
-      content.innerHTML = '';
-      content.style.display = 'none';
-    }
-    toggleApproveReject(true);
-    document.body.classList.remove('authed');
+  document.querySelectorAll('#signoutLink').forEach(link => {
+    link.addEventListener('click', async e => {
+      e.preventDefault();
+      await signOut();
+      document
+        .querySelectorAll('#signoutWrap')
+        .forEach(el => (el.style.display = 'none'));
+      document
+        .querySelectorAll('#signinButton')
+        .forEach(el => (el.style.display = ''));
+      const adminLink = document.getElementById('adminLink');
+      if (adminLink) adminLink.style.display = 'none';
+      const content = document.getElementById('pageContent');
+      if (content) {
+        content.innerHTML = '';
+        content.style.display = 'none';
+      }
+      toggleApproveReject(true);
+      document.body.classList.remove('authed');
+    });
   });
 }
 
@@ -175,10 +177,12 @@ async function submitRating(isApproved) {
 initGoogleSignIn({
   onSignIn: () => {
     document.body.classList.add('authed');
-    const signin = document.getElementById('signinButton');
-    const wrap = document.getElementById('signoutWrap');
-    signin.style.display = 'none';
-    wrap.style.display = '';
+    document
+      .querySelectorAll('#signinButton')
+      .forEach(el => (el.style.display = 'none'));
+    document
+      .querySelectorAll('#signoutWrap')
+      .forEach(el => (el.style.display = ''));
     const adminLink = document.getElementById('adminLink');
     if (isAdmin()) adminLink.style.display = '';
     wireSignOut();
@@ -204,8 +208,12 @@ export const authedFetch = async (url, opts = {}) => {
 
 if (getIdToken()) {
   document.body.classList.add('authed');
-  document.getElementById('signinButton').style.display = 'none';
-  document.getElementById('signoutWrap').style.display = '';
+  document
+    .querySelectorAll('#signinButton')
+    .forEach(el => (el.style.display = 'none'));
+  document
+    .querySelectorAll('#signoutWrap')
+    .forEach(el => (el.style.display = ''));
   if (isAdmin()) {
     const adminLink = document.getElementById('adminLink');
     if (adminLink) adminLink.style.display = '';

--- a/infra/new-page.html
+++ b/infra/new-page.html
@@ -18,6 +18,10 @@
         <a href="/new-story.html">New story</a>
         <a href="/mod.html">Moderate</a>
         <a href="/stats.html">Stats</a>
+        <div id="signinButton"></div>
+        <div id="signoutWrap" style="display: none">
+          <a id="signoutLink" href="#">Sign out</a>
+        </div>
       </nav>
 
       <button
@@ -102,9 +106,9 @@
       } from './googleAuth.js';
 
       document.addEventListener('DOMContentLoaded', () => {
-        const signin = document.getElementById('signinButton');
-        const signoutWrap = document.getElementById('signoutWrap');
-        const signoutLink = document.getElementById('signoutLink');
+        const signins = document.querySelectorAll('#signinButton');
+        const signoutWraps = document.querySelectorAll('#signoutWrap');
+        const signoutLinks = document.querySelectorAll('#signoutLink');
         const adminLink = document.getElementById('adminLink');
 
         const params = new URLSearchParams(window.location.search);
@@ -132,29 +136,32 @@
         }
         const saving = document.getElementById('saving');
 
-        initGoogleSignIn({
-          onSignIn: () => {
-            document.body.classList.add('authed');
-            signin.style.display = 'none';
-            signoutWrap.style.display = '';
-            if (isAdmin()) adminLink.style.display = '';
-          },
-        });
+        function showSignedIn() {
+          document.body.classList.add('authed');
+          signins.forEach(el => (el.style.display = 'none'));
+          signoutWraps.forEach(el => (el.style.display = ''));
+          if (isAdmin()) adminLink.style.display = '';
+        }
 
-        signoutLink.addEventListener('click', async e => {
-          e.preventDefault();
-          await signOut();
+        function showSignedOut() {
           document.body.classList.remove('authed');
-          signoutWrap.style.display = 'none';
-          signin.style.display = '';
+          signoutWraps.forEach(el => (el.style.display = 'none'));
+          signins.forEach(el => (el.style.display = ''));
           if (adminLink) adminLink.style.display = 'none';
+        }
+
+        initGoogleSignIn({ onSignIn: showSignedIn });
+
+        signoutLinks.forEach(link => {
+          link.addEventListener('click', async e => {
+            e.preventDefault();
+            await signOut();
+            showSignedOut();
+          });
         });
 
         if (getIdToken()) {
-          document.body.classList.add('authed');
-          signin.style.display = 'none';
-          signoutWrap.style.display = '';
-          if (isAdmin()) adminLink.style.display = '';
+          showSignedIn();
         }
 
         form.addEventListener('submit', async event => {

--- a/infra/new-story.html
+++ b/infra/new-story.html
@@ -18,6 +18,10 @@
         <a href="/new-story.html">New story</a>
         <a href="/mod.html">Moderate</a>
         <a href="/stats.html">Stats</a>
+        <div id="signinButton"></div>
+        <div id="signoutWrap" style="display: none">
+          <a id="signoutLink" href="#">Sign out</a>
+        </div>
       </nav>
 
       <button
@@ -112,34 +116,37 @@
         const form = document.querySelector('form');
         const button = form.querySelector("button[type='submit']");
         const originalText = button.textContent;
-        const signin = document.getElementById('signinButton');
-        const signoutWrap = document.getElementById('signoutWrap');
-        const signoutLink = document.getElementById('signoutLink');
+        const signins = document.querySelectorAll('#signinButton');
+        const signoutWraps = document.querySelectorAll('#signoutWrap');
+        const signoutLinks = document.querySelectorAll('#signoutLink');
         const adminLink = document.getElementById('adminLink');
 
-        initGoogleSignIn({
-          onSignIn: () => {
-            document.body.classList.add('authed');
-            signin.style.display = 'none';
-            signoutWrap.style.display = '';
-            if (isAdmin()) adminLink.style.display = '';
-          },
-        });
+        function showSignedIn() {
+          document.body.classList.add('authed');
+          signins.forEach(el => (el.style.display = 'none'));
+          signoutWraps.forEach(el => (el.style.display = ''));
+          if (isAdmin()) adminLink.style.display = '';
+        }
 
-        signoutLink.addEventListener('click', async e => {
-          e.preventDefault();
-          await signOut();
+        function showSignedOut() {
           document.body.classList.remove('authed');
-          signoutWrap.style.display = 'none';
-          signin.style.display = '';
+          signoutWraps.forEach(el => (el.style.display = 'none'));
+          signins.forEach(el => (el.style.display = ''));
           if (adminLink) adminLink.style.display = 'none';
+        }
+
+        initGoogleSignIn({ onSignIn: showSignedIn });
+
+        signoutLinks.forEach(link => {
+          link.addEventListener('click', async e => {
+            e.preventDefault();
+            await signOut();
+            showSignedOut();
+          });
         });
 
         if (getIdToken()) {
-          document.body.classList.add('authed');
-          signin.style.display = 'none';
-          signoutWrap.style.display = '';
-          if (isAdmin()) adminLink.style.display = '';
+          showSignedIn();
         }
 
         form.addEventListener('submit', async event => {

--- a/test/browser/googleAuth.test.js
+++ b/test/browser/googleAuth.test.js
@@ -31,7 +31,11 @@ describe('googleAuth', () => {
     sessionStorage.clear();
     global.window = { google: undefined };
     global.google = undefined;
-    global.document = { getElementById: jest.fn() };
+    const el = { innerHTML: '' };
+    global.document = {
+      getElementById: jest.fn().mockReturnValue(el),
+      querySelectorAll: jest.fn().mockReturnValue([el]),
+    };
     global.atob = str => Buffer.from(str, 'base64').toString('binary');
     ({ initGoogleSignIn, signOut, isAdmin } = await import(
       '../../infra/googleAuth.js'
@@ -65,7 +69,9 @@ describe('googleAuth', () => {
         listeners[ev] = cb;
       },
     };
-    global.document.getElementById.mockReturnValue({ innerHTML: '' });
+    const el = { innerHTML: '' };
+    global.document.getElementById.mockReturnValue(el);
+    global.document.querySelectorAll.mockReturnValue([el]);
     global.window = {
       google: { accounts: { id: { initialize: jest.fn(), renderButton } } },
       matchMedia: jest.fn().mockReturnValue(mql),

--- a/test/browser/moderate.test.js
+++ b/test/browser/moderate.test.js
@@ -19,6 +19,7 @@ describe('authedFetch', () => {
       },
     };
     sessionStorage.clear();
+    const el = { innerHTML: '', style: {} };
     global.window = {
       google: {
         accounts: {
@@ -35,7 +36,10 @@ describe('authedFetch', () => {
       }),
     };
     global.google = global.window.google;
-    global.document = { getElementById: jest.fn() };
+    global.document = {
+      getElementById: jest.fn(),
+      querySelectorAll: jest.fn().mockReturnValue([el]),
+    };
     global.fetch = jest.fn();
     ({ authedFetch } = await import('../../infra/moderate.js'));
   });


### PR DESCRIPTION
## Summary
- display sign-in/sign-out controls in desktop header beside Stats
- ensure Google auth button renders in all sign-in placeholders
- align header nav items for consistent layout

## Testing
- ✅ `npm test`
- ✅ `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6e69ffd8c832e9bfd66406976619e