### PR TITLE
Support weighted variant links

### DIFF
--- a/infra/cloud-functions/render-variant/buildHtml.js
+++ b/infra/cloud-functions/render-variant/buildHtml.js
@@ -46,7 +46,18 @@ export function buildHtml(
           ? `/p/${opt.targetPageNumber}${opt.targetVariantName || ''}.html`
           : `../new-page.html?option=${slug}`;
       const optionHtml = renderInlineMarkdown(opt.content);
-      return `<li><a href="${href}">${optionHtml}</a></li>`;
+      const attrs = [
+        'class="variant-link"',
+        `data-link-id="${slug}"`,
+        `href="${href}"`,
+      ];
+      if (opt.targetVariants) {
+        const variantsAttr = opt.targetVariants
+          .map(v => `${opt.targetPageNumber}${v.name}:${v.weight ?? 1}`)
+          .join(',');
+        attrs.push(`data-variants="${escapeHtml(variantsAttr)}"`);
+      }
+      return `<li><a ${attrs.join(' ')}>${optionHtml}</a></li>`;
     })
     .join('');
   const title = storyTitle ? `<h1>${escapeHtml(storyTitle)}</h1>` : '';
@@ -202,6 +213,82 @@ export function buildHtml(
         addEventListener('keydown', e => {
           if (e.key === 'Escape' && !overlay.hidden) closeMenu();
         });
+      })();
+    </script>
+    <script>
+      (function () {
+        function pickWeighted(pairs) {
+          let total = 0;
+          for (const p of pairs) {
+            const w = Number(p.w);
+            if (!Number.isFinite(w) || w <= 0) continue;
+            total += w;
+          }
+          if (total <= 0) return null;
+          const a = new Uint32Array(1);
+          crypto.getRandomValues(a);
+          const u = (a[0] + 1) / 4294967297;
+          let threshold = u * total;
+          for (const p of pairs) {
+            const w = Number(p.w);
+            if (!Number.isFinite(w) || w <= 0) continue;
+            threshold -= w;
+            if (threshold <= 0) return p.slug;
+          }
+          return pairs[pairs.length - 1]?.slug ?? null;
+        }
+        function parseVariants(attr) {
+          if (!attr) return [];
+          const trimmed = attr.trim();
+          if (!trimmed) return [];
+          if (trimmed[0] === '[' || trimmed[0] === '{') {
+            try {
+              const arr = JSON.parse(trimmed);
+              if (Array.isArray(arr))
+                return arr.map(x => ({ slug: x.slug, w: x.w }));
+            } catch {}
+            return [];
+          }
+          return trimmed
+            .split(',')
+            .map(pair => {
+              const [slug, w] = pair.split(':');
+              return { slug: slug?.trim(), w: Number(w ?? 1) };
+            })
+            .filter(x => x.slug);
+        }
+        function rewriteLink(a) {
+          const raw = a.getAttribute('data-variants');
+          const pairs = parseVariants(raw);
+          if (!pairs.length) return;
+          const chosen = pickWeighted(pairs);
+          if (!chosen) return;
+          try {
+            const href = new URL(a.getAttribute('href', 2), location.href);
+            const chosenUrl = new URL(href, location.href);
+            const parts = chosenUrl.pathname.split('/');
+            parts[parts.length - 1] = chosen + '.html';
+            chosenUrl.pathname = parts.join('/');
+            const linkId = a.getAttribute('data-link-id');
+            if (linkId && !chosenUrl.searchParams.has('from')) {
+              chosenUrl.searchParams.set('from', linkId);
+              chosenUrl.searchParams.set('to', chosen);
+            }
+            a.setAttribute('href', chosenUrl.toString());
+            a.setAttribute('data-chosen-variant', chosen);
+          } catch {}
+        }
+        function init() {
+          const links = document.querySelectorAll(
+            'a.variant-link[data-variants]'
+          );
+          links.forEach(rewriteLink);
+        }
+        if (document.readyState === 'loading') {
+          document.addEventListener('DOMContentLoaded', init);
+        } else {
+          init();
+        }
       })();
     </script>
   </body>

