### PR TITLE
refactor: modularize cloud functions

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -304,601 +304,131 @@ resource "google_project_iam_member" "runtime_firestore_access" {
   ]
 }
 
-
-data "archive_file" "get_api_key_src" {
-  type        = "zip"
-  source_dir  = "${path.module}/cloud-functions/get-api-key-credit"
-  output_path = "${path.module}/build/get-api-key-credit.zip"
-}
-
-resource "google_storage_bucket_object" "get_api_key_credit" {
-  name   = "${var.environment}-get-api-key-credit-${data.archive_file.get_api_key_src.output_sha256}.zip"
-  bucket = google_storage_bucket.gcf_source_bucket.name
-  source = data.archive_file.get_api_key_src.output_path
-}
-
-resource "google_cloudfunctions_function" "get_api_key_credit" {
-  name                         = "${var.environment}-get-api-key-credit"
-  description                  = "Returns credit for an API key"
-  runtime                      = var.cloud_functions_runtime
-  available_memory_mb          = 128
-  source_archive_bucket        = google_storage_bucket.gcf_source_bucket.name
-  source_archive_object        = google_storage_bucket_object.get_api_key_credit.name
-  entry_point                  = "handler"
-  trigger_http                 = true
-  https_trigger_security_level = var.https_security_level
-  service_account_email        = google_service_account.cloud_function_runtime.email
-  region                       = var.region
-
-  environment_variables = {
+locals {
+  function_env_vars = {
     GCLOUD_PROJECT       = var.project_id
     GOOGLE_CLOUD_PROJECT = var.project_id
     FIREBASE_CONFIG      = jsonencode({ projectId = var.project_id })
   }
 
-
-  depends_on = [
-    google_project_service.cloudfunctions,
-    google_project_service.cloudbuild,
-    google_project_iam_member.cloudfunctions_access,
-    google_service_account_iam_member.terraform_can_impersonate_runtime,
-    google_service_account_iam_member.terraform_can_impersonate_default_compute,
-  ]
-}
-
-resource "google_cloudfunctions_function_iam_member" "invoker" {
-  project        = var.project_id
-  region         = var.region
-  cloud_function = google_cloudfunctions_function.get_api_key_credit.name
-  role           = "roles/cloudfunctions.invoker"
-  member         = "allUsers"
-  depends_on = [
-    google_cloudfunctions_function.get_api_key_credit,
-    google_project_iam_member.terraform_cloudfunctions_viewer,
-  ]
-}
-
-data "archive_file" "submit_src" {
-  type        = "zip"
-  source_dir  = "${path.module}/cloud-functions/submit-new-story"
-  output_path = "${path.module}/build/submit-new-story.zip"
-}
-
-data "archive_file" "submit_page_src" {
-  type        = "zip"
-  source_dir  = "${path.module}/cloud-functions/submit-new-page"
-  output_path = "${path.module}/build/submit-new-page.zip"
-}
-
-resource "google_storage_bucket_object" "submit_new_story" {
-  name   = "${var.environment}-submit-new-story-${data.archive_file.submit_src.output_sha256}.zip"
-  bucket = google_storage_bucket.gcf_source_bucket.name
-  source = data.archive_file.submit_src.output_path
-}
-
-resource "google_storage_bucket_object" "submit_new_page" {
-  name   = "${var.environment}-submit-new-page-${data.archive_file.submit_page_src.output_sha256}.zip"
-  bucket = google_storage_bucket.gcf_source_bucket.name
-  source = data.archive_file.submit_page_src.output_path
-}
-
-resource "google_cloudfunctions_function" "submit_new_story" {
-  name                         = "${var.environment}-submit-new-story"
-  runtime                      = var.cloud_functions_runtime
-  entry_point                  = "submitNewStory"
-  source_archive_bucket        = google_storage_bucket.gcf_source_bucket.name
-  source_archive_object        = google_storage_bucket_object.submit_new_story.name
-  trigger_http                 = true
-  https_trigger_security_level = var.https_security_level
-  service_account_email        = google_service_account.cloud_function_runtime.email
-  region                       = var.region
-
-  environment_variables = {
-    GCLOUD_PROJECT       = var.project_id
-    GOOGLE_CLOUD_PROJECT = var.project_id
-    FIREBASE_CONFIG      = jsonencode({ projectId = var.project_id })
+  http_functions = {
+    get_api_key_credit = {
+      name        = "${var.environment}-get-api-key-credit"
+      entry_point = "handler"
+      source_dir  = "${path.module}/cloud-functions/get-api-key-credit"
+    }
+    submit_new_story = {
+      name        = "${var.environment}-submit-new-story"
+      entry_point = "submitNewStory"
+      source_dir  = "${path.module}/cloud-functions/submit-new-story"
+    }
+    submit_new_page = {
+      name        = "${var.environment}-submit-new-page"
+      entry_point = "submitNewPage"
+      source_dir  = "${path.module}/cloud-functions/submit-new-page"
+    }
+    assign_moderation_job = {
+      name        = "${var.environment}-assign-moderation-job"
+      entry_point = "assignModerationJob"
+      source_dir  = "${path.module}/cloud-functions/assign-moderation-job"
+    }
+    get_moderation_variant = {
+      name        = "${var.environment}-get-moderation-variant"
+      entry_point = "getModerationVariant"
+      source_dir  = "${path.module}/cloud-functions/get-moderation-variant"
+    }
+    submit_moderation_rating = {
+      name        = "${var.environment}-submit-moderation-rating"
+      entry_point = "submitModerationRating"
+      source_dir  = "${path.module}/cloud-functions/submit-moderation-rating"
+    }
+    report_for_moderation = {
+      name        = "${var.environment}-report-for-moderation"
+      entry_point = "reportForModeration"
+      source_dir  = "${path.module}/cloud-functions/report-for-moderation"
+    }
+    mark_variant_dirty = {
+      name        = "${var.environment}-mark-variant-dirty"
+      entry_point = "markVariantDirty"
+      source_dir  = "${path.module}/cloud-functions/mark-variant-dirty"
+    }
+    generate_stats = {
+      name        = "${var.environment}-generate-stats"
+      entry_point = "generateStats"
+      source_dir  = "${path.module}/cloud-functions/generate-stats"
+    }
+    trigger_render_contents = {
+      name        = "${var.environment}-trigger-render-contents"
+      entry_point = "triggerRenderContents"
+      source_dir  = "${path.module}/cloud-functions/render-contents"
+    }
   }
 
-
-  depends_on = [
-    google_project_service.cloudfunctions,
-    google_project_service.cloudbuild,
-    google_project_iam_member.cloudfunctions_access,
-    google_service_account_iam_member.terraform_can_impersonate_runtime,
-    google_service_account_iam_member.terraform_can_impersonate_default_compute,
-  ]
-}
-
-resource "google_cloudfunctions_function" "submit_new_page" {
-  name                         = "${var.environment}-submit-new-page"
-  runtime                      = var.cloud_functions_runtime
-  entry_point                  = "submitNewPage"
-  source_archive_bucket        = google_storage_bucket.gcf_source_bucket.name
-  source_archive_object        = google_storage_bucket_object.submit_new_page.name
-  trigger_http                 = true
-  https_trigger_security_level = var.https_security_level
-  service_account_email        = google_service_account.cloud_function_runtime.email
-  region                       = var.region
-
-  environment_variables = {
-    GCLOUD_PROJECT       = var.project_id
-    GOOGLE_CLOUD_PROJECT = var.project_id
-    FIREBASE_CONFIG      = jsonencode({ projectId = var.project_id })
+  event_functions = {
+    process_new_story = {
+      name        = "${var.environment}-process-new-story"
+      entry_point = "processNewStory"
+      source_dir  = "${path.module}/cloud-functions/process-new-story"
+      event_type  = "providers/cloud.firestore/eventTypes/document.create"
+      resource    = "projects/${var.project_id}/databases/(default)/documents/storyFormSubmissions/{subId}"
+    }
+    prod_update_variant_visibility = {
+      name        = "${var.environment}-update-variant-visibility"
+      entry_point = "prodUpdateVariantVisibility"
+      source_dir  = "${path.module}/cloud-functions/prod-update-variant-visibility"
+      event_type  = "providers/cloud.firestore/eventTypes/document.create"
+      resource    = "projects/${var.project_id}/databases/(default)/documents/moderationRatings/{ratingId}"
+    }
+    process_new_page = {
+      name        = "${var.environment}-process-new-page"
+      entry_point = "processNewPage"
+      source_dir  = "${path.module}/cloud-functions/process-new-page"
+      event_type  = "providers/cloud.firestore/eventTypes/document.create"
+      resource    = "projects/${var.project_id}/databases/(default)/documents/pageFormSubmissions/{subId}"
+    }
+    render_variant = {
+      name        = "${var.environment}-render-variant"
+      entry_point = "renderVariant"
+      source_dir  = "${path.module}/cloud-functions/render-variant"
+      event_type  = "providers/cloud.firestore/eventTypes/document.write"
+      resource    = "projects/${var.project_id}/databases/(default)/documents/stories/{storyId}/pages/{pageId}/variants/{variantId}"
+    }
+    hide_variant_html = {
+      name        = "${var.environment}-hide-variant-html"
+      entry_point = "hideVariantHtml"
+      source_dir  = "${path.module}/cloud-functions/hide-variant-html"
+      event_type  = "providers/cloud.firestore/eventTypes/document.write"
+      resource    = "projects/${var.project_id}/databases/(default)/documents/stories/{storyId}/pages/{pageId}/variants/{variantId}"
+    }
+    render_contents = {
+      name        = "${var.environment}-render-contents"
+      entry_point = "renderContents"
+      source_dir  = "${path.module}/cloud-functions/render-contents"
+      event_type  = "providers/cloud.firestore/eventTypes/document.create"
+      resource    = "projects/${var.project_id}/databases/(default)/documents/stories/{storyId}"
+    }
   }
-
-
-  depends_on = [
-    google_project_service.cloudfunctions,
-    google_project_service.cloudbuild,
-    google_project_iam_member.cloudfunctions_access,
-    google_service_account_iam_member.terraform_can_impersonate_runtime,
-    google_service_account_iam_member.terraform_can_impersonate_default_compute,
-  ]
 }
 
-resource "google_cloudfunctions_function_iam_member" "submit_new_story_invoker" {
-  project        = var.project_id
-  region         = var.region
-  cloud_function = google_cloudfunctions_function.submit_new_story.name
-  role           = "roles/cloudfunctions.invoker"
-  member         = "allUsers"
-  depends_on = [
-    google_cloudfunctions_function.submit_new_story,
-    google_project_iam_member.terraform_cloudfunctions_viewer,
-  ]
-}
-
-resource "google_cloudfunctions_function_iam_member" "submit_new_page_invoker" {
-  project        = var.project_id
-  region         = var.region
-  cloud_function = google_cloudfunctions_function.submit_new_page.name
-  role           = "roles/cloudfunctions.invoker"
-  member         = "allUsers"
-  depends_on = [
-    google_cloudfunctions_function.submit_new_page,
-    google_project_iam_member.terraform_cloudfunctions_viewer,
-  ]
-}
-
-data "archive_file" "assign_moderation_job_src" {
-  type        = "zip"
-  source_dir  = "${path.module}/cloud-functions/assign-moderation-job"
-  output_path = "${path.module}/build/assign-moderation-job.zip"
-}
-
-resource "google_storage_bucket_object" "assign_moderation_job" {
-  name   = "${var.environment}-assign-moderation-job-${data.archive_file.assign_moderation_job_src.output_sha256}.zip"
-  bucket = google_storage_bucket.gcf_source_bucket.name
-  source = data.archive_file.assign_moderation_job_src.output_path
-}
-
-resource "google_cloudfunctions_function" "assign_moderation_job" {
-  name                         = "${var.environment}-assign-moderation-job"
-  runtime                      = var.cloud_functions_runtime
-  entry_point                  = "assignModerationJob"
-  source_archive_bucket        = google_storage_bucket.gcf_source_bucket.name
-  source_archive_object        = google_storage_bucket_object.assign_moderation_job.name
-  trigger_http                 = true
-  https_trigger_security_level = var.https_security_level
-  service_account_email        = google_service_account.cloud_function_runtime.email
-  region                       = var.region
-
-  environment_variables = {
-    GCLOUD_PROJECT       = var.project_id
-    GOOGLE_CLOUD_PROJECT = var.project_id
-    FIREBASE_CONFIG      = jsonencode({ projectId = var.project_id })
-  }
-
-  depends_on = [
-    google_project_service.cloudfunctions,
-    google_project_service.cloudbuild,
-    google_project_iam_member.cloudfunctions_access,
-    google_service_account_iam_member.terraform_can_impersonate_runtime,
-    google_service_account_iam_member.terraform_can_impersonate_default_compute,
-  ]
-}
-
-resource "google_cloudfunctions_function_iam_member" "assign_moderation_job_invoker" {
-  project        = var.project_id
-  region         = var.region
-  cloud_function = google_cloudfunctions_function.assign_moderation_job.name
-  role           = "roles/cloudfunctions.invoker"
-  member         = "allUsers"
-  depends_on = [
-    google_cloudfunctions_function.assign_moderation_job,
-    google_project_iam_member.terraform_cloudfunctions_viewer,
-  ]
-}
-
-data "archive_file" "get_moderation_variant_src" {
-  type        = "zip"
-  source_dir  = "${path.module}/cloud-functions/get-moderation-variant"
-  output_path = "${path.module}/build/get-moderation-variant.zip"
-}
-
-resource "google_storage_bucket_object" "get_moderation_variant" {
-  name   = "${var.environment}-get-moderation-variant-${data.archive_file.get_moderation_variant_src.output_sha256}.zip"
-  bucket = google_storage_bucket.gcf_source_bucket.name
-  source = data.archive_file.get_moderation_variant_src.output_path
-}
-
-resource "google_cloudfunctions_function" "get_moderation_variant" {
-  name                         = "${var.environment}-get-moderation-variant"
-  runtime                      = var.cloud_functions_runtime
-  entry_point                  = "getModerationVariant"
-  source_archive_bucket        = google_storage_bucket.gcf_source_bucket.name
-  source_archive_object        = google_storage_bucket_object.get_moderation_variant.name
-  trigger_http                 = true
-  https_trigger_security_level = var.https_security_level
-  service_account_email        = google_service_account.cloud_function_runtime.email
-  region                       = var.region
-
-  environment_variables = {
-    GCLOUD_PROJECT       = var.project_id
-    GOOGLE_CLOUD_PROJECT = var.project_id
-    FIREBASE_CONFIG      = jsonencode({ projectId = var.project_id })
-  }
-
-  depends_on = [
-    google_project_service.cloudfunctions,
-    google_project_service.cloudbuild,
-    google_project_iam_member.cloudfunctions_access,
-    google_service_account_iam_member.terraform_can_impersonate_runtime,
-    google_service_account_iam_member.terraform_can_impersonate_default_compute,
-  ]
-}
-
-resource "google_cloudfunctions_function_iam_member" "get_moderation_variant_invoker" {
-  project        = var.project_id
-  region         = var.region
-  cloud_function = google_cloudfunctions_function.get_moderation_variant.name
-  role           = "roles/cloudfunctions.invoker"
-  member         = "allUsers"
-
-  depends_on = [
-    google_cloudfunctions_function.get_moderation_variant,
-    google_project_iam_member.terraform_cloudfunctions_viewer,
-  ]
-}
-data "archive_file" "submit_moderation_rating_src" {
-  type        = "zip"
-  source_dir  = "${path.module}/cloud-functions/submit-moderation-rating"
-  output_path = "${path.module}/build/submit-moderation-rating.zip"
-}
-
-resource "google_storage_bucket_object" "submit_moderation_rating" {
-  name   = "${var.environment}-submit-moderation-rating-${data.archive_file.submit_moderation_rating_src.output_sha256}.zip"
-  bucket = google_storage_bucket.gcf_source_bucket.name
-  source = data.archive_file.submit_moderation_rating_src.output_path
-}
-
-resource "google_cloudfunctions_function" "submit_moderation_rating" {
-  name                         = "${var.environment}-submit-moderation-rating"
-  runtime                      = var.cloud_functions_runtime
-  entry_point                  = "submitModerationRating"
-  source_archive_bucket        = google_storage_bucket.gcf_source_bucket.name
-  source_archive_object        = google_storage_bucket_object.submit_moderation_rating.name
-  trigger_http                 = true
-  https_trigger_security_level = var.https_security_level
-  service_account_email        = google_service_account.cloud_function_runtime.email
-  region                       = var.region
-
-  environment_variables = {
-    GCLOUD_PROJECT       = var.project_id
-    GOOGLE_CLOUD_PROJECT = var.project_id
-    FIREBASE_CONFIG      = jsonencode({ projectId = var.project_id })
-  }
-
-  depends_on = [
-    google_project_service.cloudfunctions,
-    google_project_service.cloudbuild,
-    google_project_iam_member.cloudfunctions_access,
-    google_service_account_iam_member.terraform_can_impersonate_runtime,
-    google_service_account_iam_member.terraform_can_impersonate_default_compute,
-  ]
-}
-
-resource "google_cloudfunctions_function_iam_member" "submit_moderation_rating_invoker" {
-  project        = var.project_id
-  region         = var.region
-  cloud_function = google_cloudfunctions_function.submit_moderation_rating.name
-  role           = "roles/cloudfunctions.invoker"
-  member         = "allUsers"
-  depends_on = [
-    google_cloudfunctions_function.submit_moderation_rating,
-    google_project_iam_member.terraform_cloudfunctions_viewer,
-  ]
-}
-
-
-data "archive_file" "report_for_moderation_src" {
-  type        = "zip"
-  source_dir  = "${path.module}/cloud-functions/report-for-moderation"
-  output_path = "${path.module}/build/report-for-moderation.zip"
-}
-
-resource "google_storage_bucket_object" "report_for_moderation" {
-  name   = "${var.environment}-report-for-moderation-${data.archive_file.report_for_moderation_src.output_sha256}.zip"
-  bucket = google_storage_bucket.gcf_source_bucket.name
-  source = data.archive_file.report_for_moderation_src.output_path
-}
-
-resource "google_cloudfunctions_function" "report_for_moderation" {
-  name                         = "${var.environment}-report-for-moderation"
-  runtime                      = var.cloud_functions_runtime
-  entry_point                  = "reportForModeration"
-  source_archive_bucket        = google_storage_bucket.gcf_source_bucket.name
-  source_archive_object        = google_storage_bucket_object.report_for_moderation.name
-  trigger_http                 = true
-  https_trigger_security_level = var.https_security_level
-  service_account_email        = google_service_account.cloud_function_runtime.email
-  region                       = var.region
-
-  environment_variables = {
-    GCLOUD_PROJECT       = var.project_id
-    GOOGLE_CLOUD_PROJECT = var.project_id
-    FIREBASE_CONFIG      = jsonencode({ projectId = var.project_id })
-  }
-
-  depends_on = [
-    google_project_service.cloudfunctions,
-    google_project_service.cloudbuild,
-    google_project_iam_member.cloudfunctions_access,
-    google_service_account_iam_member.terraform_can_impersonate_runtime,
-    google_service_account_iam_member.terraform_can_impersonate_default_compute,
-  ]
-}
-
-resource "google_cloudfunctions_function_iam_member" "report_for_moderation_invoker" {
-  project        = var.project_id
-  region         = var.region
-  cloud_function = google_cloudfunctions_function.report_for_moderation.name
-  role           = "roles/cloudfunctions.invoker"
-  member         = "allUsers"
-  depends_on = [
-    google_cloudfunctions_function.report_for_moderation,
-    google_project_iam_member.terraform_cloudfunctions_viewer,
-  ]
-}
-
-
-data "archive_file" "process_src" {
-  type        = "zip"
-  source_dir  = "${path.module}/cloud-functions/process-new-story"
-  output_path = "${path.module}/build/process-new-story.zip"
-}
-
-resource "google_storage_bucket_object" "process_new_story" {
-  name   = "${var.environment}-process-new-story-${data.archive_file.process_src.output_sha256}.zip"
-  bucket = google_storage_bucket.gcf_source_bucket.name
-  source = data.archive_file.process_src.output_path
-}
-
-resource "google_cloudfunctions_function" "process_new_story" {
-  name        = "${var.environment}-process-new-story"
-  runtime     = var.cloud_functions_runtime
-  region      = var.region
-  entry_point = "processNewStory"
-
-  source_archive_bucket = google_storage_bucket.gcf_source_bucket.name
-  source_archive_object = google_storage_bucket_object.process_new_story.name
-
+module "http_functions" {
+  source                = "./modules/cloud-function"
+  for_each              = local.http_functions
+  name                  = each.value.name
+  entry_point           = each.value.entry_point
+  source_dir            = each.value.source_dir
+  env_vars              = local.function_env_vars
+  project_id            = var.project_id
+  region                = var.region
+  runtime               = var.cloud_functions_runtime
+  source_bucket         = google_storage_bucket.gcf_source_bucket.name
   service_account_email = google_service_account.cloud_function_runtime.email
-
-  environment_variables = {
-    GCLOUD_PROJECT       = var.project_id
-    GOOGLE_CLOUD_PROJECT = var.project_id
-    FIREBASE_CONFIG      = jsonencode({ projectId = var.project_id })
+  https_security_level  = var.https_security_level
+  trigger = {
+    http = true
   }
-
-
-  event_trigger {
-    event_type = "providers/cloud.firestore/eventTypes/document.create"
-    resource   = "projects/${var.project_id}/databases/(default)/documents/storyFormSubmissions/{subId}"
-  }
-
-  depends_on = [
-    google_project_service.cloudfunctions,
-    google_project_service.cloudbuild,
-    google_project_iam_member.cloudfunctions_access
+  iam_members = [
+    { role = "roles/cloudfunctions.invoker", member = "allUsers" }
   ]
-}
-
-data "archive_file" "prod_update_variant_visibility_src" {
-  type        = "zip"
-  source_dir  = "${path.module}/cloud-functions/prod-update-variant-visibility"
-  output_path = "${path.module}/build/prod-update-variant-visibility.zip"
-}
-
-resource "google_storage_bucket_object" "prod_update_variant_visibility" {
-  name   = "${var.environment}-update-variant-visibility-${data.archive_file.prod_update_variant_visibility_src.output_sha256}.zip"
-  bucket = google_storage_bucket.gcf_source_bucket.name
-  source = data.archive_file.prod_update_variant_visibility_src.output_path
-}
-
-resource "google_cloudfunctions_function" "prod_update_variant_visibility" {
-  name        = "${var.environment}-update-variant-visibility"
-  runtime     = var.cloud_functions_runtime
-  region      = var.region
-  entry_point = "prodUpdateVariantVisibility"
-
-  source_archive_bucket = google_storage_bucket.gcf_source_bucket.name
-  source_archive_object = google_storage_bucket_object.prod_update_variant_visibility.name
-
-  service_account_email = google_service_account.cloud_function_runtime.email
-
-  environment_variables = {
-    GCLOUD_PROJECT       = var.project_id
-    GOOGLE_CLOUD_PROJECT = var.project_id
-    FIREBASE_CONFIG      = jsonencode({ projectId = var.project_id })
-  }
-
-  event_trigger {
-    event_type = "providers/cloud.firestore/eventTypes/document.create"
-    resource   = "projects/${var.project_id}/databases/(default)/documents/moderationRatings/{ratingId}"
-  }
-
-  depends_on = [
-    google_project_service.cloudfunctions,
-    google_project_service.cloudbuild,
-    google_project_iam_member.cloudfunctions_access
-  ]
-}
-
-data "archive_file" "process_page_src" {
-  type        = "zip"
-  source_dir  = "${path.module}/cloud-functions/process-new-page"
-  output_path = "${path.module}/build/process-new-page.zip"
-}
-
-resource "google_storage_bucket_object" "process_new_page" {
-  name   = "${var.environment}-process-new-page-${data.archive_file.process_page_src.output_sha256}.zip"
-  bucket = google_storage_bucket.gcf_source_bucket.name
-  source = data.archive_file.process_page_src.output_path
-}
-
-resource "google_cloudfunctions_function" "process_new_page" {
-  name        = "${var.environment}-process-new-page"
-  runtime     = var.cloud_functions_runtime
-  region      = var.region
-  entry_point = "processNewPage"
-
-  source_archive_bucket = google_storage_bucket.gcf_source_bucket.name
-  source_archive_object = google_storage_bucket_object.process_new_page.name
-
-  service_account_email = google_service_account.cloud_function_runtime.email
-
-  environment_variables = {
-    GCLOUD_PROJECT       = var.project_id
-    GOOGLE_CLOUD_PROJECT = var.project_id
-    FIREBASE_CONFIG      = jsonencode({ projectId = var.project_id })
-  }
-
-
-  event_trigger {
-    event_type = "providers/cloud.firestore/eventTypes/document.create"
-    resource   = "projects/${var.project_id}/databases/(default)/documents/pageFormSubmissions/{subId}"
-  }
-
-  depends_on = [
-    google_project_service.cloudfunctions,
-    google_project_service.cloudbuild,
-    google_project_iam_member.cloudfunctions_access
-  ]
-}
-
-data "archive_file" "render_variant_src" {
-  type        = "zip"
-  source_dir  = "${path.module}/cloud-functions/render-variant"
-  output_path = "${path.module}/build/render-variant.zip"
-}
-
-resource "google_storage_bucket_object" "render_variant" {
-  name   = "${var.environment}-render-variant-${data.archive_file.render_variant_src.output_sha256}.zip"
-  bucket = google_storage_bucket.gcf_source_bucket.name
-  source = data.archive_file.render_variant_src.output_path
-}
-
-resource "google_cloudfunctions_function" "render_variant" {
-  name        = "${var.environment}-render-variant"
-  runtime     = var.cloud_functions_runtime
-  region      = var.region
-  entry_point = "renderVariant"
-
-  source_archive_bucket = google_storage_bucket.gcf_source_bucket.name
-  source_archive_object = google_storage_bucket_object.render_variant.name
-
-  service_account_email = google_service_account.cloud_function_runtime.email
-
-  environment_variables = {
-    GCLOUD_PROJECT       = var.project_id
-    GOOGLE_CLOUD_PROJECT = var.project_id
-    FIREBASE_CONFIG      = jsonencode({ projectId = var.project_id })
-  }
-
-
-  event_trigger {
-    event_type = "providers/cloud.firestore/eventTypes/document.write"
-    resource   = "projects/${var.project_id}/databases/(default)/documents/stories/{storyId}/pages/{pageId}/variants/{variantId}"
-  }
-
-  depends_on = [
-    google_project_service.cloudfunctions,
-    google_project_service.cloudbuild,
-    google_project_iam_member.cloudfunctions_access
-  ]
-}
-
-data "archive_file" "hide_variant_html_src" {
-  type        = "zip"
-  source_dir  = "${path.module}/cloud-functions/hide-variant-html"
-  output_path = "${path.module}/build/hide-variant-html.zip"
-}
-
-resource "google_storage_bucket_object" "hide_variant_html" {
-  name   = "${var.environment}-hide-variant-html-${data.archive_file.hide_variant_html_src.output_sha256}.zip"
-  bucket = google_storage_bucket.gcf_source_bucket.name
-  source = data.archive_file.hide_variant_html_src.output_path
-}
-
-resource "google_cloudfunctions_function" "hide_variant_html" {
-  name        = "${var.environment}-hide-variant-html"
-  runtime     = var.cloud_functions_runtime
-  region      = var.region
-  entry_point = "hideVariantHtml"
-
-  source_archive_bucket = google_storage_bucket.gcf_source_bucket.name
-  source_archive_object = google_storage_bucket_object.hide_variant_html.name
-
-  service_account_email = google_service_account.cloud_function_runtime.email
-
-  environment_variables = {
-    GCLOUD_PROJECT       = var.project_id
-    GOOGLE_CLOUD_PROJECT = var.project_id
-    FIREBASE_CONFIG      = jsonencode({ projectId = var.project_id })
-  }
-
-  event_trigger {
-    event_type = "providers/cloud.firestore/eventTypes/document.write"
-    resource   = "projects/${var.project_id}/databases/(default)/documents/stories/{storyId}/pages/{pageId}/variants/{variantId}"
-  }
-
-  depends_on = [
-    google_project_service.cloudfunctions,
-    google_project_service.cloudbuild,
-    google_project_iam_member.cloudfunctions_access
-  ]
-}
-
-data "archive_file" "mark_variant_dirty_src" {
-  type        = "zip"
-  source_dir  = "${path.module}/cloud-functions/mark-variant-dirty"
-  output_path = "${path.module}/build/mark-variant-dirty.zip"
-}
-
-resource "google_storage_bucket_object" "mark_variant_dirty" {
-  name   = "${var.environment}-mark-variant-dirty-${data.archive_file.mark_variant_dirty_src.output_sha256}.zip"
-  bucket = google_storage_bucket.gcf_source_bucket.name
-  source = data.archive_file.mark_variant_dirty_src.output_path
-}
-
-resource "google_cloudfunctions_function" "mark_variant_dirty" {
-  name                         = "${var.environment}-mark-variant-dirty"
-  runtime                      = var.cloud_functions_runtime
-  entry_point                  = "markVariantDirty"
-  source_archive_bucket        = google_storage_bucket.gcf_source_bucket.name
-  source_archive_object        = google_storage_bucket_object.mark_variant_dirty.name
-  trigger_http                 = true
-  https_trigger_security_level = var.https_security_level
-  service_account_email        = google_service_account.cloud_function_runtime.email
-  region                       = var.region
-
-  environment_variables = {
-    GCLOUD_PROJECT       = var.project_id
-    GOOGLE_CLOUD_PROJECT = var.project_id
-    FIREBASE_CONFIG      = jsonencode({ projectId = var.project_id })
-  }
-
   depends_on = [
     google_project_service.cloudfunctions,
     google_project_service.cloudbuild,
@@ -908,65 +438,29 @@ resource "google_cloudfunctions_function" "mark_variant_dirty" {
   ]
 }
 
-resource "google_cloudfunctions_function_iam_member" "mark_variant_dirty_invoker" {
-  project        = var.project_id
-  region         = var.region
-  cloud_function = google_cloudfunctions_function.mark_variant_dirty.name
-  role           = "roles/cloudfunctions.invoker"
-  member         = "allUsers"
-  depends_on = [
-    google_cloudfunctions_function.mark_variant_dirty,
-    google_project_iam_member.terraform_cloudfunctions_viewer,
-  ]
-}
-
-data "archive_file" "generate_stats_src" {
-  type        = "zip"
-  source_dir  = "${path.module}/cloud-functions/generate-stats"
-  output_path = "${path.module}/build/generate-stats.zip"
-}
-
-resource "google_storage_bucket_object" "generate_stats" {
-  name   = "${var.environment}-generate-stats-${data.archive_file.generate_stats_src.output_sha256}.zip"
-  bucket = google_storage_bucket.gcf_source_bucket.name
-  source = data.archive_file.generate_stats_src.output_path
-}
-
-resource "google_cloudfunctions_function" "generate_stats" {
-  name                         = "${var.environment}-generate-stats"
-  runtime                      = var.cloud_functions_runtime
-  entry_point                  = "generateStats"
-  source_archive_bucket        = google_storage_bucket.gcf_source_bucket.name
-  source_archive_object        = google_storage_bucket_object.generate_stats.name
-  trigger_http                 = true
-  https_trigger_security_level = var.https_security_level
-  service_account_email        = google_service_account.cloud_function_runtime.email
-  region                       = var.region
-
-  environment_variables = {
-    GCLOUD_PROJECT       = var.project_id
-    GOOGLE_CLOUD_PROJECT = var.project_id
-    FIREBASE_CONFIG      = jsonencode({ projectId = var.project_id })
+module "event_functions" {
+  source                = "./modules/cloud-function"
+  for_each              = local.event_functions
+  name                  = each.value.name
+  entry_point           = each.value.entry_point
+  source_dir            = each.value.source_dir
+  env_vars              = local.function_env_vars
+  project_id            = var.project_id
+  region                = var.region
+  runtime               = var.cloud_functions_runtime
+  source_bucket         = google_storage_bucket.gcf_source_bucket.name
+  service_account_email = google_service_account.cloud_function_runtime.email
+  https_security_level  = var.https_security_level
+  trigger = {
+    event = {
+      event_type = each.value.event_type
+      resource   = each.value.resource
+    }
   }
-
   depends_on = [
     google_project_service.cloudfunctions,
     google_project_service.cloudbuild,
     google_project_iam_member.cloudfunctions_access,
-    google_service_account_iam_member.terraform_can_impersonate_runtime,
-    google_service_account_iam_member.terraform_can_impersonate_default_compute,
-  ]
-}
-
-resource "google_cloudfunctions_function_iam_member" "generate_stats_invoker" {
-  project        = var.project_id
-  region         = var.region
-  cloud_function = google_cloudfunctions_function.generate_stats.name
-  role           = "roles/cloudfunctions.invoker"
-  member         = "allUsers"
-  depends_on = [
-    google_cloudfunctions_function.generate_stats,
-    google_project_iam_member.terraform_cloudfunctions_viewer,
   ]
 }
 
@@ -976,94 +470,15 @@ resource "google_cloud_scheduler_job" "generate_stats_daily" {
   time_zone = "UTC"
   http_target {
     http_method = "POST"
-    uri         = google_cloudfunctions_function.generate_stats.https_trigger_url
+    uri         = module.http_functions["generate_stats"].https_trigger_url
     headers = {
       "X-Appengine-Cron" = "true"
     }
   }
   depends_on = [
     google_project_service.cloudscheduler,
-    google_cloudfunctions_function.generate_stats,
+    module.http_functions["generate_stats"],
     google_project_iam_member.terraform_cloudscheduler_admin,
   ]
 }
 
-data "archive_file" "render_contents_src" {
-  type        = "zip"
-  source_dir  = "${path.module}/cloud-functions/render-contents"
-  output_path = "${path.module}/build/render-contents.zip"
-}
-
-resource "google_storage_bucket_object" "render_contents" {
-  name   = "${var.environment}-render-contents-${data.archive_file.render_contents_src.output_sha256}.zip"
-  bucket = google_storage_bucket.gcf_source_bucket.name
-  source = data.archive_file.render_contents_src.output_path
-}
-
-resource "google_cloudfunctions_function" "render_contents" {
-  name        = "${var.environment}-render-contents"
-  runtime     = var.cloud_functions_runtime
-  region      = var.region
-  entry_point = "renderContents"
-
-  source_archive_bucket = google_storage_bucket.gcf_source_bucket.name
-  source_archive_object = google_storage_bucket_object.render_contents.name
-
-  service_account_email = google_service_account.cloud_function_runtime.email
-
-  environment_variables = {
-    GCLOUD_PROJECT       = var.project_id
-    GOOGLE_CLOUD_PROJECT = var.project_id
-    FIREBASE_CONFIG      = jsonencode({ projectId = var.project_id })
-  }
-
-
-  event_trigger {
-    event_type = "providers/cloud.firestore/eventTypes/document.create"
-    resource   = "projects/${var.project_id}/databases/(default)/documents/stories/{storyId}"
-  }
-
-  depends_on = [
-    google_project_service.cloudfunctions,
-    google_project_service.cloudbuild,
-    google_project_iam_member.cloudfunctions_access
-  ]
-}
-
-resource "google_cloudfunctions_function" "trigger_render_contents" {
-  name                         = "${var.environment}-trigger-render-contents"
-  runtime                      = var.cloud_functions_runtime
-  entry_point                  = "triggerRenderContents"
-  source_archive_bucket        = google_storage_bucket.gcf_source_bucket.name
-  source_archive_object        = google_storage_bucket_object.render_contents.name
-  trigger_http                 = true
-  https_trigger_security_level = var.https_security_level
-  service_account_email        = google_service_account.cloud_function_runtime.email
-  region                       = var.region
-
-  environment_variables = {
-    GCLOUD_PROJECT       = var.project_id
-    GOOGLE_CLOUD_PROJECT = var.project_id
-    FIREBASE_CONFIG      = jsonencode({ projectId = var.project_id })
-  }
-
-  depends_on = [
-    google_project_service.cloudfunctions,
-    google_project_service.cloudbuild,
-    google_project_iam_member.cloudfunctions_access,
-    google_service_account_iam_member.terraform_can_impersonate_runtime,
-    google_service_account_iam_member.terraform_can_impersonate_default_compute,
-  ]
-}
-
-resource "google_cloudfunctions_function_iam_member" "trigger_render_contents_invoker" {
-  project        = var.project_id
-  region         = var.region
-  cloud_function = google_cloudfunctions_function.trigger_render_contents.name
-  role           = "roles/cloudfunctions.invoker"
-  member         = "allUsers"
-  depends_on = [
-    google_cloudfunctions_function.trigger_render_contents,
-    google_project_iam_member.terraform_cloudfunctions_viewer,
-  ]
-}


### PR DESCRIPTION
## Summary
- replace hand-written Cloud Function resources with reusable modules
- define HTTP and event-driven functions via `for_each` maps
- update scheduler job to reference module output

## Testing
- `npm test`
- `npm run lint`
- `terraform init` *(fails: could not find default credentials)*


------
https://chatgpt.com/codex/tasks/task_e_68ae83bff798832ea7627e37084228e2