### PR TITLE
chore: update gcloud components in Terraform workflow

### DIFF
--- a/.github/workflows/deploy-terraform.yml
+++ b/.github/workflows/deploy-terraform.yml
@@ -33,7 +33,7 @@ jobs:
         uses: google-github-actions/setup-gcloud@v2
         with:
           project_id: ${{ secrets.GOOGLE_PROJECT }}
-          install_components: 'alpha,firebaserules'
+          install_components: alpha
 
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v3


### PR DESCRIPTION
## Summary
- only install the `alpha` component when setting up the Google Cloud SDK in the Terraform deploy workflow

## Testing
- `npm test`
- `npm run lint`
- `git push` *(fails: No configured push destination)*
- `gh workflow run deploy-terraform.yml` *(fails: requires GitHub authentication)*

------
https://chatgpt.com/codex/tasks/task_e_68b101b24eac832e95dbc1e5af921703