### PR TITLE
Verify firebaserules state during Terraform workflow

### DIFF
--- a/.github/workflows/deploy-terraform.yml
+++ b/.github/workflows/deploy-terraform.yml
@@ -43,6 +43,14 @@ jobs:
       - name: Terraform Init
         run: terraform init -migrate-state
 
+      - name: Verify firebaserules state move
+        run: |
+          count=$(terraform state list | grep firebaserules | wc -l)
+          if [ "$count" -ne 1 ]; then
+            echo "Expected exactly one firebaserules service resource, found $count"
+            exit 1
+          fi
+
       - name: Enable core GCP APIs
         run: |
           terraform apply -auto-approve \
@@ -57,6 +65,13 @@ jobs:
 
       - name: Terraform Plan
         run: terraform plan -lock-timeout=5m -input=false -out=tfplan
+
+      - name: Ensure firebaserules not destroyed
+        run: |
+          if terraform show -no-color tfplan | grep -q '# google_project_service.firebaserules will be destroyed'; then
+            echo 'firebaserules.googleapis.com service would be destroyed'
+            exit 1
+          fi
 
       - name: Terraform Apply
         run: terraform apply -lock-timeout=5m -auto-approve tfplan


### PR DESCRIPTION
## Summary
- add workflow step to ensure `firebaserules` service has migrated state and is sole entry
- guard against accidentally destroying `firebaserules.googleapis.com` during plan

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68afbfd1297c832eb57a0fb712f020d6