### PR TITLE
Include environment var file in Terraform plan

### DIFF
--- a/.github/workflows/deploy-terraform.yml
+++ b/.github/workflows/deploy-terraform.yml
@@ -44,7 +44,7 @@ jobs:
         run: terraform init
 
       - name: Terraform Plan
-        run: terraform plan -lock-timeout=5m -input=false -out=tfplan
+        run: terraform plan -lock-timeout=5m -input=false -out=tfplan -var-file=environments/${ENVIRONMENT}/${ENVIRONMENT}.auto.tfvars
 
       - name: Terraform Apply
         run: terraform apply -lock-timeout=5m -auto-approve tfplan


### PR DESCRIPTION
## Summary
- ensure `terraform plan` uses the environment-specific variable file to supply `project_id`

## Testing
- `npm test`
- `npm run lint`
- ⚠️ `terraform init` (Terraform CLI missing; `apt-get install terraform` unable to locate package)


------
https://chatgpt.com/codex/tasks/task_e_68ad908fcf68832e8866e3a6d61643c9