### PR TITLE
Handle Cloud Function event trigger retry policy

### DIFF
--- a/infra/modules/cloud-function/main.tf
+++ b/infra/modules/cloud-function/main.tf
@@ -32,7 +32,12 @@ resource "google_cloudfunctions_function" "function" {
     content {
       event_type = event_trigger.value.event_type
       resource   = event_trigger.value.resource
-      retry      = try(event_trigger.value.retry, null)
+      dynamic "failure_policy" {
+        for_each = try(event_trigger.value.retry, false) ? [1] : []
+        content {
+          retry = true
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- wrap Cloud Function event trigger retry handling in a `failure_policy` block to avoid Terraform plan failures

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae921188cc832eb1de56654c6892fb