### PR TITLE
Use state migration in Terraform deploy workflow

### DIFF
--- a/.github/workflows/deploy-terraform.yml
+++ b/.github/workflows/deploy-terraform.yml
@@ -41,18 +41,7 @@ jobs:
           terraform_version: 1.6.6
 
       - name: Terraform Init
-        run: terraform init
-
-      - name: Migrate Firebase service state
-        run: |
-          if terraform state list | grep -Fq 'google_project_service.apis["firebase.googleapis.com"]' \
-            && ! terraform state list | grep -Fq 'google_project_service.firebase_api'; then
-            terraform state mv 'google_project_service.apis["firebase.googleapis.com"]' google_project_service.firebase_api
-          fi
-          if terraform state list | grep -Fq 'google_project_service.apis["firebaserules.googleapis.com"]' \
-            && ! terraform state list | grep -Fq 'google_project_service.firebaserules'; then
-            terraform state mv 'google_project_service.apis["firebaserules.googleapis.com"]' google_project_service.firebaserules
-          fi
+        run: terraform init -migrate-state
 
       - name: Enable core GCP APIs
         run: |


### PR DESCRIPTION
## Summary
- simplify Terraform deploy by relying on `terraform init -migrate-state`
- remove manual state migration script now handled by init

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68afacad1554832e95b2c608cf09396f