### PR TITLE
Use grep -c for firebaserules count

### DIFF
--- a/.github/workflows/deploy-terraform.yml
+++ b/.github/workflows/deploy-terraform.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Verify firebaserules state move
         run: |
-          count=$(terraform state list | grep -c firebaserules || true)
+          count=$(terraform state list | grep -c firebaserules)
           if [ "$count" -ne 1 ]; then
             echo "Expected exactly one firebaserules service resource, found $count"
             exit 1


### PR DESCRIPTION
## Summary
- simplify firebaserules state verification using `grep -c`

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68afd2740080832e9edadb189cde67c1