### PR TITLE
Ensure authors collection entries for new submissions

### DIFF
--- a/infra/cloud-functions/process-new-page/index.js
+++ b/infra/cloud-functions/process-new-page/index.js
@@ -126,6 +126,14 @@ export const processNewPage = functions
     }
     batch.update(snap.ref, { processed: true });
 
+    if (sub.authorId) {
+      const authorRef = db.doc(`authors/${sub.authorId}`);
+      const authorSnap = await authorRef.get();
+      if (!authorSnap.exists) {
+        batch.set(authorRef, { uuid: crypto.randomUUID() });
+      }
+    }
+
     await batch.commit();
     return null;
   });

--- a/infra/cloud-functions/process-new-story/index.js
+++ b/infra/cloud-functions/process-new-story/index.js
@@ -76,6 +76,14 @@ export const processNewStory = functions
     batch.set(db.doc(`storyStats/${storyId}`), { variantCount: 1 });
     batch.update(snap.ref, { processed: true });
 
+    if (sub.authorId) {
+      const authorRef = db.doc(`authors/${sub.authorId}`);
+      const authorSnap = await authorRef.get();
+      if (!authorSnap.exists) {
+        batch.set(authorRef, { uuid: crypto.randomUUID() });
+      }
+    }
+
     await batch.commit();
     return null;
   });


### PR DESCRIPTION
## Summary
- Ensure `processNewStory` creates an author document with a random `uuid` when a new story submission has an `authorId`
- Ensure `processNewPage` creates an author document with a random `uuid` when a new page submission has an `authorId`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68abfd1e4c88832e87c0d6408b14ed9a