### PR TITLE
chore: clean up firebaserules state

### DIFF
--- a/.github/workflows/deploy-terraform.yml
+++ b/.github/workflows/deploy-terraform.yml
@@ -43,6 +43,14 @@ jobs:
       - name: Terraform Init
         run: terraform init -migrate-state
 
+      - name: Cleanup firebaserules state
+        run: |
+          extra=$(terraform state list | grep firebaserules | grep -v '^google_project_service.firebaserules$' || true)
+          if [ -n "$extra" ]; then
+            echo "Removing duplicate firebaserules entries:"
+            echo "$extra" | xargs -n1 terraform state rm
+          fi
+
       - name: Verify firebaserules state move
         run: |
           count=$(terraform state list | grep firebaserules | wc -l)


### PR DESCRIPTION
## Summary
- remove duplicate firebaserules state entries before verification in deploy-terraform workflow

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68afc552db94832e85dfaf9025177842