### PR TITLE
Add Dendrite about page

### DIFF
--- a/infra/about.html
+++ b/infra/about.html
@@ -1,0 +1,172 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>Dendrite - About</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Share+Tech+Mono&family=Sono:wght@200..800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+    <link rel="icon" href="/favicon.ico" type="image/x-icon" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="192x192"
+      href="/android-chrome-192x192.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="512x512"
+      href="/android-chrome-512x512.png"
+    />
+    <link rel="manifest" href="/site.webmanifest" />
+    <style>
+      body {
+        background-color: #121212;
+        background-image: linear-gradient(
+          rgba(255, 255, 255, 0.05) 1px,
+          transparent 1px
+        );
+        background-size: 100% 3px;
+        color: #cccccc;
+        font-family: 'Sono', Consolas, monospace;
+        font-size: 16px;
+        line-height: 1.5;
+        margin: 0;
+        padding: 0;
+      }
+      #container {
+        max-width: 85rch;
+        padding: 1em 1rch;
+      }
+      a {
+        color: #00ffff;
+        text-decoration: none;
+      }
+      a:hover {
+        color: #33ffff;
+        text-decoration: underline;
+      }
+      h1,
+      h2 {
+        color: #ffffff;
+        font-size: 16px;
+        margin: 0;
+        text-transform: uppercase;
+      }
+      h1 {
+        margin-top: 1em;
+      }
+      p {
+        margin: 0 0 1em 0;
+      }
+      ul {
+        margin: 0 0 1em 0;
+        padding-left: 1.5em;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="container">
+      <h1>About</h1>
+      <p>
+        Dendrite is an online, choose-your-own-adventure book that you can both
+        read, and write. This allows you, the reader and author, to participate
+        in the story however you see fit. The stories branch through various
+        pathways, with endless potential to read, write, re-write, edit, and
+        change the story to make it truly your own. Find your way through other
+        authors' stories, and pick up where they left off, creating your own
+        thrilling plot lines to pique your interest.
+      </p>
+      <p>
+        Dendrites, from the Greek δένδρον (meaning tree), are spindly tentacles
+        which connect the nucleus of one brain cell to another, very similar to
+        the way that links on Dendrite connect the pages of each story. The
+        dendrites form a significant part in growth and learning in the brain,
+        and slowly extend to connect to other brain cells, forming new thoughts
+        and memories in the process.
+      </p>
+      <p>
+        You, the reader and author, can take on a role as a part of the
+        adventure—you can be a spy, a princess, a pirate, a rockstar, a ninja, a
+        space cowboy, an explorer, a chef, a supermodel, a scientist, or write
+        the story and watch it unfold for any and all of these characters.
+      </p>
+      <p>Dendrite is a creation of Deuterium Labs.</p>
+      <h2>Discuss Dendrite with us at:</h2>
+      <ul>
+        <li>
+          <a href="https://reddit.com/r/DendriteStories"
+            >reddit.com/r/DendriteStories</a
+          >
+        </li>
+        <li>
+          <a href="https://twitter.com/DendriteStories"
+            >twitter.com/DendriteStories</a
+          >
+        </li>
+        <li>
+          <a href="https://facebook.com/DendriteStories"
+            >facebook.com/DendriteStories</a
+          >
+        </li>
+      </ul>
+      <h1>Contributors</h1>
+      <h2>Developer</h2>
+      <p>
+        Matthew Heard: software developer behind Dendrite. He began working on
+        Dendrite in 2013. Matthew's primary motivation for Dendrite is to build
+        a creative environment which gets better when more people create
+        stories, as he wants to explore how network effects and organic user
+        contributions can combine to bloom new communities.
+      </p>
+      <p>
+        Matthew has optimised Dendrite to run well on multiple platforms and
+        browsers, as he considers that accessibility is pivotal to obtaining
+        collaboration from a wide variety of users.
+      </p>
+      <p>
+        Matthew is a sustaining software developer for Oracle in New Zealand. He
+        primarily works with C++, Java, and SQL to find bugs and provide
+        software patches for the telecommunication networks of Oracle customers.
+      </p>
+      <p>
+        Matthew writes a blog at
+        <a href="https://MattHeard.net">MattHeard.net</a>.
+      </p>
+      <h2>Major contributors</h2>
+      <p>
+        Leah Hamilton: assisted with the general creative direction of Dendrite,
+        and provided significant amounts of feedback when testing early releases
+        of Dendrite. She also wrote the About and Contributors pages, and
+        drafted the Terms and Privacy pages. Leah is a solicitor at Minter
+        Ellison Rudd Watts, as well as an editor, writer, and tutor.
+      </p>
+      <p>
+        Ryan Hamilton: provided creative direction and web design assistance, as
+        well as logo design and feedback from testing early releases of
+        Dendrite. Ryan is a service designer for the Inland Revenue Department
+        of New Zealand.
+      </p>
+      <h2>Beta testing and bug reporting</h2>
+      <ul>
+        <li>Calum Barrett</li>
+        <li>Neil Dudley</li>
+        <li>Duncan Hamilton</li>
+        <li>Sean Hamilton</li>
+        <li>John Heard</li>
+        <li>Nic Henwood</li>
+        <li>Jack Li</li>
+        <li>Bayard Randel</li>
+        <li>Isaac Randel</li>
+      </ul>
+    </div>
+  </body>
+</html>

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -79,6 +79,13 @@ resource "google_storage_bucket_object" "dendrite_new_page" {
   content_type = "text/html"
 }
 
+resource "google_storage_bucket_object" "dendrite_about" {
+  name         = "about.html"
+  bucket       = google_storage_bucket.dendrite_static.name
+  source       = "${path.module}/about.html"
+  content_type = "text/html"
+}
+
 resource "google_storage_bucket_object" "dendrite_mod" {
   name   = "mod.html"
   bucket = google_storage_bucket.dendrite_static.name


### PR DESCRIPTION
## Summary
- move Dendrite about page into `infra` directory
- register About page as Google Cloud Storage object via Terraform

## Testing
- `npm test`
- `npm run lint` *(139 warnings: Ternary operator used, Identifier 'access_token' is not in camel case, Missing JSDoc @returns declaration, Missing JSDoc @param description/type, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68ad24de3130832e808047be37a2e073