### PR TITLE
Limit contents link hit area

### DIFF
--- a/infra/dendrite.css
+++ b/infra/dendrite.css
@@ -235,7 +235,7 @@ ol.contents li::marker {
 }
 
 ol.contents a {
-  display: block;
+  display: inline-block;
   padding-block: 6px;
 }
 


### PR DESCRIPTION
## Summary
- limit the contents list link hit area to the text by switching the anchors to inline-block display

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca6c4ba1f8832e8f2320d393bb0020