### PR TITLE
Allow disabling Firebase services with dependencies

### DIFF
--- a/infra/firebase-auth.tf
+++ b/infra/firebase-auth.tf
@@ -11,7 +11,8 @@ resource "google_project_service" "identitytoolkit" {
 resource "google_project_service" "firebase_api" {
   project            = var.project_id
   service            = "firebase.googleapis.com"
-  disable_on_destroy = false
+  disable_on_destroy        = false
+  disable_dependent_services = true
 }
 
 resource "google_firebase_project" "core" {

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -184,7 +184,8 @@ resource "google_project_service" "cloudscheduler" {
 resource "google_project_service" "firebaserules" {
   project            = var.project_id
   service            = "firebaserules.googleapis.com"
-  disable_on_destroy = false
+  disable_on_destroy        = false
+  disable_dependent_services = true
 }
 
 # Needed for Gen2 (backed by Cloud Run)


### PR DESCRIPTION
## Summary
- enable Terraform to disable Firebase API even with dependent services
- allow Firebaserules service to disable dependencies during teardown

## Testing
- `npm test`
- `npm run lint` *(warnings: Missing JSDoc, camelcase identifiers, no-ternary)*

------
https://chatgpt.com/codex/tasks/task_e_68af9cde1918832eb6fa88cb95f83606