### PR TITLE
Handle guard errors via helper

### DIFF
--- a/infra/cloud-functions/assign-moderation-job/index.js
+++ b/infra/cloud-functions/assign-moderation-job/index.js
@@ -51,8 +51,9 @@ function getIdTokenFromRequest(req) {
 async function handleAssignModerationJob(req, res) {
   const guardResult = await runGuards({ req });
 
-  if (guardResult.error) {
-    res.status(guardResult.error.status).send(guardResult.error.body);
+  const derivedGuardError = deriveGuardErrorResponse(guardResult);
+  if (derivedGuardError) {
+    res.status(derivedGuardError.status).send(derivedGuardError.body);
     return;
   }
 
@@ -76,6 +77,20 @@ async function handleAssignModerationJob(req, res) {
   });
 
   res.status(201).json({});
+}
+
+/**
+ * Convert a guard result into an HTTP response description if it failed.
+ * @param {GuardResult} guardResult Outcome from the guard chain.
+ * @returns {{ status: number, body: string } | undefined} Response metadata or undefined when successful.
+ */
+function deriveGuardErrorResponse(guardResult) {
+  const error = guardResult?.error;
+  if (!error) {
+    return undefined;
+  }
+
+  return { status: error.status, body: error.body };
 }
 
 /**


### PR DESCRIPTION
## Summary
- add a deriveGuardErrorResponse helper to convert guard failures into HTTP response metadata
- update handleAssignModerationJob to use the helper and exit early when guards fail

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca855734e0832eb489d5281f301375