### PR TITLE
Prevent accidental project service disabling in Terraform

### DIFF
--- a/infra/firebase-api-key.tf
+++ b/infra/firebase-api-key.tf
@@ -13,7 +13,8 @@ resource "google_project_iam_member" "terraform_apikeys_admin" {
   depends_on = [google_project_service.apikeys_api]
 }
 resource "google_project_service" "apikeys_api" {
-  project = var.project_id
-  service = "apikeys.googleapis.com"
+  project            = var.project_id
+  service            = "apikeys.googleapis.com"
+  disable_on_destroy = false
 }
 

--- a/infra/firebase-auth.tf
+++ b/infra/firebase-auth.tf
@@ -2,14 +2,16 @@
 
 # identity-toolkit = Firebase Auth backend
 resource "google_project_service" "identitytoolkit" {
-  project = var.project_id
-  service = "identitytoolkit.googleapis.com"
+  project            = var.project_id
+  service            = "identitytoolkit.googleapis.com"
+  disable_on_destroy = false
 }
 
 # firebase.googleapis.com upgrades the project to Firebase
 resource "google_project_service" "firebase_api" {
-  project = var.project_id
-  service = "firebase.googleapis.com"
+  project            = var.project_id
+  service            = "firebase.googleapis.com"
+  disable_on_destroy = false
 }
 
 resource "google_firebase_project" "core" {

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -158,46 +158,54 @@ resource "google_storage_bucket" "gcf_source_bucket" {
 }
 
 resource "google_project_service" "firestore" {
-  project = var.project_id
-  service = "firestore.googleapis.com"
+  project            = var.project_id
+  service            = "firestore.googleapis.com"
+  disable_on_destroy = false
 }
 
 resource "google_project_service" "cloudfunctions" {
-  project = var.project_id
-  service = "cloudfunctions.googleapis.com"
+  project            = var.project_id
+  service            = "cloudfunctions.googleapis.com"
+  disable_on_destroy = false
 }
 
 resource "google_project_service" "cloudbuild" {
-  project = var.project_id
-  service = "cloudbuild.googleapis.com"
+  project            = var.project_id
+  service            = "cloudbuild.googleapis.com"
+  disable_on_destroy = false
 }
 
 resource "google_project_service" "cloudscheduler" {
-  project = var.project_id
-  service = "cloudscheduler.googleapis.com"
+  project            = var.project_id
+  service            = "cloudscheduler.googleapis.com"
+  disable_on_destroy = false
 }
 
 resource "google_project_service" "firebaserules" {
-  project = var.project_id
-  service = "firebaserules.googleapis.com"
+  project            = var.project_id
+  service            = "firebaserules.googleapis.com"
+  disable_on_destroy = false
 }
 
 # Needed for Gen2 (backed by Cloud Run)
 resource "google_project_service" "run" {
-  project = var.project_id
-  service = "run.googleapis.com"
+  project            = var.project_id
+  service            = "run.googleapis.com"
+  disable_on_destroy = false
 }
 
 # Container images for Gen2 builds live here
 resource "google_project_service" "artifactregistry" {
-  project = var.project_id
-  service = "artifactregistry.googleapis.com"
+  project            = var.project_id
+  service            = "artifactregistry.googleapis.com"
+  disable_on_destroy = false
 }
 
 # Optional now, useful later for non-HTTP triggers
 resource "google_project_service" "eventarc" {
-  project = var.project_id
-  service = "eventarc.googleapis.com"
+  project            = var.project_id
+  service            = "eventarc.googleapis.com"
+  disable_on_destroy = false
 }
 
 

--- a/infra/moved.tf
+++ b/infra/moved.tf
@@ -1,0 +1,63 @@
+# State move blocks to migrate project service resources
+# from legacy for_each-based resource to individually named resources
+
+moved {
+  from = google_project_service.apis["firebase.googleapis.com"]
+  to   = google_project_service.firebase_api
+}
+
+moved {
+  from = google_project_service.apis["identitytoolkit.googleapis.com"]
+  to   = google_project_service.identitytoolkit
+}
+
+moved {
+  from = google_project_service.apis["cloudscheduler.googleapis.com"]
+  to   = google_project_service.cloudscheduler
+}
+
+moved {
+  from = google_project_service.apis["compute.googleapis.com"]
+  to   = google_project_service.compute
+}
+
+moved {
+  from = google_project_service.apis["eventarc.googleapis.com"]
+  to   = google_project_service.eventarc
+}
+
+moved {
+  from = google_project_service.apis["firebaserules.googleapis.com"]
+  to   = google_project_service.firebaserules
+}
+
+moved {
+  from = google_project_service.apis["cloudfunctions.googleapis.com"]
+  to   = google_project_service.cloudfunctions
+}
+
+moved {
+  from = google_project_service.apis["artifactregistry.googleapis.com"]
+  to   = google_project_service.artifactregistry
+}
+
+moved {
+  from = google_project_service.apis["firestore.googleapis.com"]
+  to   = google_project_service.firestore
+}
+
+moved {
+  from = google_project_service.apis["run.googleapis.com"]
+  to   = google_project_service.run
+}
+
+moved {
+  from = google_project_service.apis["apikeys.googleapis.com"]
+  to   = google_project_service.apikeys_api
+}
+
+moved {
+  from = google_project_service.apis["cloudbuild.googleapis.com"]
+  to   = google_project_service.cloudbuild
+}
+


### PR DESCRIPTION
## Summary
- keep key Google Cloud APIs enabled by marking `disable_on_destroy = false`
- map legacy `google_project_service.apis` resources to new names via Terraform `moved` blocks

## Testing
- ✅ `npm test`
- ✅ `npm run lint`
- ⚠️ `npx prettier --write infra/moved.tf infra/main.tf infra/firebase-auth.tf infra/firebase-api-key.tf` (No parser could be inferred for .tf files)
- ⚠️ `terraform fmt` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_68ae9cb1a908832ea2a09f4fb321cb56