### PR TITLE
Remove missing Firestore release from Terraform config

### DIFF
--- a/infra/dendrite-firestore.tf
+++ b/infra/dendrite-firestore.tf
@@ -19,21 +19,6 @@ resource "google_firebaserules_ruleset" "firestore" {
   ]
 }
 
-resource "google_firebaserules_release" "firestore" {
-  provider     = google-beta
-  project      = var.project_id
-  name         = "firestore.rules"
-  ruleset_name = google_firebaserules_ruleset.firestore.name
-
-  lifecycle {
-    ignore_changes = [ ruleset_name ]
-  }
-
-  depends_on = [
-    google_project_iam_member.ci_firebaserules_admin   # ensure role is live
-  ]
-}
-
 resource "google_firestore_index" "variants_author_created" {
   project     = var.project_id
   collection  = "variants"
@@ -124,10 +109,5 @@ resource "google_firestore_field" "pages_number_global" {
       query_scope = "COLLECTION_GROUP"
     }
   }
-}
-
-import {
-  to = google_firebaserules_release.firestore
-  id = "projects/${var.project_id}/releases/cloud.firestore"
 }
 


### PR DESCRIPTION
## Summary
- remove nonexistent `google_firebaserules_release.firestore` resource and import block

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b13a5ebfc4832e814d37427a39157b