### PR TITLE
feat: add About link to menu

### DIFF
--- a/infra/404.html
+++ b/infra/404.html
@@ -22,6 +22,7 @@
         <a href="/new-story.html">New story</a>
         <a href="/mod.html">Moderate</a>
         <a href="/stats.html">Stats</a>
+        <a href="/about.html">About</a>
         <a class="admin-link" href="/admin.html" style="display: none">Admin</a>
         <div id="signinButton"></div>
         <div id="signoutWrap" style="display: none">
@@ -57,6 +58,11 @@
             <a class="admin-link" href="/admin.html" style="display: none"
               >Admin</a
             >
+          </div>
+
+          <div class="menu-group">
+            <h3>About</h3>
+            <a href="/about.html">About</a>
           </div>
 
           <div class="menu-group">

--- a/infra/about.html
+++ b/infra/about.html
@@ -22,6 +22,7 @@
         <a href="/new-story.html">New story</a>
         <a href="/mod.html">Moderate</a>
         <a href="/stats.html">Stats</a>
+        <a href="/about.html">About</a>
         <div id="signinButton"></div>
         <div id="signoutWrap" style="display: none">
           <a id="signoutLink" href="#">Sign out</a>
@@ -54,6 +55,11 @@
             <a href="/mod.html">Moderate</a>
             <a href="/stats.html">Stats</a>
             <a id="adminLink" href="/admin.html" style="display: none">Admin</a>
+          </div>
+
+          <div class="menu-group">
+            <h3>About</h3>
+            <a href="/about.html">About</a>
           </div>
 
           <div class="menu-group">

--- a/infra/admin.html
+++ b/infra/admin.html
@@ -22,6 +22,7 @@
         <a href="/new-story.html">New story</a>
         <a href="/mod.html">Moderate</a>
         <a href="/stats.html">Stats</a>
+        <a href="/about.html">About</a>
         <div id="signinButton"></div>
         <div id="signoutWrap" style="display: none">
           <a id="signoutLink" href="#">Sign out</a>
@@ -53,6 +54,11 @@
             <h3>Moderation</h3>
             <a href="/mod.html">Moderate</a>
             <a href="/stats.html">Stats</a>
+          </div>
+
+          <div class="menu-group">
+            <h3>About</h3>
+            <a href="/about.html">About</a>
           </div>
 
           <div class="menu-group">

--- a/infra/cloud-functions/render-contents/htmlSnippets.js
+++ b/infra/cloud-functions/render-contents/htmlSnippets.js
@@ -25,6 +25,7 @@ export const PAGE_HTML = list => `<!doctype html>
         <a href="/new-story.html">New story</a>
         <a href="/mod.html">Moderate</a>
         <a href="/stats.html">Stats</a>
+        <a href="/about.html">About</a>
         <a class="admin-link" href="/admin.html" style="display:none">Admin</a>
         <div id="signinButton"></div>
         <div id="signoutWrap" style="display:none">
@@ -51,6 +52,11 @@ export const PAGE_HTML = list => `<!doctype html>
             <a href="/mod.html">Moderate</a>
             <a href="/stats.html">Stats</a>
             <a class="admin-link" href="/admin.html" style="display:none">Admin</a>
+          </div>
+
+          <div class="menu-group">
+            <h3>About</h3>
+            <a href="/about.html">About</a>
           </div>
 
           <div class="menu-group">

--- a/infra/cloud-functions/render-variant/buildHtml.js
+++ b/infra/cloud-functions/render-variant/buildHtml.js
@@ -119,6 +119,7 @@ export function buildHtml(
         <a href="/new-story.html">New story</a>
         <a href="/mod.html">Moderate</a>
         <a href="/stats.html">Stats</a>
+        <a href="/about.html">About</a>
         <a class="admin-link" href="/admin.html" style="display:none">Admin</a>
         <div id="signinButton"></div>
         <div id="signoutWrap" style="display:none">
@@ -145,6 +146,11 @@ export function buildHtml(
             <a href="/mod.html">Moderate</a>
             <a href="/stats.html">Stats</a>
             <a class="admin-link" href="/admin.html" style="display:none">Admin</a>
+          </div>
+
+          <div class="menu-group">
+            <h3>About</h3>
+            <a href="/about.html">About</a>
           </div>
 
           <div class="menu-group">

--- a/infra/manual.html
+++ b/infra/manual.html
@@ -22,6 +22,7 @@
         <a href="/new-story.html">New story</a>
         <a href="/mod.html">Moderate</a>
         <a href="/stats.html">Stats</a>
+        <a href="/about.html">About</a>
         <div id="signinButton"></div>
         <div id="signoutWrap" style="display: none">
           <a id="signoutLink" href="#">Sign out</a>
@@ -53,6 +54,11 @@
             <h3>Moderation</h3>
             <a href="/mod.html">Moderate</a>
             <a href="/stats.html">Stats</a>
+          </div>
+
+          <div class="menu-group">
+            <h3>About</h3>
+            <a href="/about.html">About</a>
           </div>
 
           <div class="menu-group">

--- a/infra/mod.html
+++ b/infra/mod.html
@@ -22,6 +22,7 @@
         <a href="/new-story.html">New story</a>
         <a href="/mod.html">Moderate</a>
         <a href="/stats.html">Stats</a>
+        <a href="/about.html">About</a>
         <a class="admin-link" href="/admin.html" style="display: none">Admin</a>
         <div id="signinButton"></div>
         <div id="signoutWrap" style="display: none">
@@ -57,6 +58,11 @@
             <a class="admin-link" href="/admin.html" style="display: none"
               >Admin</a
             >
+          </div>
+
+          <div class="menu-group">
+            <h3>About</h3>
+            <a href="/about.html">About</a>
           </div>
 
           <div class="menu-group">

--- a/infra/new-page.html
+++ b/infra/new-page.html
@@ -22,6 +22,7 @@
         <a href="/new-story.html">New story</a>
         <a href="/mod.html">Moderate</a>
         <a href="/stats.html">Stats</a>
+        <a href="/about.html">About</a>
         <a class="admin-link" href="/admin.html" style="display: none">Admin</a>
         <div id="signinButton"></div>
         <div id="signoutWrap" style="display: none">
@@ -57,6 +58,11 @@
             <a class="admin-link" href="/admin.html" style="display: none"
               >Admin</a
             >
+          </div>
+
+          <div class="menu-group">
+            <h3>About</h3>
+            <a href="/about.html">About</a>
           </div>
 
           <div class="menu-group">

--- a/infra/new-story.html
+++ b/infra/new-story.html
@@ -22,6 +22,7 @@
         <a href="/new-story.html">New story</a>
         <a href="/mod.html">Moderate</a>
         <a href="/stats.html">Stats</a>
+        <a href="/about.html">About</a>
         <a class="admin-link" href="/admin.html" style="display: none">Admin</a>
         <div id="signinButton"></div>
         <div id="signoutWrap" style="display: none">
@@ -57,6 +58,11 @@
             <a class="admin-link" href="/admin.html" style="display: none"
               >Admin</a
             >
+          </div>
+
+          <div class="menu-group">
+            <h3>About</h3>
+            <a href="/about.html">About</a>
           </div>
 
           <div class="menu-group">


### PR DESCRIPTION
## Summary
- add the About link to the desktop navigation and mobile menu overlay across the infra HTML pages so users can reach the About page from any shell
- update the story rendering helpers to emit the About link in both desktop and mobile navigation blocks

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8fb2739dc832ea45323f24e663050