### PR TITLE
Add Dendrite user manual page

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -86,6 +86,13 @@ resource "google_storage_bucket_object" "dendrite_about" {
   content_type = "text/html"
 }
 
+resource "google_storage_bucket_object" "dendrite_manual" {
+  name         = "manual.html"
+  bucket       = google_storage_bucket.dendrite_static.name
+  source       = "${path.module}/manual.html"
+  content_type = "text/html"
+}
+
 resource "google_storage_bucket_object" "dendrite_mod" {
   name   = "mod.html"
   bucket = google_storage_bucket.dendrite_static.name

--- a/infra/manual.html
+++ b/infra/manual.html
@@ -1,0 +1,171 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Dendrite - User Manual</title>
+    <link rel="icon" href="/favicon.ico" />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.fluid.classless.min.css"
+    />
+    <link rel="stylesheet" href="/dendrite.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <a class="brand" href="/">
+        <img src="/img/logo.png" alt="Dendrite logo" />
+        Dendrite
+      </a>
+
+      <nav class="nav-inline" aria-label="Primary">
+        <a href="/new-story.html">New story</a>
+        <a href="/mod.html">Moderate</a>
+        <a href="/stats.html">Stats</a>
+        <div id="signinButton"></div>
+        <div id="signoutWrap" style="display: none">
+          <a id="signoutLink" href="#">Sign out</a>
+        </div>
+      </nav>
+
+      <button
+        class="menu-toggle"
+        aria-expanded="false"
+        aria-controls="mobile-menu"
+        aria-label="Open menu"
+      >
+        ☰
+      </button>
+    </header>
+
+    <!-- Mobile menu -->
+    <div id="mobile-menu" class="menu-overlay" hidden aria-hidden="true">
+      <div class="menu-sheet" role="dialog" aria-modal="true">
+        <button class="menu-close" aria-label="Close menu">✕</button>
+
+        <nav class="menu-groups">
+          <div class="menu-group">
+            <h3>Write</h3>
+            <a href="/new-story.html">New story</a>
+          </div>
+
+          <div class="menu-group">
+            <h3>Moderation</h3>
+            <a href="/mod.html">Moderate</a>
+            <a href="/stats.html">Stats</a>
+          </div>
+
+          <div class="menu-group">
+            <h3>Account</h3>
+            <div id="signinButton"></div>
+            <div id="signoutWrap" style="display: none">
+              <a id="signoutLink" href="#">Sign out</a>
+            </div>
+          </div>
+        </nav>
+      </div>
+    </div>
+
+    <main>
+      <h1>User Manual</h1>
+      <p>
+        Welcome to Dendrite. This guide explains how to read and create
+        branching stories.
+      </p>
+      <h2>Reading stories</h2>
+      <p>
+        Navigate through a story by selecting one of the options at the end of
+        each page. Your choices determine the path you follow.
+      </p>
+      <h2>Creating new content</h2>
+      <p>
+        Use the <a href="/new-story.html">New story</a> page to start your own
+        adventure or extend existing ones. Each option you add can lead to a new
+        page.
+      </p>
+      <h2>Moderation</h2>
+      <p>
+        Community moderators review submissions on the
+        <a href="/mod.html">Moderate</a> page to keep stories safe and
+        enjoyable.
+      </p>
+    </main>
+
+    <!-- Google Identity Services -->
+    <script src="https://accounts.google.com/gsi/client" defer></script>
+    <script type="module">
+      import {
+        initGoogleSignIn,
+        getIdToken,
+        signOut,
+        isAdmin,
+      } from '/googleAuth.js';
+
+      document.addEventListener('DOMContentLoaded', () => {
+        const signins = document.querySelectorAll('#signinButton');
+        const signoutWraps = document.querySelectorAll('#signoutWrap');
+        const signoutLinks = document.querySelectorAll('#signoutLink');
+
+        function showSignedIn() {
+          document.body.classList.add('authed');
+          signins.forEach(el => (el.style.display = 'none'));
+          signoutWraps.forEach(el => (el.style.display = ''));
+        }
+
+        function showSignedOut() {
+          document.body.classList.remove('authed');
+          signoutWraps.forEach(el => (el.style.display = 'none'));
+          signins.forEach(el => (el.style.display = ''));
+        }
+
+        initGoogleSignIn({ onSignIn: showSignedIn });
+
+        signoutLinks.forEach(link => {
+          link.addEventListener('click', async e => {
+            e.preventDefault();
+            await signOut();
+            showSignedOut();
+          });
+        });
+
+        if (getIdToken()) {
+          showSignedIn();
+        }
+      });
+    </script>
+    <script>
+      (function () {
+        const toggle = document.querySelector('.menu-toggle');
+        const overlay = document.getElementById('mobile-menu');
+        const sheet = overlay.querySelector('.menu-sheet');
+        const closeBtn = overlay.querySelector('.menu-close');
+
+        function openMenu() {
+          overlay.hidden = false;
+          overlay.setAttribute('aria-hidden', 'false');
+          toggle.setAttribute('aria-expanded', 'true');
+          document.body.style.overflow = 'hidden';
+          const first = sheet.querySelector('a,button,[tabindex="0"]');
+          if (first) first.focus();
+        }
+        function closeMenu() {
+          overlay.setAttribute('aria-hidden', 'true');
+          toggle.setAttribute('aria-expanded', 'false');
+          document.body.style.overflow = '';
+          setTimeout(() => (overlay.hidden = true), 180);
+          toggle.focus();
+        }
+        toggle.addEventListener('click', () =>
+          overlay.hidden ? openMenu() : closeMenu()
+        );
+        closeBtn.addEventListener('click', closeMenu);
+        overlay.addEventListener('click', e => {
+          if (e.target === overlay) closeMenu();
+        });
+        addEventListener('keydown', e => {
+          if (e.key === 'Escape' && !overlay.hidden) closeMenu();
+        });
+      })();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add new static manual.html page with instructions for reading, creating, and moderating Dendrite stories
- deploy manual page via new Terraform storage bucket object

## Testing
- `NODE_OPTIONS=--experimental-global-webcrypto npm test`
- `NODE_OPTIONS=--experimental-global-webcrypto npm run lint` *(fails: TypeError [ERR_INVALID_ARG_TYPE])*


------
https://chatgpt.com/codex/tasks/task_e_68ad5eb7cea4832e8400e41caf294238