### PR TITLE
Align bottom sheet line height

### DIFF
--- a/infra/dendrite.css
+++ b/infra/dendrite.css
@@ -130,6 +130,7 @@ body {
   padding: 12px 16px calc(16px + env(safe-area-inset-bottom));
   max-height: 85vh;
   overflow: auto;
+  line-height: 1.5;
   transform: translateY(6%);
   opacity: 0;
   transition:


### PR DESCRIPTION
## Summary
- Ensure bottom sheet text uses the same line height as the contents page by setting `line-height: 1.5` on the sheet container.

## Testing
- `npm test`
- `npm run lint` *(warnings: 129)*

------
https://chatgpt.com/codex/tasks/task_e_68a6ef5a5d6c832e931b292546b01adb