### PR TITLE
Fix Sankey link direction in stats generator

### DIFF
--- a/infra/cloud-functions/generate-stats/index.js
+++ b/infra/cloud-functions/generate-stats/index.js
@@ -166,8 +166,8 @@ function buildHtml(storyCount, pageCount, unmoderatedCount, topStories = []) {
           data.map(d => ({ name: d.title }))
         );
         const links = data.map((d, i) => ({
-          source: i + 1,
-          target: 0,
+          source: 0,
+          target: i + 1,
           value: d.variantCount,
         }));
 


### PR DESCRIPTION
## Summary
- Build Sankey links from the root node to each story node when generating stats

## Testing
- `npm test`
- `npm run lint` *(fails: 138 warnings, 0 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68acfc48d798832ea0ab827621b313ab