### PR TITLE
Include story title in page titles

### DIFF
--- a/infra/cloud-functions/render-variant/buildHtml.js
+++ b/infra/cloud-functions/render-variant/buildHtml.js
@@ -26,6 +26,8 @@ function renderInlineMarkdown(text) {
  * @param {string} [author] Author name.
  * @param parentUrl
  * @param firstPageUrl
+ * @param {boolean} [showTitleHeading] Whether to include the story title as a
+ *   page heading.
  * @returns {string} HTML page.
  */
 export function buildHtml(
@@ -36,7 +38,8 @@ export function buildHtml(
   storyTitle = '',
   author = '',
   parentUrl = '',
-  firstPageUrl = ''
+  firstPageUrl = '',
+  showTitleHeading = true
 ) {
   const items = options
     .map(opt => {
@@ -60,7 +63,8 @@ export function buildHtml(
       return `<li><a ${attrs.join(' ')}>${optionHtml}</a></li>`;
     })
     .join('');
-  const title = storyTitle ? `<h1>${escapeHtml(storyTitle)}</h1>` : '';
+  const title =
+    storyTitle && showTitleHeading ? `<h1>${escapeHtml(storyTitle)}</h1>` : '';
   const headTitle = storyTitle
     ? `Dendrite - ${escapeHtml(storyTitle)}`
     : 'Dendrite';

--- a/infra/cloud-functions/render-variant/index.js
+++ b/infra/cloud-functions/render-variant/index.js
@@ -161,9 +161,8 @@ async function render(snap, ctx) {
   let firstPageUrl;
   if (storySnap.exists) {
     const storyData = storySnap.data();
-    if (!page.incomingOption) {
-      storyTitle = storyData.title || '';
-    } else if (storyData.rootPage) {
+    storyTitle = storyData.title || '';
+    if (page.incomingOption && storyData.rootPage) {
       try {
         const rootPageSnap = await storyData.rootPage.get();
         if (rootPageSnap.exists) {
@@ -215,7 +214,8 @@ async function render(snap, ctx) {
     storyTitle,
     authorName,
     parentUrl,
-    firstPageUrl
+    firstPageUrl,
+    !page.incomingOption
   );
   const filePath = `p/${page.number}${variant.name}.html`;
   const openVariant = options.some(opt => opt.targetPageNumber === undefined);

--- a/test/cloud-functions/buildHtml.test.js
+++ b/test/cloud-functions/buildHtml.test.js
@@ -26,6 +26,12 @@ describe('buildHtml', () => {
     expect(html).toContain('<title>Dendrite - My Story</title>');
   });
 
+  test('omits heading when showTitleHeading is false', () => {
+    const html = buildHtml(1, 'a', 'hello', [], 'My Story', '', '', '', false);
+    expect(html).toContain('<title>Dendrite - My Story</title>');
+    expect(html).not.toContain('<h1>My Story</h1>');
+  });
+
   test('links option without target page using slug', () => {
     const html = buildHtml(12, 'a', 'content', [
       { content: 'Go left', position: 0 },

--- a/test/cloud-functions/renderVariant.test.js
+++ b/test/cloud-functions/renderVariant.test.js
@@ -204,6 +204,40 @@ describe('render', () => {
     expect(html).toContain('<a href="/p/1a.html">First page</a>');
   });
 
+  test('includes story title in head title for non-root pages', async () => {
+    const snap = createSnap([{ content: 'Go', position: 0 }]);
+    snap.data = () => ({
+      name: 'a',
+      content: 'content',
+      incomingOption: 'stories/s1/pages/p1/variants/pv/options/o1',
+    });
+
+    const parentPageRef = {
+      get: jest.fn().mockResolvedValue({
+        exists: true,
+        data: () => ({ number: 7 }),
+      }),
+    };
+    const parentVariantRef = {
+      get: jest.fn().mockResolvedValue({
+        exists: true,
+        data: () => ({ name: 'b' }),
+      }),
+      parent: { parent: parentPageRef },
+    };
+    mockDoc.mockReturnValue({
+      parent: { parent: parentVariantRef },
+      get: jest
+        .fn()
+        .mockResolvedValue({ exists: true, data: () => ({ position: 2 }) }),
+    });
+
+    await render(snap, { params: { storyId: 's1', variantId: 'v1' } });
+    const html = mockSave.mock.calls[0][0];
+    expect(html).toContain('<title>Dendrite - Story</title>');
+    expect(html).not.toContain('<h1>Story</h1>');
+  });
+
   test('includes rewrite link with page parameter', async () => {
     const snap = createSnap([{ content: 'Go', position: 0 }]);
     await render(snap, { params: { storyId: 's1', variantId: 'v1' } });


### PR DESCRIPTION
## Summary
- Add `showTitleHeading` flag to variant HTML builder to allow omitting the `<h1>` while keeping the story title in the document title
- Always supply the story title when rendering variants and show the heading only on the first page
- Test rendering and builder logic to ensure non-root pages include the story title in the tab title

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68aba83b15b0832e9205323ed5311add