### PR TITLE
refactor: extract findPageRef helper

### DIFF
--- a/infra/cloud-functions/mark-variant-dirty/findPageRef.js
+++ b/infra/cloud-functions/mark-variant-dirty/findPageRef.js
@@ -1,0 +1,39 @@
+/**
+ * Find pages snapshot for a page number.
+ * @param {import('firebase-admin/firestore').Firestore} database Firestore instance.
+ * @param {number} pageNumber Page number.
+ * @returns {Promise<import('firebase-admin/firestore').QuerySnapshot>} Pages snapshot.
+ */
+export function findPagesSnap(database, pageNumber) {
+  return database
+    .collectionGroup('pages')
+    .where('number', '==', pageNumber)
+    .limit(1)
+    .get();
+}
+
+/**
+ * Extract a document reference from a query snapshot.
+ * @param {import('firebase-admin/firestore').QuerySnapshot} snap Query snapshot.
+ * @returns {import('firebase-admin/firestore').DocumentReference | null} Document ref.
+ */
+export function refFromSnap(snap) {
+  return snap.docs?.[0]?.ref || null;
+}
+
+/**
+ * Find a reference to the page document.
+ * @param {import('firebase-admin/firestore').Firestore} database Firestore instance.
+ * @param {number} pageNumber Page number.
+ * @param {{findPagesSnap: typeof findPagesSnap, refFromSnap: typeof refFromSnap}} [firebase]
+ * Optional Firebase helpers.
+ * @returns {Promise<import('firebase-admin/firestore').DocumentReference | null>} Page doc ref.
+ */
+export async function findPageRef(
+  database,
+  pageNumber,
+  firebase = { findPagesSnap, refFromSnap }
+) {
+  const pagesSnap = await firebase.findPagesSnap(database, pageNumber);
+  return firebase.refFromSnap(pagesSnap);
+}

--- a/infra/cloud-functions/mark-variant-dirty/index.js
+++ b/infra/cloud-functions/mark-variant-dirty/index.js
@@ -4,6 +4,7 @@ import { getAuth } from 'firebase-admin/auth';
 import * as functions from 'firebase-functions';
 import express from 'express';
 import cors from 'cors';
+import { findPageRef, findPagesSnap, refFromSnap } from './findPageRef.js';
 
 initializeApp();
 const db = getFirestore();
@@ -31,46 +32,6 @@ app.use(
 );
 
 app.use(express.json());
-
-/**
- * Find pages snapshot for a page number.
- * @param {import('firebase-admin/firestore').Firestore} database Firestore instance.
- * @param {number} pageNumber Page number.
- * @returns {Promise<import('firebase-admin/firestore').QuerySnapshot>} Pages snapshot.
- */
-function findPagesSnap(database, pageNumber) {
-  return database
-    .collectionGroup('pages')
-    .where('number', '==', pageNumber)
-    .limit(1)
-    .get();
-}
-
-/**
- * Extract a document reference from a query snapshot.
- * @param {import('firebase-admin/firestore').QuerySnapshot} snap Query snapshot.
- * @returns {import('firebase-admin/firestore').DocumentReference | null} Document ref.
- */
-function refFromSnap(snap) {
-  return snap.docs?.[0]?.ref || null;
-}
-
-/**
- * Find a reference to the page document.
- * @param {import('firebase-admin/firestore').Firestore} database Firestore instance.
- * @param {number} pageNumber Page number.
- * @param {{findPagesSnap: typeof findPagesSnap, refFromSnap: typeof refFromSnap}} [firebase]
- * Optional Firebase helpers.
- * @returns {Promise<import('firebase-admin/firestore').DocumentReference | null>} Page doc ref.
- */
-async function findPageRef(
-  database,
-  pageNumber,
-  firebase = { findPagesSnap, refFromSnap }
-) {
-  const pagesSnap = await firebase.findPagesSnap(database, pageNumber);
-  return firebase.refFromSnap(pagesSnap);
-}
 
 /**
  * Find variants snapshot for a variant name.


### PR DESCRIPTION
## Summary
- extract `findPageRef` and related helpers into `findPageRef.js`
- import new helpers in `index.js` for mark-variant-dirty function

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad21827490832e9ba9f19bf34ab37c