### PR TITLE
Add About link to stats page navigation

### DIFF
--- a/infra/cloud-functions/generate-stats/index.js
+++ b/infra/cloud-functions/generate-stats/index.js
@@ -67,6 +67,7 @@ function buildHtml(storyCount, pageCount, unmoderatedCount, topStories = []) {
         <a href="/new-story.html">New story</a>
         <a href="/mod.html">Moderate</a>
         <a href="/stats.html">Stats</a>
+        <a href="/about.html">About</a>
         <a class="admin-link" href="/admin.html" style="display:none">Admin</a>
         <div id="signinButton"></div>
         <div id="signoutWrap" style="display:none">
@@ -93,6 +94,11 @@ function buildHtml(storyCount, pageCount, unmoderatedCount, topStories = []) {
             <a href="/mod.html">Moderate</a>
             <a href="/stats.html">Stats</a>
             <a class="admin-link" href="/admin.html" style="display:none">Admin</a>
+          </div>
+
+          <div class="menu-group">
+            <h3>About</h3>
+            <a href="/about.html">About</a>
           </div>
 
           <div class="menu-group">


### PR DESCRIPTION
## Summary
- add an About page link to the stats page primary navigation
- mirror the About link in the stats page mobile menu for consistent access

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c90f42c164832e8c8046013b8df002