### PR TITLE
Document static vs generated HTML in infra instructions

### DIFF
--- a/infra/AGENTS.md
+++ b/infra/AGENTS.md
@@ -1,0 +1,20 @@
+# AGENTS Instructions for infra
+
+## Scope
+
+These instructions apply to everything under `infra/`.
+
+## Static vs generated HTML
+
+Several HTML files in this directory are uploaded verbatim to the static site
+bucket via Terraform. The committed copies are the source of truth for the
+following pages: `404.html`, `about.html`, `admin.html`, `manual.html`,
+`mod.html`, `new-page.html`, and `new-story.html`. Update these files directly
+when you need to change their markup.
+
+Other HTML assets that appear on the live site are produced by Cloud Functions
+in `infra/cloud-functions/`. The `render-contents` function writes `index.html`
+and `contents/{page}.html`, `render-variant` renders story and author pages
+under `p/*.html` and `a/*.html`, and `generate-stats` produces `stats.html`.
+Do not try to add or edit those generated files in Terraform; instead adjust
+the corresponding Cloud Function implementation.


### PR DESCRIPTION
## Summary
- add an infra-specific AGENTS file that documents which HTML pages are deployed as static objects
- note which site pages are generated by Cloud Functions so future updates target the right code path

## Testing
- npm test
- npm run lint (fails with existing warnings)

------
https://chatgpt.com/codex/tasks/task_e_68c8fb128664832eab64a5951480b9f4