### PR TITLE
test: cover API key credit logic

### DIFF
--- a/infra/cloud-functions/get-api-key-credit-v2/index.js
+++ b/infra/cloud-functions/get-api-key-credit-v2/index.js
@@ -1,47 +1,10 @@
-// Gen2 HTTP function: GET /api-keys/:uuid/credit  (also supports ?uuid=)
-// Returns: { credit: number } or 404 if missing
 import { onRequest } from 'firebase-functions/v2/https';
 import { Firestore } from '@google-cloud/firestore';
+import { handleRequest } from './logic.js';
 
 const db = new Firestore();
+const repo = db.collection('api-key-credit');
 
-/**
- *
- * @param req
- */
-function extractUuid(req) {
-  // Prefer REST path: /api-keys/<uuid>/credit
-  const m = (req.path || '').match(
-    /\/api-keys\/([0-9a-fA-F-]{36})\/credit\/?$/
-  );
-  if (m) return m[1];
-  // Fallbacks for parity with Gen1
-  return req.params?.uuid || req.query?.uuid || '';
-}
-
-/**
- *
- * @param uuid
- */
-async function fetchCredit(uuid) {
-  const snap = await db.collection('api-key-credit').doc(String(uuid)).get();
-  return snap.exists ? (snap.data().credit ?? 0) : null;
-}
-
-export const getApiKeyCreditV2 = onRequest(async (req, res) => {
-  if (req.method !== 'GET') {
-    res.set('Allow', 'GET');
-    return res.status(405).send('Method Not Allowed');
-  }
-  const uuid = extractUuid(req);
-  if (!uuid) return res.status(400).send('Missing UUID');
-
-  try {
-    const credit = await fetchCredit(uuid);
-    if (credit === null) return res.status(404).send('Not found');
-    return res.json({ credit });
-  } catch (e) {
-    console.error(e);
-    return res.status(500).send('Internal error');
-  }
-});
+export const getApiKeyCreditV2 = onRequest((req, res) =>
+  handleRequest(req, res, { repo })
+);

--- a/infra/cloud-functions/get-api-key-credit-v2/logic.js
+++ b/infra/cloud-functions/get-api-key-credit-v2/logic.js
@@ -1,0 +1,54 @@
+/**
+ * Extract a UUID from request path, params, or query.
+ * @param {object} req HTTP request.
+ * @returns {string} UUID string or empty string when missing.
+ */
+export function extractUuid(req) {
+  const m = (req.path || '').match(
+    /\/api-keys\/([0-9a-fA-F-]{36})\/credit\/?$/
+  );
+  if (m) return m[1];
+  return req.params?.uuid || req.query?.uuid || '';
+}
+
+/**
+ * Fetch credit value for the UUID.
+ * @param {object} repo Firestore collection with doc().get().
+ * @param {string} uuid API key identifier.
+ * @returns {Promise<number|null>} Credit or null when not found.
+ */
+export async function fetchCredit(repo, uuid) {
+  const snap = await repo.doc(String(uuid)).get();
+  return snap.exists ? (snap.data().credit ?? 0) : null;
+}
+
+/**
+ * Handle HTTP request for API key credit.
+ * @param {object} req HTTP request.
+ * @param {object} res HTTP response.
+ * @param {{repo: {doc: (id: string) => {get: () => Promise<object>}}}} deps Dependencies.
+ * @returns {Promise<void>} Response promise.
+ */
+export async function handleRequest(req, res, { repo }) {
+  if (req.method !== 'GET') {
+    res.set('Allow', 'GET');
+    res.status(405).send('Method Not Allowed');
+    return;
+  }
+  const uuid = extractUuid(req);
+  if (!uuid) {
+    res.status(400).send('Missing UUID');
+    return;
+  }
+  try {
+    const credit = await fetchCredit(repo, uuid);
+    if (credit === null) {
+      res.status(404).send('Not found');
+      return;
+    }
+    res.json({ credit });
+  } catch (e) {
+    console.error(e);
+    res.status(500).send('Internal error');
+  }
+}

--- a/infra/cloud-functions/get-api-key-credit/index.js
+++ b/infra/cloud-functions/get-api-key-credit/index.js
@@ -1,92 +1,14 @@
 import { Firestore } from '@google-cloud/firestore';
+import { handler as logicHandler } from './logic.js';
 
 const firestore = new Firestore();
