### PR TITLE
Inject database into logic and tests

### DIFF
--- a/test/cloud-functions/generateStats.test.js
+++ b/test/cloud-functions/generateStats.test.js
@@ -1,5 +1,6 @@
 import {
   buildHtml,
+  getStoryCount,
   getPageCount,
   getUnmoderatedPageCount,
   getTopStories,
@@ -28,6 +29,17 @@ describe('generate stats helpers', () => {
     expect(html).toContain('rotate(90) scale(-1,1)');
     expect(html).toContain('var(--link)');
     expect(html).toContain('Story A');
+  });
+
+  test('getStoryCount returns story count', async () => {
+    const mockDb = {
+      collection: () => ({
+        count: () => ({
+          get: () => Promise.resolve({ data: () => ({ count: 7 }) }),
+        }),
+      }),
+    };
+    await expect(getStoryCount(mockDb)).resolves.toBe(7);
   });
 
   test('getPageCount returns page count', async () => {

--- a/test/cloud-functions/markVariantDirty.test.js
+++ b/test/cloud-functions/markVariantDirty.test.js
@@ -77,13 +77,15 @@ describe('handleRequest', () => {
       uid: 'qcYSrXTaj1MZUoFsAloBwT86GNM2',
     });
     const markFn = jest.fn().mockResolvedValue(false);
+    const fakeDb = {};
     const req = {
       method: 'POST',
       get: h => (h === 'Authorization' ? 'Bearer t' : ''),
       body: { page: 5, variant: 'a' },
     };
     const res = createRes();
-    await handleRequest(req, res, { markFn });
+    await handleRequest(req, res, { markFn, db: fakeDb });
+    expect(markFn).toHaveBeenCalledWith(fakeDb, 5, 'a');
     expect(res.status).toHaveBeenCalledWith(404);
   });
 
@@ -92,14 +94,15 @@ describe('handleRequest', () => {
       uid: 'qcYSrXTaj1MZUoFsAloBwT86GNM2',
     });
     const markFn = jest.fn().mockResolvedValue(true);
+    const fakeDb = {};
     const req = {
       method: 'POST',
       get: h => (h === 'Authorization' ? 'Bearer t' : ''),
       body: { page: 5, variant: 'a' },
     };
     const res = createRes();
-    await handleRequest(req, res, { markFn });
-    expect(markFn).toHaveBeenCalledWith(5, 'a');
+    await handleRequest(req, res, { markFn, db: fakeDb });
+    expect(markFn).toHaveBeenCalledWith(fakeDb, 5, 'a');
     expect(res.status).toHaveBeenCalledWith(200);
   });
 
@@ -108,13 +111,15 @@ describe('handleRequest', () => {
       uid: 'qcYSrXTaj1MZUoFsAloBwT86GNM2',
     });
     const markFn = jest.fn().mockRejectedValue(new Error('fail'));
+    const fakeDb = {};
     const req = {
       method: 'POST',
       get: h => (h === 'Authorization' ? 'Bearer t' : ''),
       body: { page: 5, variant: 'a' },
     };
     const res = createRes();
-    await handleRequest(req, res, { markFn });
+    await handleRequest(req, res, { markFn, db: fakeDb });
+    expect(markFn).toHaveBeenCalledWith(fakeDb, 5, 'a');
     expect(res.status).toHaveBeenCalledWith(500);
   });
 });
@@ -138,7 +143,7 @@ describe('markVariantDirtyImpl', () => {
       }),
     };
     const db = { collectionGroup: () => pagesQuery };
-    const ok = await markVariantDirtyImpl(5, 'a', { db });
+    const ok = await markVariantDirtyImpl(db, 5, 'a');
     expect(ok).toBe(true);
     expect(update).toHaveBeenCalledWith({ dirty: null });
   });
@@ -150,7 +155,7 @@ describe('markVariantDirtyImpl', () => {
       get: jest.fn().mockResolvedValue({ empty: true }),
     };
     const db = { collectionGroup: () => pagesQuery };
-    const ok = await markVariantDirtyImpl(5, 'a', { db });
+    const ok = await markVariantDirtyImpl(db, 5, 'a');
     expect(ok).toBe(false);
   });
 
