### PR TITLE
Render author pages

### DIFF
--- a/infra/cloud-functions/render-variant/buildHtml.js
+++ b/infra/cloud-functions/render-variant/buildHtml.js
@@ -24,6 +24,7 @@ function renderInlineMarkdown(text) {
  * }>} options Option info.
  * @param {string} [storyTitle] Story title.
  * @param {string} [author] Author name.
+ * @param {string} [authorUrl] Author link.
  * @param parentUrl
  * @param firstPageUrl
  * @param {boolean} [showTitleHeading] Whether to include the story title as a
@@ -37,6 +38,7 @@ export function buildHtml(
   options,
   storyTitle = '',
   author = '',
+  authorUrl = '',
   parentUrl = '',
   firstPageUrl = '',
   showTitleHeading = true
@@ -68,7 +70,11 @@ export function buildHtml(
   const headTitle = storyTitle
     ? `Dendrite - ${escapeHtml(storyTitle)}`
     : 'Dendrite';
-  const authorHtml = author ? `<p>By ${escapeHtml(author)}</p>` : '';
+  const authorHtml = author
+    ? authorUrl
+      ? `<p>By <a href="${authorUrl}">${escapeHtml(author)}</a></p>`
+      : `<p>By ${escapeHtml(author)}</p>`
+    : '';
   const parentHtml = parentUrl ? `<p><a href="${parentUrl}">Back</a></p>` : '';
   const firstHtml = firstPageUrl
     ? `<p><a href="${firstPageUrl}">First page</a></p>`

--- a/test/cloud-functions/buildHtml.test.js
+++ b/test/cloud-functions/buildHtml.test.js
@@ -27,7 +27,18 @@ describe('buildHtml', () => {
   });
 
   test('omits heading when showTitleHeading is false', () => {
-    const html = buildHtml(1, 'a', 'hello', [], 'My Story', '', '', '', false);
+    const html = buildHtml(
+      1,
+      'a',
+      'hello',
+      [],
+      'My Story',
+      '',
+      '',
+      '',
+      '',
+      false
+    );
     expect(html).toContain('<title>Dendrite - My Story</title>');
     expect(html).not.toContain('<h1>My Story</h1>');
   });
@@ -81,6 +92,11 @@ describe('buildHtml', () => {
     expect(authorIndex).toBeGreaterThan(optionsIndex);
   });
 
+  test('links author name when author URL provided', () => {
+    const html = buildHtml(3, 'a', 'content', [], '', 'Jane Doe', '/a/u1.html');
+    expect(html).toContain('<p>By <a href="/a/u1.html">Jane Doe</a></p>');
+  });
+
   test('links to other variants page', () => {
     const html = buildHtml(1, 'a', 'content', []);
     expect(html).toContain('<a href="./1-alts.html">Other variants</a>');
@@ -132,6 +148,7 @@ describe('buildHtml', () => {
       'b',
       'content',
       [],
+      '',
       '',
       '',
       '/p/1a.html',

--- a/test/cloud-functions/renderContents.test.js
+++ b/test/cloud-functions/renderContents.test.js
@@ -1,5 +1,10 @@
 import { describe, test, expect, jest, beforeEach } from '@jest/globals';
-import { mockSave, mockFile, mockBucket } from '@google-cloud/storage';
+import {
+  mockSave,
+  mockFile,
+  mockBucket,
+  mockExists,
+} from '@google-cloud/storage';
 import { render } from '../../infra/cloud-functions/render-contents/index.js';
 
 describe('render contents', () => {
@@ -7,6 +12,7 @@ describe('render contents', () => {
     mockSave.mockClear();
     mockFile.mockClear();
     mockBucket.mockClear();
+    mockExists.mockClear();
     global.fetch = jest
       .fn()
       .mockResolvedValueOnce({

--- a/test/mocks/google-cloud-storage.js
+++ b/test/mocks/google-cloud-storage.js
@@ -1,7 +1,8 @@
 import { jest } from '@jest/globals';
 
 export const mockSave = jest.fn();
-export const mockFile = jest.fn(() => ({ save: mockSave }));
+export const mockExists = jest.fn().mockResolvedValue([false]);
+export const mockFile = jest.fn(() => ({ save: mockSave, exists: mockExists }));
 export const mockBucket = jest.fn(() => ({ file: mockFile }));
 
 export class Storage {


### PR DESCRIPTION
## Summary
- generate author profile page when rendering variants
- link variant pages to author profile
- test author page creation and linking

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ad5ff3598c832e9d02a813577e7457