### PR TITLE
refactor: extract page ref utility

### DIFF
--- a/infra/cloud-functions/mark-variant-dirty/index.js
+++ b/infra/cloud-functions/mark-variant-dirty/index.js
@@ -47,6 +47,15 @@ function findPagesSnap(database, pageNumber) {
 }
 
 /**
+ * Extract a page reference from a pages snapshot.
+ * @param {import('firebase-admin/firestore').QuerySnapshot} pagesSnap Pages snapshot.
+ * @returns {import('firebase-admin/firestore').DocumentReference | null} Page doc ref.
+ */
+function pageRefFromSnap(pagesSnap) {
+  return pagesSnap.docs?.[0]?.ref || null;
+}
+
+/**
  * Find a reference to the page document.
  * @param {import('firebase-admin/firestore').Firestore} database Firestore instance.
  * @param {number} pageNumber Page number.
@@ -54,7 +63,7 @@ function findPagesSnap(database, pageNumber) {
  */
 async function findPageRef(database, pageNumber) {
   const pagesSnap = await findPagesSnap(database, pageNumber);
-  return pagesSnap.docs?.[0]?.ref || null;
+  return pageRefFromSnap(pagesSnap);
 }
 
 /**


### PR DESCRIPTION
## Summary
- factor out `pageRefFromSnap` to derive page document reference from snapshot
- reuse utility in `findPageRef` for clearer logic

## Testing
- `npm test`
- `npm run lint` (warnings)


------
https://chatgpt.com/codex/tasks/task_e_68aaab10130c832eaede80b1dd263940