### PR TITLE
chore: use grep -c for firebaserules count

### DIFF
--- a/.github/workflows/deploy-terraform.yml
+++ b/.github/workflows/deploy-terraform.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Verify firebaserules state move
         run: |
-          count=$(terraform state list | grep firebaserules | wc -l)
+          count=$(terraform state list | grep -c firebaserules || true)
           if [ "$count" -ne 1 ]; then
             echo "Expected exactly one firebaserules service resource, found $count"
             exit 1


### PR DESCRIPTION
## Summary
- simplify firebaserules count check using `grep -c` in Terraform deploy workflow

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68afcc72d0e0832e9941230d173ee2e0