### PR TITLE
Prevent Enter key submission in story and page forms

### DIFF
--- a/infra/new-page.html
+++ b/infra/new-page.html
@@ -168,6 +168,15 @@
           showSignedIn();
         }
 
+        form.addEventListener('keydown', event => {
+          if (
+            event.key === 'Enter' &&
+            event.target.matches('input[type="text"]')
+          ) {
+            event.preventDefault();
+          }
+        });
+
         form.addEventListener('submit', async event => {
           event.preventDefault();
           button.disabled = true;

--- a/infra/new-story.html
+++ b/infra/new-story.html
@@ -153,6 +153,15 @@
           showSignedIn();
         }
 
+        form.addEventListener('keydown', event => {
+          if (
+            event.key === 'Enter' &&
+            event.target.matches('input[type="text"]')
+          ) {
+            event.preventDefault();
+          }
+        });
+
         form.addEventListener('submit', async event => {
           event.preventDefault();
           button.disabled = true;


### PR DESCRIPTION
## Summary
- avoid accidental submissions by canceling Enter key presses in new story and page forms

## Testing
- `npm test`
- `npm run lint` (warnings: 136)

------
https://chatgpt.com/codex/tasks/task_e_68aab2264548832e927121f188534d7b