+const repo = firestore.collection('api-key-credit');
 
 /**
- * Fetch credit value associated with the given UUID.
- * @param {string} uuid - API key identifier.
- * @returns {Promise<number|null>} Credit or null when not found.
- */
-async function fetchCredit(uuid) {
-  const doc = await firestore.collection('api-key-credit').doc(uuid).get();
-  if (doc.exists) {
-    const data = doc.data();
-    return data.credit;
-  }
-  return null;
-}
-
-/**
- * Respond with a 400 Bad Request message.
- * @param {object} res - Express response object.
- * @param {string} message - Error message.
- */
-function sendBadRequest(res, message) {
-  res.status(400).send(message);
-}
-
-/**
- * Respond with the provided credit value or a 404 error.
- * @param {object} res - Express response object.
- * @param {number|null} credit - Credit value or null when not found.
- */
-function respondWithCredit(res, credit) {
-  if (credit === null) {
-    res.status(404).send('Not found');
-    return;
-  }
-  res.status(200).json({ credit });
-}
-
-/**
- * Send a credit response or a 500 error when undefined.
- * @param {object} res - Express response object.
- * @param {number|null|undefined} credit - Credit value, null when not found, or undefined on error.
- */
-function respondWithCreditOrError(res, credit) {
-  if (credit === undefined) {
-    res.status(500).send('Internal error');
-    return;
-  }
-  respondWithCredit(res, credit);
-}
-
-/**
- * Fetch credit while logging errors.
- * @param {string} uuid - API key identifier.
- * @returns {Promise<number|null|undefined>} Credit, null when not found, or undefined on error.
- */
-async function safeFetchCredit(uuid) {
-  try {
-    return await fetchCredit(uuid);
-  } catch (error) {
-    return undefined;
-  }
-}
-
-/**
- * Extract the UUID from the request parameters or query string.
- * @param {object} req - Express request object.
- * @returns {string|undefined} The UUID when present.
- */
-function getUuid(req) {
-  return req.params.uuid || req.query.uuid;
-}
-
-/**
- * HTTP Cloud Function to retrieve credit data associated with an API key.
- * @param {object} req - Express request object.
- * @param {object} res - Express response object.
- * @returns {Promise<void>} Response with credit value or error code.
+ *
+ * @param req
+ * @param res
  */
 export async function handler(req, res) {
-  const uuid = getUuid(req);
-
-  if (!uuid) {
-    sendBadRequest(res, 'Missing UUID');
-    return;
-  }
-
-  const credit = await safeFetchCredit(uuid);
-  respondWithCreditOrError(res, credit);
+  await logicHandler(req, res, { repo });
 }

--- a/infra/cloud-functions/get-api-key-credit/logic.js
+++ b/infra/cloud-functions/get-api-key-credit/logic.js
@@ -1,0 +1,91 @@
+/**
+ * Fetch credit value associated with a UUID from repository.
+ * @param {object} repo - Firestore collection with doc().get().
+ * @param {string} uuid - API key identifier.
+ * @returns {Promise<number|null>} Credit or null when not found.
+ */
+export async function fetchCredit(repo, uuid) {
+  const doc = await repo.doc(uuid).get();
+  if (doc.exists) {
+    const data = doc.data();
+    return data.credit;
+  }
+  return null;
+}
+
+/**
+ * Respond with the provided credit value or a 404 error.
+ * @param {object} res - Express response object.
+ * @param {number|null} credit - Credit value or null when not found.
+ */
+export function respondWithCredit(res, credit) {
+  if (credit === null) {
+    res.status(404).send('Not found');
+    return;
+  }
+  res.status(200).json({ credit });
+}
+
+/**
+ * Send a credit response or a 500 error when undefined.
+ * @param {object} res - Express response object.
+ * @param {number|null|undefined} credit - Credit value, null when not found, or undefined on error.
+ */
+export function respondWithCreditOrError(res, credit) {
+  if (credit === undefined) {
+    res.status(500).send('Internal error');
+    return;
+  }
+  respondWithCredit(res, credit);
+}
+
+/**
+ * Fetch credit while logging errors.
+ * @param {object} repo - Firestore collection with doc().get().
+ * @param {string} uuid - API key identifier.
+ * @returns {Promise<number|null|undefined>} Credit, null when not found, or undefined on error.
+ */
+export async function safeFetchCredit(repo, uuid) {
+  try {
+    return await fetchCredit(repo, uuid);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Extract the UUID from the request parameters or query string.
+ * @param {object} req - Express request object.
+ * @returns {string|undefined} The UUID when present.
+ */
+export function getUuid(req) {
+  return req.params?.uuid || req.query?.uuid;
+}
+
+/**
+ * Respond with a 400 Bad Request message.
+ * @param {object} res - Express response object.
+ * @param {string} message - Error message.
+ */
+export function sendBadRequest(res, message) {
+  res.status(400).send(message);
+}
+
+/**
+ * HTTP handler to retrieve credit data associated with an API key.
+ * @param {object} req - Express request object.
+ * @param {object} res - Express response object.
+ * @param {{repo: {doc: (id: string) => {get: () => Promise<object>}}}} deps - Dependencies.
+ * @returns {Promise<void>} Response with credit value or error code.
+ */
+export async function handler(req, res, { repo }) {
+  const uuid = getUuid(req);
+
+  if (!uuid) {
+    sendBadRequest(res, 'Missing UUID');
+    return;
+  }
+
+  const credit = await safeFetchCredit(repo, uuid);
+  respondWithCreditOrError(res, credit);
+}

--- a/test/cloud-functions/getApiKeyCredit.test.js
+++ b/test/cloud-functions/getApiKeyCredit.test.js
@@ -1,0 +1,65 @@
+import { describe, test, expect, jest } from '@jest/globals';
+import { handler } from '../../infra/cloud-functions/get-api-key-credit/logic.js';
+
+/**
+ *
+ */
+function createRes() {
+  return {
+    status: jest.fn().mockReturnThis(),
+    send: jest.fn(),
+    json: jest.fn(),
+  };
+}
+
+describe('getApiKeyCredit handler', () => {
+  test('responds 400 when uuid missing', async () => {
+    const req = { params: {}, query: {} };
+    const res = createRes();
+    await handler(req, res, { repo: {} });
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.send).toHaveBeenCalledWith('Missing UUID');
+  });
+
+  test('returns credit for uuid in params', async () => {
+    const get = jest
+      .fn()
+      .mockResolvedValue({ exists: true, data: () => ({ credit: 7 }) });
+    const repo = { doc: () => ({ get }) };
+    const req = { params: { uuid: 'u1' }, query: {} };
+    const res = createRes();
+    await handler(req, res, { repo });
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ credit: 7 });
+  });
+
+  test('supports uuid in query', async () => {
+    const get = jest
+      .fn()
+      .mockResolvedValue({ exists: true, data: () => ({ credit: 3 }) });
+    const repo = { doc: () => ({ get }) };
+    const req = { params: {}, query: { uuid: 'u2' } };
+    const res = createRes();
+    await handler(req, res, { repo });
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ credit: 3 });
+  });
+
+  test('returns 404 when uuid not found', async () => {
+    const get = jest.fn().mockResolvedValue({ exists: false });
+    const repo = { doc: () => ({ get }) };
+    const req = { params: { uuid: 'u1' }, query: {} };
+    const res = createRes();
+    await handler(req, res, { repo });
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+
+  test('handles fetch errors', async () => {
+    const get = jest.fn().mockRejectedValue(new Error('fail'));
+    const repo = { doc: () => ({ get }) };
+    const req = { params: { uuid: 'u1' }, query: {} };
+    const res = createRes();
+    await handler(req, res, { repo });
+    expect(res.status).toHaveBeenCalledWith(500);
+  });
+});

