### PR TITLE
feat: deploy Gen2 API key credit function

### DIFF
--- a/infra/cloud-functions/get-api-key-credit-v2/index.js
+++ b/infra/cloud-functions/get-api-key-credit-v2/index.js
@@ -1,0 +1,47 @@
+// Gen2 HTTP function: GET /api-keys/:uuid/credit  (also supports ?uuid=)
+// Returns: { credit: number } or 404 if missing
+import { onRequest } from 'firebase-functions/v2/https';
+import { Firestore } from '@google-cloud/firestore';
+
+const db = new Firestore();
+
+/**
+ *
+ * @param req
+ */
+function extractUuid(req) {
+  // Prefer REST path: /api-keys/<uuid>/credit
+  const m = (req.path || '').match(
+    /\/api-keys\/([0-9a-fA-F-]{36})\/credit\/?$/
+  );
+  if (m) return m[1];
+  // Fallbacks for parity with Gen1
+  return req.params?.uuid || req.query?.uuid || '';
+}
+
+/**
+ *
+ * @param uuid
+ */
+async function fetchCredit(uuid) {
+  const snap = await db.collection('api-key-credit').doc(String(uuid)).get();
+  return snap.exists ? (snap.data().credit ?? 0) : null;
+}
+
+export const getApiKeyCreditV2 = onRequest(async (req, res) => {
+  if (req.method !== 'GET') {
+    res.set('Allow', 'GET');
+    return res.status(405).send('Method Not Allowed');
+  }
+  const uuid = extractUuid(req);
+  if (!uuid) return res.status(400).send('Missing UUID');
+
+  try {
+    const credit = await fetchCredit(uuid);
+    if (credit === null) return res.status(404).send('Not found');
+    return res.json({ credit });
+  } catch (e) {
+    console.error(e);
+    return res.status(500).send('Internal error');
+  }
+});

--- a/infra/cloud-functions/get-api-key-credit-v2/package.json
+++ b/infra/cloud-functions/get-api-key-credit-v2/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "get-api-key-credit-v2",
+  "private": true,
+  "type": "module",
+  "main": "index.js",
+  "engines": { "node": ">=20" },
+  "dependencies": {
+    "@google-cloud/firestore": "^7.6.0",
+    "firebase-functions": "^5.0.1"
+  }
+}

--- a/infra/functions-v2.tf
+++ b/infra/functions-v2.tf
@@ -1,0 +1,46 @@
+data "archive_file" "get_api_key_credit_v2_src" {
+  type        = "zip"
+  source_dir  = "${path.module}/cloud-functions/get-api-key-credit-v2"
+  output_path = "${path.module}/build/get-api-key-credit-v2.zip"
+}
+
+resource "google_storage_bucket_object" "get_api_key_credit_v2_zip" {
+  name   = "${var.environment}-get-api-key-credit-v2-${data.archive_file.get_api_key_credit_v2_src.output_sha256}.zip"
+  bucket = google_storage_bucket.gcf_source_bucket.name
+  source = data.archive_file.get_api_key_credit_v2_src.output_path
+}
+
+resource "google_cloudfunctions2_function" "get_api_key_credit_v2" {
+  name     = "${var.environment}-get-api-key-credit-v2"
+  location = var.region
+
+  build_config {
+    runtime     = "nodejs22"
+    entry_point = "getApiKeyCreditV2"
+    source {
+      storage_source {
+        bucket = google_storage_bucket.gcf_source_bucket.name
+        object = google_storage_bucket_object.get_api_key_credit_v2_zip.name
+      }
+    }
+  }
+
+  service_config {
+    available_memory   = "256M"
+    timeout_seconds    = 10
+    max_instance_count = 20
+    service_account_email = google_service_account.cloud_function_runtime.email
+    environment_variables = {
+      GCLOUD_PROJECT       = var.project_id
+      GOOGLE_CLOUD_PROJECT = var.project_id
+      FIREBASE_CONFIG      = jsonencode({ projectId = var.project_id })
+    }
+  }
+}
+
+resource "google_cloud_run_service_iam_member" "get_api_key_credit_v2_public" {
+  location = google_cloudfunctions2_function.get_api_key_credit_v2.location
+  service  = google_cloudfunctions2_function.get_api_key_credit_v2.name
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}


### PR DESCRIPTION
## Summary
- add Gen2 HTTP function `getApiKeyCreditV2` for retrieving API key credit
- add Terraform resources to build, deploy, and temporarily allow public access to the new function

## Testing
- `npm test`
- `npm run lint` *(warnings: Missing JSDoc, camelcase, no-ternary)*


------
https://chatgpt.com/codex/tasks/task_e_68ad56e78768832eb855fbfd23151668