### PR TITLE
chore: add manual terraform cleanup

### DIFF
--- a/.github/workflows/cleanup-terraform.yml
+++ b/.github/workflows/cleanup-terraform.yml
@@ -1,0 +1,45 @@
+name: Cleanup Terraform Services
+
+# Run this workflow only after verifying new resources function as expected.
+on:
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: infra
+    env:
+      REGION: europe-west1
+      ENVIRONMENT: prod
+      TF_VAR_google_oauth_client_id: ${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}
+      TF_VAR_google_oauth_client_secret: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set up Google Cloud auth
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: '${{ secrets.GOOGLE_CREDENTIALS }}'
+
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: ${{ secrets.GOOGLE_PROJECT }}
+          install_components: gcloud
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.6.6
+
+      - name: Terraform Init
+        run: terraform init -migrate-state
+
+      - name: Disable deprecated services
+        run: |
+          terraform apply -lock-timeout=5m -auto-approve \
+            -target=google_project_service.firebasehosting

--- a/.github/workflows/deploy-terraform.yml
+++ b/.github/workflows/deploy-terraform.yml
@@ -43,25 +43,6 @@ jobs:
       - name: Terraform Init
         run: terraform init -migrate-state
 
-      - name: Cleanup firebaserules state
-        run: |
-          set -euo pipefail
-          extra=$(terraform state list | grep firebaserules | grep -v '^google_project_service.firebaserules$' || true)
-          if [ -n "$extra" ]; then
-            echo "Removing duplicate firebaserules entries:"
-            while IFS= read -r rule; do
-              terraform state rm "$rule"
-            done <<< "$extra"
-          fi
-
-      - name: Verify firebaserules state move
-        run: |
-          count=$(terraform state list | grep -c firebaserules)
-          if [ "$count" -ne 1 ]; then
-            echo "Expected exactly one firebaserules service resource, found $count"
-            exit 1
-          fi
-
       - name: Enable core GCP APIs
         run: |
           terraform apply -auto-approve \

--- a/README.md
+++ b/README.md
@@ -73,6 +73,13 @@ npm install
 - **Formatting**: Consistent indentation (2 spaces)
 - **File Structure**: Modular components in separate files
 
+## Terraform Workflows
+
+Infrastructure is managed with Terraform via GitHub Actions. The **Deploy Terraform**
+workflow applies changes automatically when commits modify the `infra/` directory.
+After confirming that newly provisioned resources function as expected, run the
+manual **Cleanup Terraform Services** workflow to disable any deprecated services.
+
 ## Refactoring Principles
 
 - **Don't Repeat Yourself:** Eliminate duplication in content and structure.
@@ -93,11 +100,7 @@ Blog posts are defined in the `src/blog.json` file with the following structure:
       "key": "UNIQUE_KEY",
       "title": "Post Title",
       "publicationDate": "YYYY-MM-DD",
-      "content": [
-        "Paragraph 1",
-        "Paragraph 2",
-        "..."
-      ],
+      "content": ["Paragraph 1", "Paragraph 2", "..."],
       "illustration": {
         "fileType": "png|webp",
         "altText": "Description of the image"


### PR DESCRIPTION
## Summary
- remove firebaserules state cleanup from deploy workflow
- add workflow to manually disable deprecated services
- mention manual cleanup workflow in documentation

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68afd5027fd4832ea0db1891bddbd557