--- a/test/cloud-functions/getApiKeyCreditV2.test.js
+++ b/test/cloud-functions/getApiKeyCreditV2.test.js
@@ -1,0 +1,66 @@
+import { describe, test, expect, jest } from '@jest/globals';
+import { handleRequest } from '../../infra/cloud-functions/get-api-key-credit-v2/logic.js';
+
+/**
+ *
+ */
+function createRes() {
+  return {
+    status: jest.fn().mockReturnThis(),
+    send: jest.fn(),
+    json: jest.fn(),
+    set: jest.fn(),
+  };
+}
+
+describe('getApiKeyCreditV2 handleRequest', () => {
+  test('rejects non-GET method', async () => {
+    const req = { method: 'POST', path: '', params: {}, query: {} };
+    const res = createRes();
+    await handleRequest(req, res, { repo: {} });
+    expect(res.status).toHaveBeenCalledWith(405);
+    expect(res.set).toHaveBeenCalledWith('Allow', 'GET');
+  });
+
+  test('responds 400 when uuid missing', async () => {
+    const req = { method: 'GET', path: '', params: {}, query: {} };
+    const res = createRes();
+    await handleRequest(req, res, { repo: {} });
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  test('returns credit using path match', async () => {
+    const get = jest
+      .fn()
+      .mockResolvedValue({ exists: true, data: () => ({ credit: 9 }) });
+    const repo = { doc: () => ({ get }) };
+    const req = {
+      method: 'GET',
+      path: '/api-keys/12345678-1234-1234-1234-123456789abc/credit',
+      params: {},
+      query: {},
+    };
+    const res = createRes();
+    await handleRequest(req, res, { repo });
+    expect(res.status).not.toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ credit: 9 });
+  });
+
+  test('returns 404 when not found via query uuid', async () => {
+    const get = jest.fn().mockResolvedValue({ exists: false });
+    const repo = { doc: () => ({ get }) };
+    const req = { method: 'GET', path: '', params: {}, query: { uuid: 'x' } };
+    const res = createRes();
+    await handleRequest(req, res, { repo });
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+
+  test('handles repository errors', async () => {
+    const get = jest.fn().mockRejectedValue(new Error('fail'));
+    const repo = { doc: () => ({ get }) };
+    const req = { method: 'GET', path: '', params: { uuid: 'x' }, query: {} };
+    const res = createRes();
+    await handleRequest(req, res, { repo });
+    expect(res.status).toHaveBeenCalledWith(500);
+  });
+});


### PR DESCRIPTION
## Summary
- add dedicated logic modules for API key credit cloud functions
- mock Firestore repositories to test handlers without Firebase

## Testing
- `npm test`
- `npm run lint` (warnings: no-ternary, camelcase, jsdoc)


------
https://chatgpt.com/codex/tasks/task_e_68ad699553b0832e95b688f1cf0f3724