### PR TITLE
refactor hide variant html logic

### DIFF
--- a/infra/cloud-functions/hide-variant-html/index.js
+++ b/infra/cloud-functions/hide-variant-html/index.js
@@ -1,6 +1,7 @@
 import { initializeApp } from 'firebase-admin/app';
 import { Storage } from '@google-cloud/storage';
 import * as functions from 'firebase-functions';
+import { decideRemovalPath } from './logic.js';
 
 initializeApp();
 const storage = new Storage();
@@ -14,33 +15,19 @@ export const hideVariantHtml = functions
   .region('europe-west1')
   .firestore.document('stories/{storyId}/pages/{pageId}/variants/{variantId}')
   .onWrite(async change => {
-    if (!change.after.exists) {
-      return removeFile(change.before);
+    const pageRef = change.after.ref.parent.parent;
+    const pageSnap = await pageRef.get();
+    if (!pageSnap.exists) {
+      return null;
     }
-
-    const beforeVis = change.before.data()?.visibility ?? 0;
-    const afterVis = change.after.data().visibility ?? 0;
-    if (beforeVis >= VISIBILITY_THRESHOLD && afterVis < VISIBILITY_THRESHOLD) {
-      return removeFile(change.after);
+    const path = decideRemovalPath(
+      change.before.exists ? change.before.data() : null,
+      change.after.exists ? change.after.data() : null,
+      pageSnap.data(),
+      VISIBILITY_THRESHOLD
+    );
+    if (path) {
+      await storage.bucket(BUCKET).file(path).delete({ ignoreNotFound: true });
     }
-
     return null;
   });
-
-/**
- *
- * @param snap
- */
-async function removeFile(snap) {
-  const variant = snap.data();
-  const pageSnap = await snap.ref.parent.parent.get();
-  if (!pageSnap.exists) {
-    return null;
-  }
-
-  const page = pageSnap.data();
-  const path = `p/${page.number}${variant.name}.html`;
-
-  await storage.bucket(BUCKET).file(path).delete({ ignoreNotFound: true });
-  return null;
-}

--- a/infra/cloud-functions/hide-variant-html/logic.js
+++ b/infra/cloud-functions/hide-variant-html/logic.js
@@ -1,0 +1,25 @@
+/**
+ * Determine the HTML file path to remove for a variant change.
+ * @param {object|null} before Variant data before the change.
+ * @param {object|null} after Variant data after the change.
+ * @param {{number: number}} page Page data containing its number.
+ * @param {number} [threshold] Visibility threshold.
+ * @returns {string|null} Path to remove or null if nothing to delete.
+ */
+export function decideRemovalPath(before, after, page, threshold = 0.5) {
+  if (!page) {
+    return null;
+  }
+  if (!after) {
+    if (!before) {
+      return null;
+    }
+    return `p/${page.number}${before.name}.html`;
+  }
+  const beforeVis = before?.visibility ?? 0;
+  const afterVis = after.visibility ?? 0;
+  if (beforeVis >= threshold && afterVis < threshold) {
+    return `p/${page.number}${after.name}.html`;
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- extract pure `decideRemovalPath` for hide-variant-html function
- call the logic from Cloud Function to determine which HTML file to remove

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ad69912314832e857f86357aef2e37