### PR TITLE
Add default trigger config for cloud function modules

### DIFF
--- a/infra/modules/cloud-function-v2/variables.tf
+++ b/infra/modules/cloud-function-v2/variables.tf
@@ -18,6 +18,7 @@ variable "trigger" {
       filters    = map(string)
     }))
   })
+  default = { http = false }
 }
 
 variable "env_vars" {

--- a/infra/modules/cloud-function/variables.tf
+++ b/infra/modules/cloud-function/variables.tf
@@ -18,6 +18,7 @@ variable "trigger" {
       resource   = string
     }))
   })
+  default = { http = false }
 }
 
 variable "env_vars" {


### PR DESCRIPTION
## Summary
- default trigger http flag to false in Cloud Function modules to avoid null checks

## Testing
- `npm test`
- `npm run lint`
- `npx prettier infra/modules/cloud-function/variables.tf infra/modules/cloud-function-v2/variables.tf -w` *(fails: No parser could be inferred for file)*

------
https://chatgpt.com/codex/tasks/task_e_68ae8cddc280832ea18c9f970ab1e25a