### PR TITLE
Include admin link in wide layout navigation

### DIFF
--- a/infra/404.html
+++ b/infra/404.html
@@ -22,6 +22,7 @@
         <a href="/new-story.html">New story</a>
         <a href="/mod.html">Moderate</a>
         <a href="/stats.html">Stats</a>
+        <a class="admin-link" href="/admin.html" style="display: none">Admin</a>
         <div id="signinButton"></div>
         <div id="signoutWrap" style="display: none">
           <a id="signoutLink" href="#">Sign out</a>
@@ -53,7 +54,9 @@
             <h3>Moderation</h3>
             <a href="/mod.html">Moderate</a>
             <a href="/stats.html">Stats</a>
-            <a id="adminLink" href="/admin.html" style="display: none">Admin</a>
+            <a class="admin-link" href="/admin.html" style="display: none"
+              >Admin</a
+            >
           </div>
 
           <div class="menu-group">
@@ -84,20 +87,20 @@
         const signins = document.querySelectorAll('#signinButton');
         const signoutWraps = document.querySelectorAll('#signoutWrap');
         const signoutLinks = document.querySelectorAll('#signoutLink');
-        const adminLink = document.getElementById('adminLink');
+        const adminLinks = document.querySelectorAll('.admin-link');
 
         function showSignedIn() {
           document.body.classList.add('authed');
           signins.forEach(el => (el.style.display = 'none'));
           signoutWraps.forEach(el => (el.style.display = ''));
-          if (isAdmin()) adminLink.style.display = '';
+          if (isAdmin()) adminLinks.forEach(el => (el.style.display = ''));
         }
 
         function showSignedOut() {
           document.body.classList.remove('authed');
           signoutWraps.forEach(el => (el.style.display = 'none'));
           signins.forEach(el => (el.style.display = ''));
-          if (adminLink) adminLink.style.display = 'none';
+          adminLinks.forEach(el => (el.style.display = 'none'));
         }
 
         initGoogleSignIn({ onSignIn: showSignedIn });

