### PR TITLE
Ensure Terraform firebaserules cleanup aborts on errors

### DIFF
--- a/.github/workflows/deploy-terraform.yml
+++ b/.github/workflows/deploy-terraform.yml
@@ -45,6 +45,7 @@ jobs:
 
       - name: Cleanup firebaserules state
         run: |
+          set -euo pipefail
           extra=$(terraform state list | grep firebaserules | grep -v '^google_project_service.firebaserules$' || true)
           if [ -n "$extra" ]; then
             echo "Removing duplicate firebaserules entries:"


### PR DESCRIPTION
## Summary
- Make `Cleanup firebaserules state` step fail fast by enabling `set -euo pipefail`

## Testing
- `npm test`
- `npm run lint` (warnings: 150)

------
https://chatgpt.com/codex/tasks/task_e_68afcbd5d400832ebe020b31ae7497f4