### PR TITLE
Wait for auth state before showing admin panel

### DIFF
--- a/infra/admin.js
+++ b/infra/admin.js
@@ -1,5 +1,8 @@
 import { initGoogleSignIn, getIdToken, signOut } from './googleAuth.js';
-import { getAuth } from 'https://www.gstatic.com/firebasejs/12.0.0/firebase-auth.js';
+import {
+  getAuth,
+  onAuthStateChanged,
+} from 'https://www.gstatic.com/firebasejs/12.0.0/firebase-auth.js';
 
 const ADMIN_UID = 'qcYSrXTaj1MZUoFsAloBwT86GNM2';
 const RENDER_URL =
@@ -142,24 +145,10 @@ function wireSignOut() {
     link.addEventListener('click', async e => {
       e.preventDefault();
       await signOut();
-      document
-        .querySelectorAll('#signoutWrap')
-        .forEach(el => (el.style.display = 'none'));
-      document
-        .querySelectorAll('#signinButton')
-        .forEach(el => (el.style.display = ''));
     });
   });
 }
 
-initGoogleSignIn({
-  onSignIn: () => {
-    checkAccess();
-    wireSignOut();
-  },
-});
-
-if (getIdToken()) {
-  checkAccess();
-  wireSignOut();
-}
+wireSignOut();
+onAuthStateChanged(getAuth(), checkAccess);
+initGoogleSignIn();


### PR DESCRIPTION
## Summary
- Use Firebase `onAuthStateChanged` on the admin page to show content only after auth rehydrates
- Simplify sign-out wiring to rely on auth state updates

## Testing
- `npm test`
- `npm run lint` *(warnings: Ternary operator used, camelcase, Missing JSDoc returns, Missing JSDoc param description, Missing JSDoc param type)*

------
https://chatgpt.com/codex/tasks/task_e_68aa48a6cc14832e9fbb6e922a89bc38