### PR TITLE
Enable Firebase management API early in Terraform workflow

### DIFF
--- a/.github/workflows/deploy-terraform.yml
+++ b/.github/workflows/deploy-terraform.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Terraform Init
         run: terraform init -migrate-state
 
+      - name: Enable Firebase management API
+        run: terraform apply -auto-approve -target=google_project_service.firebase_api
+
       - name: Enable core GCP APIs
         run: |
           terraform apply -auto-approve \


### PR DESCRIPTION
## Summary
- enable Firebase Management API before other GCP services in Terraform GitHub Actions workflow

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b12e2a92f0832eab9cda482e15ea84