### PR TITLE
Style Dendrite buttons with theme colors

### DIFF
--- a/infra/dendrite.css
+++ b/infra/dendrite.css
@@ -307,8 +307,22 @@ form textarea {
   min-height: 8em;
 }
 
-form button {
+button {
   padding: var(--s2) var(--s3);
+  border: 1px solid var(--link);
+  border-radius: var(--s1);
+  background: var(--link);
+  color: var(--bg);
+  cursor: pointer;
+}
+
+button:hover,
+button:focus-visible {
+  background: var(--link-hover);
+  outline: none;
+}
+
+form button {
   width: fit-content;
 }
 


### PR DESCRIPTION
### Summary
- use Dendrite theme colors for button background, text and hover states

### Testing
- `npm test`
- `npm run lint` *(warnings: Ternary operator used, camelcase, missing JSDoc annotations)*

------
https://chatgpt.com/codex/tasks/task_e_68aa4af8841c832ebf32f350a54139aa