### PR TITLE
Remove block margin spacing in contents list

### DIFF
--- a/infra/dendrite.css
+++ b/infra/dendrite.css
@@ -244,7 +244,7 @@ ol.contents a:focus-visible {
   outline: none;
 }
 
-ol.contents li:nth-child(10n + 1) {
+ol.contents li:first-child {
   margin-top: var(--s2);
 }
 


### PR DESCRIPTION
## Summary
- Replace nth-child block spacing with first-child rule so contents page renders as a single continuous list

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac0cfb5c74832e882aa38e7eadeec5