### PR TITLE
Default project_id from env

### DIFF
--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,6 +1,12 @@
 variable "project_id" {
   description = "The GCP project ID"
   type        = string
+  default     = env("GOOGLE_CLOUD_PROJECT")
+
+  validation {
+    condition     = length(var.project_id) > 0
+    error_message = "project_id must be set or the GOOGLE_CLOUD_PROJECT environment variable must be defined."
+  }
 }
 
 variable "region" {


### PR DESCRIPTION
## Summary
- default Terraform project_id to GOOGLE_CLOUD_PROJECT environment variable and validate presence

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ad6bc0c088832eac2eed60bf7ba276