### PR TITLE
Ensure firebaserules cleanup fails on state removal errors

### DIFF
--- a/.github/workflows/deploy-terraform.yml
+++ b/.github/workflows/deploy-terraform.yml
@@ -49,7 +49,9 @@ jobs:
           extra=$(terraform state list | grep firebaserules | grep -v '^google_project_service.firebaserules$' || true)
           if [ -n "$extra" ]; then
             echo "Removing duplicate firebaserules entries:"
-            echo "$extra" | xargs -n1 terraform state rm
+            while IFS= read -r rule; do
+              terraform state rm "$rule"
+            done <<< "$extra"
           fi
 
       - name: Verify firebaserules state move


### PR DESCRIPTION
## Summary
- enforce strict error handling in the firebaserules state cleanup
- remove duplicate state entries with a loop so `terraform state rm` failures stop the workflow

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68afd12b85ec832e8c82cbbef1653787