--- a/infra/cloud-functions/generate-stats/index.js
+++ b/infra/cloud-functions/generate-stats/index.js
@@ -67,6 +67,7 @@ function buildHtml(storyCount, pageCount, unmoderatedCount, topStories = []) {
         <a href="/new-story.html">New story</a>
         <a href="/mod.html">Moderate</a>
         <a href="/stats.html">Stats</a>
+        <a class="admin-link" href="/admin.html" style="display:none">Admin</a>
         <div id="signinButton"></div>
         <div id="signoutWrap" style="display:none">
           <a id="signoutLink" href="#">Sign out</a>
@@ -91,7 +92,7 @@ function buildHtml(storyCount, pageCount, unmoderatedCount, topStories = []) {
             <h3>Moderation</h3>
             <a href="/mod.html">Moderate</a>
             <a href="/stats.html">Stats</a>
-            <a id="adminLink" href="/admin.html" style="display:none">Admin</a>
+            <a class="admin-link" href="/admin.html" style="display:none">Admin</a>
           </div>
 
           <div class="menu-group">
@@ -121,19 +122,19 @@ function buildHtml(storyCount, pageCount, unmoderatedCount, topStories = []) {
         isAdmin,
         signOut,
       } from './googleAuth.js';
-      const al = document.getElementById('adminLink');
+      const als = document.querySelectorAll('.admin-link');
       const sbs = document.querySelectorAll('#signinButton');
       const sws = document.querySelectorAll('#signoutWrap');
       const sos = document.querySelectorAll('#signoutLink');
       function showSignedIn() {
         sbs.forEach(el => (el.style.display = 'none'));
         sws.forEach(el => (el.style.display = ''));
-        if (al && isAdmin()) al.style.display = '';
+        if (isAdmin()) als.forEach(el => (el.style.display = ''));
       }
       function showSignedOut() {
         sbs.forEach(el => (el.style.display = ''));
         sws.forEach(el => (el.style.display = 'none'));
-        if (al) al.style.display = 'none';
+        als.forEach(el => (el.style.display = 'none'));
       }
       initGoogleSignIn({ onSignIn: showSignedIn });
       sos.forEach(link => {

--- a/infra/cloud-functions/render-contents/htmlSnippets.js
+++ b/infra/cloud-functions/render-contents/htmlSnippets.js
@@ -25,6 +25,7 @@ export const PAGE_HTML = list => `<!doctype html>
         <a href="/new-story.html">New story</a>
         <a href="/mod.html">Moderate</a>
         <a href="/stats.html">Stats</a>
+        <a class="admin-link" href="/admin.html" style="display:none">Admin</a>
         <div id="signinButton"></div>
         <div id="signoutWrap" style="display:none">
             <a id="signoutLink" href="#">Sign out</a>
@@ -49,7 +50,7 @@ export const PAGE_HTML = list => `<!doctype html>
             <h3>Moderation</h3>
             <a href="/mod.html">Moderate</a>
             <a href="/stats.html">Stats</a>
-            <a id="adminLink" href="/admin.html" style="display:none">Admin</a>
+            <a class="admin-link" href="/admin.html" style="display:none">Admin</a>
           </div>
 
           <div class="menu-group">
@@ -77,16 +78,16 @@ export const PAGE_HTML = list => `<!doctype html>
         const sbs = document.querySelectorAll('#signinButton');
         const sws = document.querySelectorAll('#signoutWrap');
         const sos = document.querySelectorAll('#signoutLink');
-        const al = document.getElementById('adminLink');
+        const als = document.querySelectorAll('.admin-link');
       function showSignedIn() {
         sbs.forEach(el => (el.style.display = 'none'));
         sws.forEach(el => (el.style.display = ''));
-        if (isAdmin()) al.style.display = '';
+        if (isAdmin()) als.forEach(el => (el.style.display = ''));
       }
       function showSignedOut() {
         sbs.forEach(el => (el.style.display = ''));
         sws.forEach(el => (el.style.display = 'none'));
-        if (al) al.style.display = 'none';
+        als.forEach(el => (el.style.display = 'none'));
       }
       initGoogleSignIn({
         onSignIn: showSignedIn,

--- a/infra/cloud-functions/render-variant/buildAltsHtml.js
+++ b/infra/cloud-functions/render-variant/buildAltsHtml.js
@@ -52,6 +52,7 @@ export function buildAltsHtml(pageNumber, variants) {
         <a href="/new-story.html">New story</a>
         <a href="/mod.html">Moderate</a>
         <a href="/stats.html">Stats</a>
+        <a class="admin-link" href="/admin.html" style="display:none">Admin</a>
         <div id="signinButton"></div>
         <div id="signoutWrap" style="display:none">
           <a id="signoutLink" href="#">Sign out</a>
@@ -76,7 +77,7 @@ export function buildAltsHtml(pageNumber, variants) {
             <h3>Moderation</h3>
             <a href="/mod.html">Moderate</a>
             <a href="/stats.html">Stats</a>
-            <a id="adminLink" href="/admin.html" style="display:none">Admin</a>
+            <a class="admin-link" href="/admin.html" style="display:none">Admin</a>
           </div>
 
           <div class="menu-group">
@@ -98,19 +99,19 @@ export function buildAltsHtml(pageNumber, variants) {
         isAdmin,
         signOut,
       } from '../googleAuth.js';
-      const al = document.getElementById('adminLink');
+      const als = document.querySelectorAll('.admin-link');
       const sbs = document.querySelectorAll('#signinButton');
       const sws = document.querySelectorAll('#signoutWrap');
       const sos = document.querySelectorAll('#signoutLink');
       function showSignedIn() {
         sbs.forEach(el => (el.style.display = 'none'));
         sws.forEach(el => (el.style.display = ''));
-        if (isAdmin()) al.style.display = '';
+        if (isAdmin()) als.forEach(el => (el.style.display = ''));
       }
       function showSignedOut() {
         sbs.forEach(el => (el.style.display = ''));
         sws.forEach(el => (el.style.display = 'none'));
-        if (al) al.style.display = 'none';
+        als.forEach(el => (el.style.display = 'none'));
       }
       initGoogleSignIn({ onSignIn: showSignedIn });
       sos.forEach(link => {

--- a/infra/cloud-functions/render-variant/buildHtml.js
+++ b/infra/cloud-functions/render-variant/buildHtml.js
@@ -113,6 +113,7 @@ export function buildHtml(
         <a href="/new-story.html">New story</a>
         <a href="/mod.html">Moderate</a>
         <a href="/stats.html">Stats</a>
+        <a class="admin-link" href="/admin.html" style="display:none">Admin</a>
         <div id="signinButton"></div>
         <div id="signoutWrap" style="display:none">
           <a id="signoutLink" href="#">Sign out</a>
@@ -137,7 +138,7 @@ export function buildHtml(
             <h3>Moderation</h3>
             <a href="/mod.html">Moderate</a>
             <a href="/stats.html">Stats</a>
-            <a id="adminLink" href="/admin.html" style="display:none">Admin</a>
+            <a class="admin-link" href="/admin.html" style="display:none">Admin</a>
           </div>
 
           <div class="menu-group">
@@ -159,19 +160,19 @@ export function buildHtml(
         isAdmin,
         signOut,
       } from '../googleAuth.js';
-      const al = document.getElementById('adminLink');
+      const als = document.querySelectorAll('.admin-link');
       const sbs = document.querySelectorAll('#signinButton');
       const sws = document.querySelectorAll('#signoutWrap');
       const sos = document.querySelectorAll('#signoutLink');
       function showSignedIn() {
         sbs.forEach(el => (el.style.display = 'none'));
         sws.forEach(el => (el.style.display = ''));
-        if (isAdmin()) al.style.display = '';
+        if (isAdmin()) als.forEach(el => (el.style.display = ''));
       }
       function showSignedOut() {
         sbs.forEach(el => (el.style.display = ''));
         sws.forEach(el => (el.style.display = 'none'));
-        if (al) al.style.display = 'none';
+        als.forEach(el => (el.style.display = 'none'));
       }
       initGoogleSignIn({ onSignIn: showSignedIn });
       sos.forEach(link => {

--- a/infra/mod.html
+++ b/infra/mod.html
@@ -22,6 +22,7 @@
         <a href="/new-story.html">New story</a>
         <a href="/mod.html">Moderate</a>
         <a href="/stats.html">Stats</a>
+        <a class="admin-link" href="/admin.html" style="display: none">Admin</a>
         <div id="signinButton"></div>
         <div id="signoutWrap" style="display: none">
           <a id="signoutLink" href="#">Sign out</a>
@@ -53,7 +54,9 @@
             <h3>Moderation</h3>
             <a href="/mod.html">Moderate</a>
             <a href="/stats.html">Stats</a>
-            <a id="adminLink" href="/admin.html" style="display: none">Admin</a>
+            <a class="admin-link" href="/admin.html" style="display: none"
+              >Admin</a
+            >
           </div>
 
           <div class="menu-group">

--- a/infra/moderate.js
+++ b/infra/moderate.js
@@ -59,8 +59,9 @@ function wireSignOut() {
       document
         .querySelectorAll('#signinButton')
         .forEach(el => (el.style.display = ''));
-      const adminLink = document.getElementById('adminLink');
-      if (adminLink) adminLink.style.display = 'none';
+      document
+        .querySelectorAll('.admin-link')
+        .forEach(link => (link.style.display = 'none'));
       const content = document.getElementById('pageContent');
       if (content) {
         content.innerHTML = '';
@@ -183,8 +184,11 @@ initGoogleSignIn({
     document
       .querySelectorAll('#signoutWrap')
       .forEach(el => (el.style.display = ''));
-    const adminLink = document.getElementById('adminLink');
-    if (isAdmin()) adminLink.style.display = '';
+    if (isAdmin()) {
+      document
+        .querySelectorAll('.admin-link')
+        .forEach(link => (link.style.display = ''));
+    }
     wireSignOut();
     loadVariant();
   },
@@ -215,8 +219,9 @@ if (getIdToken()) {
     .querySelectorAll('#signoutWrap')
     .forEach(el => (el.style.display = ''));
   if (isAdmin()) {
-    const adminLink = document.getElementById('adminLink');
-    if (adminLink) adminLink.style.display = '';
+    document
+      .querySelectorAll('.admin-link')
+      .forEach(link => (link.style.display = ''));
   }
   wireSignOut();
   loadVariant();

--- a/infra/new-page.html
+++ b/infra/new-page.html
@@ -22,6 +22,7 @@
         <a href="/new-story.html">New story</a>
         <a href="/mod.html">Moderate</a>
         <a href="/stats.html">Stats</a>
+        <a class="admin-link" href="/admin.html" style="display: none">Admin</a>
         <div id="signinButton"></div>
         <div id="signoutWrap" style="display: none">
           <a id="signoutLink" href="#">Sign out</a>
@@ -53,7 +54,9 @@
             <h3>Moderation</h3>
             <a href="/mod.html">Moderate</a>
             <a href="/stats.html">Stats</a>
-            <a id="adminLink" href="/admin.html" style="display: none">Admin</a>
+            <a class="admin-link" href="/admin.html" style="display: none"
+              >Admin</a
+            >
           </div>
 
           <div class="menu-group">
@@ -113,7 +116,7 @@
         const signins = document.querySelectorAll('#signinButton');
         const signoutWraps = document.querySelectorAll('#signoutWrap');
         const signoutLinks = document.querySelectorAll('#signoutLink');
-        const adminLink = document.getElementById('adminLink');
+        const adminLinks = document.querySelectorAll('.admin-link');
 
         const params = new URLSearchParams(window.location.search);
         const incoming = params.get('option');
@@ -144,14 +147,14 @@
           document.body.classList.add('authed');
           signins.forEach(el => (el.style.display = 'none'));
           signoutWraps.forEach(el => (el.style.display = ''));
-          if (isAdmin()) adminLink.style.display = '';
+          if (isAdmin()) adminLinks.forEach(el => (el.style.display = ''));
         }
 
         function showSignedOut() {
           document.body.classList.remove('authed');
           signoutWraps.forEach(el => (el.style.display = 'none'));
           signins.forEach(el => (el.style.display = ''));
-          if (adminLink) adminLink.style.display = 'none';
+          adminLinks.forEach(el => (el.style.display = 'none'));
         }
 
         initGoogleSignIn({ onSignIn: showSignedIn });

--- a/infra/new-story.html
+++ b/infra/new-story.html
@@ -22,6 +22,7 @@
         <a href="/new-story.html">New story</a>
         <a href="/mod.html">Moderate</a>
         <a href="/stats.html">Stats</a>
+        <a class="admin-link" href="/admin.html" style="display: none">Admin</a>
         <div id="signinButton"></div>
         <div id="signoutWrap" style="display: none">
           <a id="signoutLink" href="#">Sign out</a>
@@ -53,7 +54,9 @@
             <h3>Moderation</h3>
             <a href="/mod.html">Moderate</a>
             <a href="/stats.html">Stats</a>
-            <a id="adminLink" href="/admin.html" style="display: none">Admin</a>
+            <a class="admin-link" href="/admin.html" style="display: none"
+              >Admin</a
+            >
           </div>
 
           <div class="menu-group">
@@ -123,20 +126,20 @@
         const signins = document.querySelectorAll('#signinButton');
         const signoutWraps = document.querySelectorAll('#signoutWrap');
         const signoutLinks = document.querySelectorAll('#signoutLink');
-        const adminLink = document.getElementById('adminLink');
+        const adminLinks = document.querySelectorAll('.admin-link');
 
         function showSignedIn() {
           document.body.classList.add('authed');
           signins.forEach(el => (el.style.display = 'none'));
           signoutWraps.forEach(el => (el.style.display = ''));
-          if (isAdmin()) adminLink.style.display = '';
+          if (isAdmin()) adminLinks.forEach(el => (el.style.display = ''));
         }
 
         function showSignedOut() {
           document.body.classList.remove('authed');
           signoutWraps.forEach(el => (el.style.display = 'none'));
           signins.forEach(el => (el.style.display = ''));
-          if (adminLink) adminLink.style.display = 'none';
+          adminLinks.forEach(el => (el.style.display = 'none'));
         }
 
         initGoogleSignIn({ onSignIn: showSignedIn });


### PR DESCRIPTION
## Summary
- add hidden Admin link to wide layout header navigation
- reveal all admin links only when user is verified as admin

## Testing
- `npm test`
- `npm run lint` *(warnings: Ternary operator used, camelcase, missing JSDoc)*

------
https://chatgpt.com/codex/tasks/task_e_68ad57216e30832e9a1952f9c6d7ea5d