### PR TITLE
Refactor page number generation in process-new-page function

### DIFF
--- a/infra/cloud-functions/process-new-page/findAvailablePageNumber.js
+++ b/infra/cloud-functions/process-new-page/findAvailablePageNumber.js
@@ -1,0 +1,19 @@
+/**
+ * Choose a random page number that is not already taken.
+ * @param {import('firebase-admin/firestore').Firestore} db Firestore instance.
+ * @param {number} [i=0] Recursion depth used to widen the search range.
+ * @returns {Promise<number>} A unique page number.
+ */
+export async function findAvailablePageNumber(db, i = 0) {
+  const max = 2 ** i;
+  const candidate = Math.floor(Math.random() * max) + 1;
+  const existing = await db
+    .collectionGroup('pages')
+    .where('number', '==', candidate)
+    .limit(1)
+    .get();
+  if (existing.empty) {
+    return candidate;
+  }
+  return findAvailablePageNumber(db, i + 1);
+}


### PR DESCRIPTION
## Summary
- extract page number selection logic into new `findAvailablePageNumber` helper
- reuse helper in `processNewPage` cloud function to simplify workflow

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6eeb7114c832e9cd7d399c9ac1bc1