### PR TITLE
Enable Cloud Run and Artifact Registry for Gen2 functions

### DIFF
--- a/infra/functions-v2.tf
+++ b/infra/functions-v2.tf
@@ -36,6 +36,12 @@ resource "google_cloudfunctions2_function" "get_api_key_credit_v2" {
       FIREBASE_CONFIG      = jsonencode({ projectId = var.project_id })
     }
   }
+
+  depends_on = [
+    google_project_service.run,
+    google_project_service.artifactregistry,
+    # google_project_service.eventarc, # if you added it
+  ]
 }
 
 resource "google_cloud_run_service_iam_member" "get_api_key_credit_v2_public" {
@@ -43,4 +49,6 @@ resource "google_cloud_run_service_iam_member" "get_api_key_credit_v2_public" {
   service  = google_cloudfunctions2_function.get_api_key_credit_v2.name
   role     = "roles/run.invoker"
   member   = "allUsers"
+
+  depends_on = [google_cloudfunctions2_function.get_api_key_credit_v2]
 }

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -175,6 +175,24 @@ resource "google_project_service" "firebaserules" {
   service = "firebaserules.googleapis.com"
 }
 
+# Needed for Gen2 (backed by Cloud Run)
+resource "google_project_service" "run" {
+  project = var.project_id
+  service = "run.googleapis.com"
+}
+
+# Container images for Gen2 builds live here
+resource "google_project_service" "artifactregistry" {
+  project = var.project_id
+  service = "artifactregistry.googleapis.com"
+}
+
+# Optional now, useful later for non-HTTP triggers
+resource "google_project_service" "eventarc" {
+  project = var.project_id
+  service = "eventarc.googleapis.com"
+}
+
 
 resource "google_firestore_database" "default" {
   project     = var.project_id


### PR DESCRIPTION
## Summary
- enable Cloud Run, Artifact Registry, and Eventarc APIs for the project
- ensure the Gen2 function waits for those APIs before deploying
- delay public IAM binding until after the function exists

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad5e98a4bc832eb0f693b2a1091448