### PR TITLE
Style moderation story content in card

### DIFF
--- a/infra/dendrite.css
+++ b/infra/dendrite.css
@@ -212,6 +212,46 @@ main {
   margin: 0 auto;
 }
 
+.moderation-card {
+  margin: var(--s4) 0;
+  padding: var(--s4);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  background: var(--surface-800);
+  box-shadow: 0 12px 30px rgba(11, 15, 20, 0.12);
+  transition:
+    box-shadow 0.2s ease,
+    transform 0.2s ease;
+}
+
+.moderation-card:hover,
+.moderation-card:focus-within {
+  box-shadow: 0 16px 40px rgba(11, 15, 20, 0.18);
+  transform: translateY(-2px);
+}
+
+.moderation-card h3 {
+  margin-top: 0;
+  margin-bottom: var(--s2);
+}
+
+.moderation-card p {
+  margin-top: 0;
+  margin-bottom: var(--s3);
+}
+
+.moderation-card ol {
+  margin-top: var(--s3);
+  padding-left: 1.25rem;
+}
+
+#actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--s2);
+  margin-top: var(--s4);
+}
+
 /* Headings */
 h1 {
   margin: var(--s3) 0 var(--s2);

--- a/infra/mod.html
+++ b/infra/mod.html
@@ -85,7 +85,12 @@
         When you're signed in, a page will be shown to approve or reject. After
         submitting a rating, the next page will load automatically.
       </p>
-      <div id="pageContent"></div>
+      <div
+        id="pageContent"
+        class="moderation-card"
+        style="display: none"
+        aria-live="polite"
+      ></div>
       <div id="actions">
         <button id="approveBtn" type="button" disabled>Approve</button>
         <button id="rejectBtn" type="button" disabled>Reject</button>


### PR DESCRIPTION
## Summary
- wrap the moderation story container in a dedicated card region with polite live updates
- add card styling and refreshed action layout so moderated stories stand out from the page

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68caa2e83930832e8d8ef1a76ecc83ff