### PR TITLE
Remove Pico CSS from public HTML pages

### DIFF
--- a/public/2024-10-02/hello-world.html
+++ b/public/2024-10-02/hello-world.html
@@ -4,10 +4,6 @@
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>Hello World</title>
-        <link
-          rel="stylesheet"
-          href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.fluid.classless.min.css"
-        />
         <link rel="stylesheet" href="styles.css">
         <style>
             /* Flexbox layout to center the content */

--- a/public/2024-10-03/hi-lo.html
+++ b/public/2024-10-03/hi-lo.html
@@ -4,10 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Hi-Lo Game</title>
-  <link
-    rel="stylesheet"
-    href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.fluid.classless.min.css"
-  />
   <link rel="stylesheet" href="styles.css">
   <style>
     body {

--- a/public/dnd-grid.html
+++ b/public/dnd-grid.html
@@ -3,10 +3,6 @@
 <head>
   <meta charset="UTF-8">
   <title>D&D Grid</title>
-  <link
-    rel="stylesheet"
-    href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.fluid.classless.min.css"
-  />
   <style>
     @page {
       size: A4 portrait;

--- a/public/index.html
+++ b/public/index.html
@@ -10,10 +10,6 @@
       href="https://fonts.googleapis.com/css2?family=Share+Tech+Mono&family=Sono:wght@200..800&display=swap"
       rel="stylesheet"
     />
-    <link
-      rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.fluid.classless.min.css"
-    />
     <!-- Standard favicon -->
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />


### PR DESCRIPTION
## Summary
- remove Pico CSS stylesheet links from static pages in `public`

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a7e3765b10832eb6a407dc69014cce