@@ -169,7 +174,7 @@ describe('markVariantDirtyImpl', () => {
       }),
     };
     const db = { collectionGroup: () => pagesQuery };
-    const ok = await markVariantDirtyImpl(5, 'a', { db });
+    const ok = await markVariantDirtyImpl(db, 5, 'a');
     expect(ok).toBe(false);
   });
 
@@ -183,9 +188,10 @@ describe('markVariantDirtyImpl', () => {
       .mockReturnValueOnce(pageRef)
       .mockReturnValueOnce(variantRef);
     const db = {};
-    await markVariantDirtyImpl(5, 'a', {
-      db,
-      firebase: { findPagesSnap, findVariantsSnap, refFromSnap },
+    await markVariantDirtyImpl(db, 5, 'a', {
+      findPagesSnap,
+      findVariantsSnap,
+      refFromSnap,
     });
     expect(findPagesSnap).toHaveBeenCalledWith(db, 5);
     expect(refFromSnap).toHaveBeenNthCalledWith(1, 'psnap');

--- a/test/cloud-functions/renderContents.test.js
+++ b/test/cloud-functions/renderContents.test.js
@@ -25,8 +25,9 @@ describe('render contents', () => {
   test('invalidates cache for generated pages', async () => {
     const ids = Array.from({ length: 31 }, (_, i) => `s${i + 1}`);
     await render({
+      db: {},
       fetchTopStoryIds: async () => ids,
-      fetchStoryInfo: async id => ({
+      fetchStoryInfo: async (_db, id) => ({
         title: id,
         pageNumber: Number(id.slice(1)),
       }),
@@ -53,6 +54,7 @@ describe('render contents', () => {
       .mockResolvedValue({ ok: false, status: 500 });
 
     await render({
+      db: {},
       fetchTopStoryIds: async () => ids,
       fetchStoryInfo: async () => ({ title: 't', pageNumber: 1 }),
     });

--- a/test/cloud-functions/triggerRenderContents.test.js
+++ b/test/cloud-functions/triggerRenderContents.test.js
@@ -106,6 +106,7 @@ describe('handleRenderRequest', () => {
       uid: 'qcYSrXTaj1MZUoFsAloBwT86GNM2',
     });
     const renderFn = jest.fn().mockResolvedValue(null);
+    const fakeDb = {};
     const req = {
       method: 'POST',
       get: h => {
@@ -116,8 +117,8 @@ describe('handleRenderRequest', () => {
       },
     };
     const res = createRes();
-    await handleRenderRequest(req, res, { renderFn });
-    expect(renderFn).toHaveBeenCalled();
+    await handleRenderRequest(req, res, { renderFn, db: fakeDb });
+    expect(renderFn).toHaveBeenCalledWith({ db: fakeDb });
     expect(res.status).toHaveBeenCalledWith(200);
   });
 
@@ -126,6 +127,7 @@ describe('handleRenderRequest', () => {
       uid: 'qcYSrXTaj1MZUoFsAloBwT86GNM2',
     });
     const renderFn = jest.fn().mockRejectedValue(new Error('fail'));
+    const fakeDb = {};
     const req = {
       method: 'POST',
       get: h => {
@@ -136,7 +138,8 @@ describe('handleRenderRequest', () => {
       },
     };
     const res = createRes();
-    await handleRenderRequest(req, res, { renderFn });
+    await handleRenderRequest(req, res, { renderFn, db: fakeDb });
+    expect(renderFn).toHaveBeenCalledWith({ db: fakeDb });
     expect(res.status).toHaveBeenCalledWith(500);
   });
 });


### PR DESCRIPTION
## Summary
- Refactor mark-variant-dirty to require a Firestore instance and inject it from HTTP handler
- Pass database references through generate-stats helpers and HTTP wrapper
- Feed Firestore into render-contents helpers and Cloud Function triggers

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ad6993c2b0832e9f3c3326efd66723