### PR TITLE
Avoid duplicate Terraform state moves

### DIFF
--- a/.github/workflows/deploy-terraform.yml
+++ b/.github/workflows/deploy-terraform.yml
@@ -45,10 +45,12 @@ jobs:
 
       - name: Migrate Firebase service state
         run: |
-          if terraform state list | grep -Fq 'google_project_service.apis["firebase.googleapis.com"]'; then
+          if terraform state list | grep -Fq 'google_project_service.apis["firebase.googleapis.com"]' \
+            && ! terraform state list | grep -Fq 'google_project_service.firebase_api'; then
             terraform state mv 'google_project_service.apis["firebase.googleapis.com"]' google_project_service.firebase_api
           fi
-          if terraform state list | grep -Fq 'google_project_service.apis["firebaserules.googleapis.com"]'; then
+          if terraform state list | grep -Fq 'google_project_service.apis["firebaserules.googleapis.com"]' \
+            && ! terraform state list | grep -Fq 'google_project_service.firebaserules'; then
             terraform state mv 'google_project_service.apis["firebaserules.googleapis.com"]' google_project_service.firebaserules
           fi
 


### PR DESCRIPTION
## Summary
- prevent Terraform state migration step from running when the target resource already exists

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af986f67c4832eb1271afd6796f0e5