### PR TITLE
Add Pico CSS to static pages

### DIFF
--- a/infra/404.html
+++ b/infra/404.html
@@ -5,6 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Page Not Found</title>
     <link rel="icon" href="/favicon.ico" />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.fluid.classless.min.css"
+    />
     <link rel="stylesheet" href="/dendrite.css" />
   </head>
   <body>

--- a/infra/admin.html
+++ b/infra/admin.html
@@ -5,6 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Admin</title>
     <link rel="icon" href="/favicon.ico" />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.fluid.classless.min.css"
+    />
     <link rel="stylesheet" href="/dendrite.css" />
   </head>
   <body>

--- a/infra/new-page.html
+++ b/infra/new-page.html
@@ -5,6 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>New Page</title>
     <link rel="icon" href="/favicon.ico" />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.fluid.classless.min.css"
+    />
     <link rel="stylesheet" href="/dendrite.css" />
   </head>
   <body>

--- a/infra/new-story.html
+++ b/infra/new-story.html
@@ -5,6 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>New Story</title>
     <link rel="icon" href="/favicon.ico" />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.fluid.classless.min.css"
+    />
     <link rel="stylesheet" href="/dendrite.css" />
   </head>
   <body>

--- a/public/2024-10-02/hello-world.html
+++ b/public/2024-10-02/hello-world.html
@@ -4,6 +4,10 @@
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>Hello World</title>
+        <link
+          rel="stylesheet"
+          href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.fluid.classless.min.css"
+        />
         <link rel="stylesheet" href="styles.css">
         <style>
             /* Flexbox layout to center the content */

--- a/public/2024-10-03/hi-lo.html
+++ b/public/2024-10-03/hi-lo.html
@@ -4,6 +4,10 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Hi-Lo Game</title>
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.fluid.classless.min.css"
+  />
   <link rel="stylesheet" href="styles.css">
   <style>
     body {

--- a/public/dnd-grid.html
+++ b/public/dnd-grid.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="UTF-8">
   <title>D&D Grid</title>
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.fluid.classless.min.css"
+  />
   <style>
     @page {
       size: A4 portrait;

--- a/public/index.html
+++ b/public/index.html
@@ -10,6 +10,10 @@
       href="https://fonts.googleapis.com/css2?family=Share+Tech+Mono&family=Sono:wght@200..800&display=swap"
       rel="stylesheet"
     />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.fluid.classless.min.css"
+    />
     <!-- Standard favicon -->
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />


### PR DESCRIPTION
## Summary
- Load Pico CSS on static admin, new page, new story, and 404 templates
- Include Pico CSS on public index and demo pages for consistent styling

## Testing
- `npm test`
- `npm run lint` (warnings: no-ternary, camelcase, jsdoc/require-returns, jsdoc/require-param-description, jsdoc/require-param-type)


------
https://chatgpt.com/codex/tasks/task_e_68a7cb0b1100832ea64b8ee7330dd2fc