### PR TITLE
ci: enable core GCP APIs before Terraform plan

### DIFF
--- a/.github/workflows/deploy-terraform.yml
+++ b/.github/workflows/deploy-terraform.yml
@@ -43,6 +43,18 @@ jobs:
       - name: Terraform Init
         run: terraform init
 
+      - name: Enable core GCP APIs
+        run: |
+          terraform apply -auto-approve \
+            -target=google_project_service.firestore \
+            -target=google_project_service.identitytoolkit \
+            -target=google_project_service.cloudfunctions \
+            -target=google_project_service.compute \
+            -target=google_project_service.run \
+            -target=google_project_service.artifactregistry \
+            -target=google_project_service.cloudscheduler \
+            -target=google_project_service.firebaserules
+
       - name: Terraform Plan
         run: terraform plan -lock-timeout=5m -input=false -out=tfplan
 


### PR DESCRIPTION
## Summary
- bootstrap core Google Cloud APIs in Terraform deploy workflow so subsequent plan/apply succeed

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aeaa28f990832e818c044402944c29