### PR TITLE
Inject firebase helpers into findPageRef

### DIFF
--- a/test/cloud-functions/markVariantDirty.test.js
+++ b/test/cloud-functions/markVariantDirty.test.js
@@ -172,4 +172,22 @@ describe('markVariantDirtyImpl', () => {
     const ok = await markVariantDirtyImpl(5, 'a', { db });
     expect(ok).toBe(false);
   });
+
+  test('injects firebase helpers into findPageRef', async () => {
+    const variantsQuery = {
+      where: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      get: jest.fn().mockResolvedValue({ empty: true }),
+    };
+    const pageRef = { collection: () => variantsQuery };
+    const findPagesSnap = jest.fn().mockResolvedValue('snap');
+    const refFromSnap = jest.fn().mockReturnValue(pageRef);
+    const db = {};
+    await markVariantDirtyImpl(5, 'a', {
+      db,
+      firebase: { findPagesSnap, refFromSnap },
+    });
+    expect(findPagesSnap).toHaveBeenCalledWith(db, 5);
+    expect(refFromSnap).toHaveBeenCalledWith('snap');
+  });
 });


### PR DESCRIPTION
## Summary
- allow `findPageRef` to accept a `firebase` object providing `findPagesSnap` and `refFromSnap`
- propagate firebase helpers through `findVariantRef` and `markVariantDirtyImpl`
- test dependency injection of firebase helpers

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac225bd3d0832e846519d0c90fb587