### PR TITLE
Centralize Terraform GCP API service enabling

### DIFF
--- a/infra/dendrite-firestore.tf
+++ b/infra/dendrite-firestore.tf
@@ -14,7 +14,7 @@ resource "google_firebaserules_ruleset" "firestore" {
     }
   }
   depends_on = [
-    google_project_service.firebaserules,
+    google_project_service.enabled["firebaserules.googleapis.com"],
     google_project_iam_member.ci_firebaserules_admin,
   ]
 }

--- a/infra/firebase-api-key.tf
+++ b/infra/firebase-api-key.tf
@@ -10,10 +10,6 @@ resource "google_project_iam_member" "terraform_apikeys_admin" {
   role    = "roles/serviceusage.apiKeysAdmin"
   member  = "serviceAccount:terraform@${var.project_id}.iam.gserviceaccount.com"
 
-  depends_on = [google_project_service.apikeys_api]
-}
-resource "google_project_service" "apikeys_api" {
-  project = var.project_id
-  service = "apikeys.googleapis.com"
+  depends_on = [google_project_service.enabled["apikeys.googleapis.com"]]
 }
 

--- a/infra/firebase-auth-iam.tf
+++ b/infra/firebase-auth-iam.tf
@@ -20,7 +20,7 @@ resource "google_project_iam_member" "runtime_identityplatform_viewer" {
 
   # optional, but makes the dependency explicit
   depends_on = [
-    google_project_service.identitytoolkit       # turned on in firebase-auth.tf
+    google_project_service.enabled["identitytoolkit.googleapis.com"]       # turned on in firebase-auth.tf
   ]
 }
 

--- a/infra/firebase-auth.tf
+++ b/infra/firebase-auth.tf
@@ -1,23 +1,13 @@
 # Firebase Authentication setup
 
 # identity-toolkit = Firebase Auth backend
-resource "google_project_service" "identitytoolkit" {
-  project = var.project_id
-  service = "identitytoolkit.googleapis.com"
-}
-
-# firebase.googleapis.com upgrades the project to Firebase
-resource "google_project_service" "firebase_api" {
-  project = var.project_id
-  service = "firebase.googleapis.com"
-}
 
 resource "google_firebase_project" "core" {
   provider   = google-beta
   project    = var.project_id
   depends_on = [
-    google_project_service.firebase_api,
-    google_project_service.identitytoolkit,
+    google_project_service.enabled["firebase.googleapis.com"],
+    google_project_service.enabled["identitytoolkit.googleapis.com"],
   ]
 }
 

--- a/infra/functions-v2.tf
+++ b/infra/functions-v2.tf
@@ -38,9 +38,9 @@ resource "google_cloudfunctions2_function" "get_api_key_credit_v2" {
   }
 
   depends_on = [
-    google_project_service.run,
-    google_project_service.artifactregistry,
-    # google_project_service.eventarc, # if you added it
+    google_project_service.enabled["run.googleapis.com"],
+    google_project_service.enabled["artifactregistry.googleapis.com"],
+    # google_project_service.enabled["eventarc.googleapis.com"], # if you added it
   ]
 }
 

--- a/infra/load-balancer.tf
+++ b/infra/load-balancer.tf
@@ -10,12 +10,6 @@ variable "lb_cert_domains" {
   ]
 }
 
-resource "google_project_service" "compute" {
-  project            = var.project_id
-  service            = "compute.googleapis.com"
-  disable_on_destroy = false
-}
-
 resource "google_compute_backend_bucket" "dendrite_static" {
   name        = "${var.environment}-dendrite-static"
   bucket_name = google_storage_bucket.dendrite_static.name
@@ -27,7 +21,7 @@ resource "google_compute_backend_bucket" "dendrite_static" {
   ]
 
   depends_on = [
-    google_project_service.compute,
+    google_project_service.enabled["compute.googleapis.com"],
     google_project_iam_member.terraform_loadbalancer_admin,
     google_project_iam_member.terraform_security_admin,
   ]
@@ -41,7 +35,7 @@ resource "google_compute_managed_ssl_certificate" "dendrite" {
   }
 
   depends_on = [
-    google_project_service.compute,
+    google_project_service.enabled["compute.googleapis.com"],
     google_project_iam_member.terraform_security_admin,
   ]
 }