--- a/test/cloud-functions/buildHtml.test.js
+++ b/test/cloud-functions/buildHtml.test.js
@@ -30,7 +30,7 @@ describe('buildHtml', () => {
       { content: 'Go left', position: 0 },
     ]);
     expect(html).toContain(
-      '<li><a href="../new-page.html?option=12-a-0">Go left</a></li>'
+      '<li><a class="variant-link" data-link-id="12-a-0" href="../new-page.html?option=12-a-0">Go left</a></li>'
     );
   });
 
@@ -43,7 +43,28 @@ describe('buildHtml', () => {
         targetVariantName: 'b',
       },
     ]);
-    expect(html).toContain('<li><a href="/p/42b.html">Go right</a></li>');
+    expect(html).toContain(
+      '<li><a class="variant-link" data-link-id="5-a-1" href="/p/42b.html">Go right</a></li>'
+    );
+  });
+
+  test('includes data-variants when multiple target variants provided', () => {
+    const html = buildHtml(5, 'a', 'content', [
+      {
+        content: 'Go elsewhere',
+        position: 0,
+        targetPageNumber: 10,
+        targetVariantName: 'a',
+        targetVariants: [
+          { name: 'a', weight: 1 },
+          { name: 'b', weight: 2 },
+        ],
+      },
+    ]);
+    expect(html).toContain(
+      '<li><a class="variant-link" data-link-id="5-a-0" href="/p/10a.html" data-variants="10a:1,10b:2">Go elsewhere</a></li>'
+    );
+    expect(html).toContain('a.variant-link[data-variants]');
   });
 
   test('includes author below options when provided', () => {
@@ -94,7 +115,7 @@ describe('buildHtml', () => {
       { content: 'Go *left* and **bold**', position: 0 },
     ]);
     expect(html).toContain(
-      '<li><a href="../new-page.html?option=1-a-0">Go <em>left</em> and <strong>bold</strong></a></li>'
+      '<li><a class="variant-link" data-link-id="1-a-0" href="../new-page.html?option=1-a-0">Go <em>left</em> and <strong>bold</strong></a></li>'
     );
   });
 

--- a/test/cloud-functions/renderVariant.test.js
+++ b/test/cloud-functions/renderVariant.test.js
@@ -87,6 +87,34 @@ describe('render', () => {
     expect(mockSave.mock.calls[0][1]).toEqual({ contentType: 'text/html' });
   });
 
+  test('includes data-variants for options linking to multi-variant page', async () => {
+    const variantCollection = {
+      orderBy: jest.fn().mockReturnThis(),
+      get: jest.fn().mockResolvedValue({
+        empty: false,
+        docs: [
+          { data: () => ({ name: 'a', visibility: 1 }) },
+          { data: () => ({ name: 'b', visibility: 1 }) },
+        ],
+      }),
+    };
+    const targetPageRef = {
+      get: jest.fn().mockResolvedValue({
+        exists: true,
+        data: () => ({ number: 10 }),
+      }),
+      collection: jest.fn(() => variantCollection),
+    };
+    const snap = createSnap([
+      { content: 'Go', position: 0, targetPage: targetPageRef },
+    ]);
+    await render(snap, { params: { storyId: 's1', variantId: 'v1' } });
+    const html = mockSave.mock.calls[0][0];
+    expect(html).toContain(
+      '<li><a class="variant-link" data-link-id="5-a-0" href="/p/10a.html" data-variants="10a:1,10b:1">Go</a></li>'
+    );
+  });
+
   test('logs error when cache invalidation fails', async () => {
     const snap = createSnap([{ content: 'Go', position: 0 }]);
     const consoleError = jest


### PR DESCRIPTION
## Summary
- allow render-variant to gather all visible target variants and their weights
- embed variant link metadata and script to pick weighted targets on the client
- test weighted variant selection and ensure existing links include tracking attributes

## Testing
- ✅ `npm run lint`
- ✅ `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa4d62d4e4832eb7469cd531bdcdfa