### PR TITLE
Refactor assign moderation workflow

### DIFF
--- a/infra/cloud-functions/assign-moderation-job/workflow.js
+++ b/infra/cloud-functions/assign-moderation-job/workflow.js
@@ -1,0 +1,61 @@
+/**
+ * @typedef {object} AssignModerationWorkflowDeps
+ * @property {(context: { req: import("express").Request }) => Promise<{ error?: { status: number, body: string }, context?: { userRecord?: import("firebase-admin/auth").UserRecord } }>} runGuards
+ * @property {(randomValue: number) => Promise<unknown>} fetchVariantSnapshot
+ * @property {(snapshot: unknown) => { variantDoc?: { ref: unknown }, errorMessage?: string }} selectVariantDoc
+ * @property {(variantRef: unknown, createdAt: unknown) => { variant: unknown, createdAt: unknown }} buildAssignment
+ * @property {(uid: string) => { set: (assignment: unknown) => Promise<unknown> }} createModeratorRef
+ * @property {() => unknown} now
+ * @property {() => number} random
+ */
+
+/**
+ * @typedef {{ req: import("express").Request }} AssignModerationWorkflowInput
+ */
+
+/**
+ * Create the moderation assignment workflow.
+ * @param {AssignModerationWorkflowDeps} deps Dependencies required by the workflow.
+ * @returns {(input: AssignModerationWorkflowInput) => Promise<{ status: number, body: unknown }>}
+ */
+export function createAssignModerationWorkflow({
+  runGuards,
+  fetchVariantSnapshot,
+  selectVariantDoc,
+  buildAssignment,
+  createModeratorRef,
+  now,
+  random,
+}) {
+  return async function assignModerationWorkflow({ req }) {
+    const guardResult = await runGuards({ req });
+
+    if (guardResult?.error) {
+      return {
+        status: guardResult.error.status,
+        body: guardResult.error.body,
+      };
+    }
+
+    const { userRecord } = guardResult.context ?? {};
+
+    if (!userRecord?.uid) {
+      return { status: 500, body: "Moderator lookup failed" };
+    }
+
+    const randomValue = random();
+    const variantSnapshot = await fetchVariantSnapshot(randomValue);
+    const { errorMessage, variantDoc } = selectVariantDoc(variantSnapshot);
+
+    if (errorMessage) {
+      return { status: 500, body: errorMessage };
+    }
+
+    const moderatorRef = createModeratorRef(userRecord.uid);
+    const createdAt = now();
+    const assignment = buildAssignment(variantDoc.ref, createdAt);
+    await moderatorRef.set(assignment);
+
+    return { status: 201, body: {} };
+  };
+}