@@ -108,7 +102,7 @@ resource "google_compute_url_map" "dendrite" {
   }
 
   depends_on = [
-    google_project_service.compute,
+    google_project_service.enabled["compute.googleapis.com"],
     google_project_iam_member.terraform_loadbalancer_admin,
   ]
 }
@@ -119,7 +113,7 @@ resource "google_compute_target_https_proxy" "dendrite" {
   ssl_certificates = [google_compute_managed_ssl_certificate.dendrite.id]
 
   depends_on = [
-    google_project_service.compute,
+    google_project_service.enabled["compute.googleapis.com"],
     google_project_iam_member.terraform_loadbalancer_admin,
     google_project_iam_member.terraform_security_admin,
   ]
@@ -129,7 +123,7 @@ resource "google_compute_global_address" "dendrite" {
   name = "${var.environment}-dendrite-ip"
 
   depends_on = [
-    google_project_service.compute,
+    google_project_service.enabled["compute.googleapis.com"],
     google_project_iam_member.terraform_loadbalancer_admin,
   ]
 }
@@ -141,7 +135,7 @@ resource "google_compute_global_forwarding_rule" "dendrite_https" {
   ip_address = google_compute_global_address.dendrite.address
 
   depends_on = [
-    google_project_service.compute,
+    google_project_service.enabled["compute.googleapis.com"],
     google_project_iam_member.terraform_loadbalancer_admin,
     google_project_iam_member.terraform_security_admin,
   ]
@@ -155,7 +149,7 @@ resource "google_compute_url_map" "redirect" {
   }
 
   depends_on = [
-    google_project_service.compute,
+    google_project_service.enabled["compute.googleapis.com"],
     google_project_iam_member.terraform_loadbalancer_admin,
   ]
 }
@@ -165,7 +159,7 @@ resource "google_compute_target_http_proxy" "redirect" {
   url_map = google_compute_url_map.redirect.id
 
   depends_on = [
-    google_project_service.compute,
+    google_project_service.enabled["compute.googleapis.com"],
     google_project_iam_member.terraform_loadbalancer_admin,
   ]
 }
@@ -177,7 +171,7 @@ resource "google_compute_global_forwarding_rule" "dendrite_http" {
   ip_address = google_compute_global_address.dendrite.address
 
   depends_on = [
-    google_project_service.compute,
+    google_project_service.enabled["compute.googleapis.com"],
     google_project_iam_member.terraform_loadbalancer_admin,
   ]
 }

--- a/infra/services.tf
+++ b/infra/services.tf
@@ -1,0 +1,24 @@
+locals {
+  required_apis = toset([
+    "firestore.googleapis.com",
+    "cloudfunctions.googleapis.com",
+    "cloudbuild.googleapis.com",
+    "cloudscheduler.googleapis.com",
+    "firebaserules.googleapis.com",
+    "run.googleapis.com",
+    "artifactregistry.googleapis.com",
+    "eventarc.googleapis.com",
+    "compute.googleapis.com",
+    "apikeys.googleapis.com",
+    "identitytoolkit.googleapis.com",
+    "firebase.googleapis.com",
+  ])
+}
+
+resource "google_project_service" "enabled" {
+  for_each = local.required_apis
+  project  = var.project_id
+  service  = each.key
+
+  disable_on_destroy = each.key == "compute.googleapis.com" ? false : true
+}


### PR DESCRIPTION
### Summary
- Centralize activation of required Google APIs via new `services.tf` using a local set and `for_each`.
- Remove scattered `google_project_service` resources and update modules to depend on centralized services.

### Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad60429bb8832e81f38c78f49120a4