### PR TITLE
refactor: extract request validator

### DIFF
--- a/infra/cloud-functions/render-contents/index.js
+++ b/infra/cloud-functions/render-contents/index.js
@@ -168,12 +168,12 @@ async function render(deps = {}) {
 }
 
 /**
- *
- * @param req
- * @param res
- * @param deps
+ * Validate request origin and method.
+ * @param {import('express').Request} req HTTP request
+ * @param {import('express').Response} res HTTP response
+ * @returns {boolean} True if request is valid
  */
-async function handleRenderRequest(req, res, deps = {}) {
+function validateRequest(req, res) {
   const origin = req.get('Origin');
   if (!origin || allowed.includes(origin)) {
     if (origin) {
@@ -181,16 +181,29 @@ async function handleRenderRequest(req, res, deps = {}) {
     }
   } else {
     res.status(403).send('CORS');
-    return;
+    return false;
   }
   if (req.method === 'OPTIONS') {
     res.set('Access-Control-Allow-Methods', 'POST');
     res.set('Access-Control-Allow-Headers', 'Authorization');
     res.status(204).send('');
-    return;
+    return false;
   }
   if (req.method !== 'POST') {
     res.status(405).send('POST only');
+    return false;
+  }
+  return true;
+}
+
+/**
+ *
+ * @param req
+ * @param res
+ * @param deps
+ */
+async function handleRenderRequest(req, res, deps = {}) {
+  if (!validateRequest(req, res)) {
     return;
   }
   const authHeader = req.get('Authorization') || '';

--- a/test/cloud-functions/triggerRenderContents.test.js
+++ b/test/cloud-functions/triggerRenderContents.test.js
@@ -9,13 +9,14 @@ const { handleRenderRequest } = mod;
  */
 /**
  * Create a mock response object.
- * @returns {{status: jest.Mock, send: jest.Mock, json: jest.Mock}} Response
+ * @returns {{status: jest.Mock, send: jest.Mock, json: jest.Mock, set: jest.Mock}} Response
  */
 function createRes() {
   return {
     status: jest.fn().mockReturnThis(),
     send: jest.fn(),
     json: jest.fn(),
+    set: jest.fn(),
   };
 }
 
@@ -29,6 +30,21 @@ describe('handleRenderRequest', () => {
     const res = createRes();
     await handleRenderRequest(req, res);
     expect(res.status).toHaveBeenCalledWith(405);
+  });
+
+  test('handles OPTIONS preflight', async () => {
+    const req = { method: 'OPTIONS', get: () => '' };
+    const res = createRes();
+    await handleRenderRequest(req, res);
+    expect(res.status).toHaveBeenCalledWith(204);
+    expect(res.set).toHaveBeenCalledWith(
+      'Access-Control-Allow-Methods',
+      'POST'
+    );
+    expect(res.set).toHaveBeenCalledWith(
+      'Access-Control-Allow-Headers',
+      'Authorization'
+    );
   });
 
   test('rejects disallowed origin', async () => {


### PR DESCRIPTION
### Summary
- reduce `handleRenderRequest` cyclomatic complexity by moving origin and method checks into a reusable `validateRequest` helper
- cover CORS preflight path in triggerRenderContents tests

### Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a704d4b408832e879326d48484754a