### PR TITLE
Inject variant snapshot into markVariantDirty

### DIFF
--- a/infra/cloud-functions/mark-variant-dirty/index.js
+++ b/infra/cloud-functions/mark-variant-dirty/index.js
@@ -91,17 +91,25 @@ function findVariantsSnap(pageRef, variantName) {
  * @param {import('firebase-admin/firestore').Firestore} database Firestore instance.
  * @param {number} pageNumber Page number.
  * @param {string} variantName Variant name.
- * @param {{findPagesSnap: typeof findPagesSnap, refFromSnap: typeof refFromSnap}} [firebase]
- * Optional Firebase helpers.
+ * @param {{
+ *   findPagesSnap: typeof findPagesSnap,
+ *   findVariantsSnap: typeof findVariantsSnap,
+ *   refFromSnap: typeof refFromSnap,
+ * }} [firebase] Optional Firebase helpers.
  * @returns {Promise<import('firebase-admin/firestore').DocumentReference | null>} Variant doc ref.
  */
-async function findVariantRef(database, pageNumber, variantName, firebase) {
+async function findVariantRef(
+  database,
+  pageNumber,
+  variantName,
+  firebase = { findPagesSnap, findVariantsSnap, refFromSnap }
+) {
   const pageRef = await findPageRef(database, pageNumber, firebase);
   if (!pageRef) {
     return null;
   }
-  const variantsSnap = await findVariantsSnap(pageRef, variantName);
-  return refFromSnap(variantsSnap);
+  const variantsSnap = await firebase.findVariantsSnap(pageRef, variantName);
+  return firebase.refFromSnap(variantsSnap);
 }
 
 /**
@@ -121,6 +129,7 @@ function updateVariantDirty(variantRef) {
  *   db?: import('firebase-admin/firestore').Firestore,
  *   firebase?: {
  *     findPagesSnap: typeof findPagesSnap,
+ *     findVariantsSnap: typeof findVariantsSnap,
  *     refFromSnap: typeof refFromSnap,
  *   },
  * }} [deps] Optional dependencies.

--- a/test/cloud-functions/markVariantDirty.test.js
+++ b/test/cloud-functions/markVariantDirty.test.js
@@ -173,21 +173,24 @@ describe('markVariantDirtyImpl', () => {
     expect(ok).toBe(false);
   });
 
-  test('injects firebase helpers into findPageRef', async () => {
-    const variantsQuery = {
-      where: jest.fn().mockReturnThis(),
-      limit: jest.fn().mockReturnThis(),
-      get: jest.fn().mockResolvedValue({ empty: true }),
-    };
-    const pageRef = { collection: () => variantsQuery };
-    const findPagesSnap = jest.fn().mockResolvedValue('snap');
-    const refFromSnap = jest.fn().mockReturnValue(pageRef);
+  test('injects firebase helpers into findVariantRef', async () => {
+    const variantRef = { update: jest.fn() };
+    const pageRef = {};
+    const findPagesSnap = jest.fn().mockResolvedValue('psnap');
+    const findVariantsSnap = jest.fn().mockResolvedValue('vsnap');
+    const refFromSnap = jest
+      .fn()
+      .mockReturnValueOnce(pageRef)
+      .mockReturnValueOnce(variantRef);
     const db = {};
     await markVariantDirtyImpl(5, 'a', {
       db,
-      firebase: { findPagesSnap, refFromSnap },
+      firebase: { findPagesSnap, findVariantsSnap, refFromSnap },
     });
     expect(findPagesSnap).toHaveBeenCalledWith(db, 5);
-    expect(refFromSnap).toHaveBeenCalledWith('snap');
+    expect(refFromSnap).toHaveBeenNthCalledWith(1, 'psnap');
+    expect(findVariantsSnap).toHaveBeenCalledWith(pageRef, 'a');
+    expect(refFromSnap).toHaveBeenNthCalledWith(2, 'vsnap');
+    expect(variantRef.update).toHaveBeenCalledWith({ dirty: null });
   });
 });


### PR DESCRIPTION
## Summary
- Use injected Firebase helpers to locate variant documents in `findVariantRef`
- Allow `markVariantDirtyImpl` to accept `findVariantsSnap` for variant lookups
- Test that `findVariantRef` uses injected Firebase functions

## Testing
- `npm test`
- `npm run lint` *(fails: 139 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68acfd2c1f80832eb74079d84064543d