### PR TITLE
Avoid conflicting Cloud Function triggers

### DIFF
--- a/infra/modules/cloud-function/variables.tf
+++ b/infra/modules/cloud-function/variables.tf
@@ -16,9 +16,14 @@ variable "trigger" {
     event = optional(object({
       event_type = string
       resource   = string
+      retry      = optional(bool)
     }))
   })
   default = { http = false }
+  validation {
+    condition     = !(coalesce(var.trigger.http, false) && var.trigger.event != null)
+    error_message = "Provide either trigger.http OR trigger.event, not both."
+  }
 }
 
 variable "env_vars" {


### PR DESCRIPTION
## Summary
- Guard `trigger_http` and `event_trigger` in cloud-function module to avoid conflicts
- Validate trigger input and support optional retry field

## Testing
- `npm test`
- `npm run lint` *(277 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68ae90fc93a8832eb8dcd2b472b197f9