### PR TITLE
chore: remove firestore release import

### DIFF
--- a/.github/workflows/deploy-terraform.yml
+++ b/.github/workflows/deploy-terraform.yml
@@ -42,20 +42,6 @@ jobs:
 
       - name: Terraform Init
         run: terraform init -migrate-state
-
-      - name: Import existing Firestore rules release
-        run: |
-          if ! terraform state list | grep -q google_firebaserules_release.firestore; then
-            RELEASE_NAME=$(gcloud alpha firebaserules releases list --project ${{ secrets.GOOGLE_PROJECT }} --format='value(name)' --filter='name:firestore.rules' | head -n 1)
-            if [ -n "$RELEASE_NAME" ]; then
-              terraform import google_firebaserules_release.firestore "$RELEASE_NAME"
-            else
-              echo 'No existing Firestore rules release found'
-            fi
-          else
-            echo 'Firestore rules release already imported'
-          fi
-
       - name: Terraform Plan
         run: terraform plan -lock-timeout=5m -input=false -out=tfplan
 


### PR DESCRIPTION
## Summary
- remove firestore rules release import step from terraform deploy workflow

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b144af6350832e872aa57ac69a9cc9