### PR TITLE
feat: add lock timeout to terraform workflow

### DIFF
--- a/.github/workflows/deploy-terraform.yml
+++ b/.github/workflows/deploy-terraform.yml
@@ -44,7 +44,7 @@ jobs:
         run: terraform init
 
       - name: Terraform Plan
-        run: terraform plan -input=false -out=tfplan
+        run: terraform plan -lock-timeout=5m -input=false -out=tfplan
 
       - name: Terraform Apply
-        run: terraform apply -auto-approve tfplan
+        run: terraform apply -lock-timeout=5m -auto-approve tfplan


### PR DESCRIPTION
## Summary
- avoid concurrent state lock errors by adding lock timeout to Terraform plan and apply steps

## Testing
- `npm test`
- `npm run lint` *(warnings: Ternary operator used, JSDoc missing returns, camelcase)*

------
https://chatgpt.com/codex/tasks/task_e_68aa47032cf8832e8ad0fa28ecf5fda9