### PR TITLE
feat: orient sankey links vertically

### DIFF
--- a/infra/cloud-functions/generate-stats/index.js
+++ b/infra/cloud-functions/generate-stats/index.js
@@ -148,6 +148,44 @@ function buildHtml(storyCount, pageCount, unmoderatedCount, topStories = []) {
       }
     </script>
     <script>
+      // Generate vertical Sankey links by swapping x/y coordinates from
+      // d3.sankeyLinkHorizontal's output.
+      function sankeyLinkVertical() {
+        let curvature = 0.5;
+        function link(d) {
+          const y0 = d.source.x1;
+          const y1 = d.target.x0;
+          const yi = d3.interpolateNumber(y0, y1);
+          const y2 = yi(curvature);
+          const y3 = yi(1 - curvature);
+          const x0 = d.source.y1;
+          const x1 = d.target.y0;
+          return (
+            'M' +
+            x0 +
+            ',' +
+            y0 +
+            'C' +
+            x0 +
+            ',' +
+            y2 +
+            ' ' +
+            x1 +
+            ',' +
+            y3 +
+            ' ' +
+            x1 +
+            ',' +
+            y1
+          );
+        }
+        link.curvature = function (_) {
+          return arguments.length ? ((curvature = +_), link) : curvature;
+        };
+        return link;
+      }
+    </script>
+    <script>
       (function () {
         const data = ${JSON.stringify(topStories)};
         if (data.length) {
@@ -175,13 +213,13 @@ function buildHtml(storyCount, pageCount, unmoderatedCount, topStories = []) {
           });
           const svg = d3
             .create("svg")
-            .attr("viewBox", \`0 0 \${width} \${height}\`);
+            .attr("viewBox", \`0 0 \${height} \${width}\`);
           svg
             .append("g")
             .selectAll("path")
             .data(graph.links)
             .join("path")
-            .attr("d", d3.sankeyLinkVertical())
+            .attr("d", sankeyLinkVertical())
             .attr("stroke", "var(--muted)")
             .attr("stroke-width", d => d.width)
             .attr("fill", "none");
@@ -199,10 +237,10 @@ function buildHtml(storyCount, pageCount, unmoderatedCount, topStories = []) {
             .attr("fill", "var(--link)");
           node
             .append("text")
-            .attr("x", d => (d.y0 < width / 2 ? d.y1 + 6 : d.y0 - 6))
+            .attr("x", d => (d.y0 < height / 2 ? d.y1 + 6 : d.y0 - 6))
             .attr("y", d => (d.x0 + d.x1) / 2)
             .attr("dy", "0.35em")
-            .attr("text-anchor", d => (d.y0 < width / 2 ? "start" : "end"))
+            .attr("text-anchor", d => (d.y0 < height / 2 ? "start" : "end"))
             .text(d => d.name);
           document.getElementById("topStories").appendChild(svg.node());
         }


### PR DESCRIPTION
## Summary
- add helper to build top-to-bottom Sankey links
- use custom vertical link generator and swap viewBox dimensions

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a96a82d598832e83eff050835d71ac