### PR TITLE
chore: align about page styling

### DIFF
--- a/infra/about.html
+++ b/infra/about.html
@@ -2,79 +2,72 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Dendrite - About</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="icon" href="/favicon.ico" />
     <link
-      href="https://fonts.googleapis.com/css2?family=Share+Tech+Mono&family=Sono:wght@200..800&display=swap"
       rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.fluid.classless.min.css"
     />
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
-    <link rel="icon" href="/favicon.ico" type="image/x-icon" />
-    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-    <link
-      rel="icon"
-      type="image/png"
-      sizes="192x192"
-      href="/android-chrome-192x192.png"
-    />
-    <link
-      rel="icon"
-      type="image/png"
-      sizes="512x512"
-      href="/android-chrome-512x512.png"
-    />
-    <link rel="manifest" href="/site.webmanifest" />
-    <style>
-      body {
-        background-color: #121212;
-        background-image: linear-gradient(
-          rgba(255, 255, 255, 0.05) 1px,
-          transparent 1px
-        );
-        background-size: 100% 3px;
-        color: #cccccc;
-        font-family: 'Sono', Consolas, monospace;
-        font-size: 16px;
-        line-height: 1.5;
-        margin: 0;
-        padding: 0;
-      }
-      #container {
-        max-width: 85rch;
-        padding: 1em 1rch;
-      }
-      a {
-        color: #00ffff;
-        text-decoration: none;
-      }
-      a:hover {
-        color: #33ffff;
-        text-decoration: underline;
-      }
-      h1,
-      h2 {
-        color: #ffffff;
-        font-size: 16px;
-        margin: 0;
-        text-transform: uppercase;
-      }
-      h1 {
-        margin-top: 1em;
-      }
-      p {
-        margin: 0 0 1em 0;
-      }
-      ul {
-        margin: 0 0 1em 0;
-        padding-left: 1.5em;
-      }
-    </style>
+    <link rel="stylesheet" href="/dendrite.css" />
   </head>
   <body>
-    <div id="container">
+    <header class="site-header">
+      <a class="brand" href="/">
+        <img src="/img/logo.png" alt="Dendrite logo" />
+        Dendrite
+      </a>
+
+      <nav class="nav-inline" aria-label="Primary">
+        <a href="/new-story.html">New story</a>
+        <a href="/mod.html">Moderate</a>
+        <a href="/stats.html">Stats</a>
+        <div id="signinButton"></div>
+        <div id="signoutWrap" style="display: none">
+          <a id="signoutLink" href="#">Sign out</a>
+        </div>
+      </nav>
+
+      <button
+        class="menu-toggle"
+        aria-expanded="false"
+        aria-controls="mobile-menu"
+        aria-label="Open menu"
+      >
+        ☰
+      </button>
+    </header>
+
+    <!-- Mobile menu -->
+    <div id="mobile-menu" class="menu-overlay" hidden aria-hidden="true">
+      <div class="menu-sheet" role="dialog" aria-modal="true">
+        <button class="menu-close" aria-label="Close menu">✕</button>
+
+        <nav class="menu-groups">
+          <div class="menu-group">
+            <h3>Write</h3>
+            <a href="/new-story.html">New story</a>
+          </div>
+
+          <div class="menu-group">
+            <h3>Moderation</h3>
+            <a href="/mod.html">Moderate</a>
+            <a href="/stats.html">Stats</a>
+            <a id="adminLink" href="/admin.html" style="display: none">Admin</a>
+          </div>
+
+          <div class="menu-group">
+            <h3>Account</h3>
+            <div id="signinButton"></div>
+            <div id="signoutWrap" style="display: none">
+              <a id="signoutLink" href="#">Sign out</a>
+            </div>
+          </div>
+        </nav>
+      </div>
+    </div>
+
+    <main>
       <h1>About</h1>
       <p>
         Dendrite is an online, choose-your-own-adventure book that you can both
@@ -167,6 +160,86 @@
         <li>Bayard Randel</li>
         <li>Isaac Randel</li>
       </ul>
-    </div>
+    </main>
+
+    <!-- Google Identity Services -->
+    <script src="https://accounts.google.com/gsi/client" defer></script>
+    <script type="module">
+      import {
+        initGoogleSignIn,
+        getIdToken,
+        signOut,
+        isAdmin,
+      } from '/googleAuth.js';
+
+      document.addEventListener('DOMContentLoaded', () => {
+        const signins = document.querySelectorAll('#signinButton');
+        const signoutWraps = document.querySelectorAll('#signoutWrap');
+        const signoutLinks = document.querySelectorAll('#signoutLink');
+        const adminLink = document.getElementById('adminLink');
+
+        function showSignedIn() {
+          document.body.classList.add('authed');
+          signins.forEach(el => (el.style.display = 'none'));
+          signoutWraps.forEach(el => (el.style.display = ''));
+          if (isAdmin()) adminLink.style.display = '';
+        }
+
+        function showSignedOut() {
+          document.body.classList.remove('authed');
+          signoutWraps.forEach(el => (el.style.display = 'none'));
+          signins.forEach(el => (el.style.display = ''));
+          if (adminLink) adminLink.style.display = 'none';
+        }
+
+        initGoogleSignIn({ onSignIn: showSignedIn });
+
+        signoutLinks.forEach(link => {
+          link.addEventListener('click', async e => {
+            e.preventDefault();
+            await signOut();
+            showSignedOut();
+          });
+        });
+
+        if (getIdToken()) {
+          showSignedIn();
+        }
+      });
+    </script>
+    <script>
+      (function () {
+        const toggle = document.querySelector('.menu-toggle');
+        const overlay = document.getElementById('mobile-menu');
+        const sheet = overlay.querySelector('.menu-sheet');
+        const closeBtn = overlay.querySelector('.menu-close');
+
+        function openMenu() {
+          overlay.hidden = false;
+          overlay.setAttribute('aria-hidden', 'false');
+          toggle.setAttribute('aria-expanded', 'true');
+          document.body.style.overflow = 'hidden';
+          const first = sheet.querySelector('a,button,[tabindex="0"]');
+          if (first) first.focus();
+        }
+        function closeMenu() {
+          overlay.setAttribute('aria-hidden', 'true');
+          toggle.setAttribute('aria-expanded', 'false');
+          document.body.style.overflow = '';
+          setTimeout(() => (overlay.hidden = true), 180);
+          toggle.focus();
+        }
+        toggle.addEventListener('click', () =>
+          overlay.hidden ? openMenu() : closeMenu()
+        );
+        closeBtn.addEventListener('click', closeMenu);
+        overlay.addEventListener('click', e => {
+          if (e.target === overlay) closeMenu();
+        });
+        addEventListener('keydown', e => {
+          if (e.key === 'Escape' && !overlay.hidden) closeMenu();
+        });
+      })();
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Replace bespoke styling on about page with shared PicoCSS and dendrite.css
- Add site header, navigation, and mobile menu for consistency with other pages

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad561d5600832ea2e2be78e4bf72d2