--- a/test/cloud-functions/assignModerationWorkflow.test.js
+++ b/test/cloud-functions/assignModerationWorkflow.test.js
@@ -1,0 +1,143 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { createAssignModerationWorkflow } from '../../infra/cloud-functions/assign-moderation-job/workflow.js';
+
+describe('createAssignModerationWorkflow', () => {
+  const request = { method: 'POST' };
+
+  it('returns guard failure responses without invoking downstream steps', async () => {
+    const runGuards = jest.fn().mockResolvedValue({
+      error: { status: 401, body: 'Nope' },
+    });
+    const fetchVariantSnapshot = jest.fn();
+    const selectVariantDoc = jest.fn();
+    const buildAssignment = jest.fn();
+    const createModeratorRef = jest.fn();
+    const now = jest.fn();
+    const random = jest.fn();
+
+    const assignModerationWorkflow = createAssignModerationWorkflow({
+      runGuards,
+      fetchVariantSnapshot,
+      selectVariantDoc,
+      buildAssignment,
+      createModeratorRef,
+      now,
+      random,
+    });
+
+    const response = await assignModerationWorkflow({ req: request });
+
+    expect(response).toEqual({ status: 401, body: 'Nope' });
+    expect(fetchVariantSnapshot).not.toHaveBeenCalled();
+    expect(selectVariantDoc).not.toHaveBeenCalled();
+    expect(buildAssignment).not.toHaveBeenCalled();
+    expect(createModeratorRef).not.toHaveBeenCalled();
+    expect(now).not.toHaveBeenCalled();
+    expect(random).not.toHaveBeenCalled();
+  });
+
+  it('returns an error when no variant can be selected', async () => {
+    const runGuards = jest.fn().mockResolvedValue({
+      context: { userRecord: { uid: 'moderator-1' } },
+    });
+    const fetchVariantSnapshot = jest.fn().mockResolvedValue({});
+    const selectVariantDoc = jest
+      .fn()
+      .mockReturnValue({ errorMessage: 'Variant fetch failed' });
+    const buildAssignment = jest.fn();
+    const createModeratorRef = jest.fn();
+    const now = jest.fn();
+    const random = jest.fn().mockReturnValue(0.42);
+
+    const assignModerationWorkflow = createAssignModerationWorkflow({
+      runGuards,
+      fetchVariantSnapshot,
+      selectVariantDoc,
+      buildAssignment,
+      createModeratorRef,
+      now,
+      random,
+    });
+
+    const response = await assignModerationWorkflow({ req: request });
+
+    expect(random).toHaveBeenCalledTimes(1);
+    expect(fetchVariantSnapshot).toHaveBeenCalledWith(0.42);
+    expect(selectVariantDoc).toHaveBeenCalledWith({});
+    expect(createModeratorRef).not.toHaveBeenCalled();
+    expect(buildAssignment).not.toHaveBeenCalled();
+    expect(now).not.toHaveBeenCalled();
+    expect(response).toEqual({ status: 500, body: 'Variant fetch failed' });
+  });
+
+  it('returns an error when the user record is missing', async () => {
+    const runGuards = jest.fn().mockResolvedValue({ context: {} });
+    const fetchVariantSnapshot = jest.fn();
+    const selectVariantDoc = jest.fn();
+    const buildAssignment = jest.fn();
+    const createModeratorRef = jest.fn();
+    const now = jest.fn();
+    const random = jest.fn();
+
+    const assignModerationWorkflow = createAssignModerationWorkflow({
+      runGuards,
+      fetchVariantSnapshot,
+      selectVariantDoc,
+      buildAssignment,
+      createModeratorRef,
+      now,
+      random,
+    });
+
+    const response = await assignModerationWorkflow({ req: request });
+
+    expect(random).not.toHaveBeenCalled();
+    expect(fetchVariantSnapshot).not.toHaveBeenCalled();
+    expect(selectVariantDoc).not.toHaveBeenCalled();
+    expect(createModeratorRef).not.toHaveBeenCalled();
+    expect(buildAssignment).not.toHaveBeenCalled();
+    expect(now).not.toHaveBeenCalled();
+    expect(response).toEqual({
+      status: 500,
+      body: 'Moderator lookup failed',
+    });
+  });
+
+  it('persists the assignment when a variant is available', async () => {
+    const runGuards = jest.fn().mockResolvedValue({
+      context: { userRecord: { uid: 'moderator-2' } },
+    });
+    const fetchVariantSnapshot = jest
+      .fn()
+      .mockResolvedValue({ snapshot: true });
+    const variantDoc = { ref: { path: 'variants/123' } };
+    const selectVariantDoc = jest.fn().mockReturnValue({ variantDoc });
+    const assignment = { variant: 'variants/123', createdAt: 'timestamp' };
+    const buildAssignment = jest.fn().mockReturnValue(assignment);
+    const set = jest.fn().mockResolvedValue(undefined);
+    const createModeratorRef = jest.fn().mockReturnValue({ set });
+    const now = jest.fn().mockReturnValue('timestamp');
+    const random = jest.fn().mockReturnValue(0.84);
+
+    const assignModerationWorkflow = createAssignModerationWorkflow({
+      runGuards,
+      fetchVariantSnapshot,
+      selectVariantDoc,
+      buildAssignment,
+      createModeratorRef,
+      now,
+      random,
+    });
+
+    const response = await assignModerationWorkflow({ req: request });
+
+    expect(random).toHaveBeenCalledTimes(1);
+    expect(fetchVariantSnapshot).toHaveBeenCalledWith(0.84);
+    expect(selectVariantDoc).toHaveBeenCalledWith({ snapshot: true });
+    expect(createModeratorRef).toHaveBeenCalledWith('moderator-2');
+    expect(now).toHaveBeenCalledTimes(1);
+    expect(buildAssignment).toHaveBeenCalledWith(variantDoc.ref, 'timestamp');
+    expect(set).toHaveBeenCalledWith(assignment);
+    expect(response).toEqual({ status: 201, body: {} });
+  });
+});


### PR DESCRIPTION
## Summary
- extract the assign moderation orchestration into a dependency-injected workflow module
- update the HTTP handler to delegate to the workflow and keep request/response adaptation concerns
- add unit tests that stub the workflow dependencies to cover guard failures, missing variants, and success

## Testing
- npm test
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68caaea9244c832eb2e05f3339e6eec3