### PR TITLE
Refactor variant selection workflow

### DIFF
--- a/infra/cloud-functions/assign-moderation-job/variant-selection.js
+++ b/infra/cloud-functions/assign-moderation-job/variant-selection.js
@@ -1,0 +1,88 @@
+/**
+ * @typedef {object} VariantQueryDescriptor
+ * @property {"zeroRated"|"any"} reputation Reputation filter applied to the query.
+ * @property {">="|"<"} comparator Comparison operator applied to the random value.
+ * @property {number} randomValue Random value that seeds the Firestore cursor.
+ */
+
+/**
+ * Describe the queries used to fetch a moderation candidate.
+ * @param {number} randomValue Random value that seeds the Firestore cursor.
+ * @returns {VariantQueryDescriptor[]} Ordered query descriptors.
+ */
+export function buildVariantQueryPlan(randomValue) {
+  return [
+    {
+      reputation: 'zeroRated',
+      comparator: '>=',
+      randomValue,
+    },
+    {
+      reputation: 'zeroRated',
+      comparator: '<',
+      randomValue,
+    },
+    {
+      reputation: 'any',
+      comparator: '>=',
+      randomValue,
+    },
+    {
+      reputation: 'any',
+      comparator: '<',
+      randomValue,
+    },
+  ];
+}
+
+const snapshotHasResults = snapshot => snapshot?.empty === false;
+
+/**
+ * Evaluate a snapshot and continue the plan when empty.
+ * @param {{ plan: VariantQueryDescriptor[], runQuery: (descriptor: VariantQueryDescriptor) => Promise<{ empty?: boolean }>, index: number, snapshot: { empty?: boolean } }} input Query evaluation context.
+ * @returns {Promise<unknown>|unknown} Snapshot containing results or the promise for the next step.
+ */
+function selectSnapshotFromStep({ plan, runQuery, index, snapshot }) {
+  if (snapshotHasResults(snapshot)) {
+    return snapshot;
+  }
+
+  return resolvePlanStep({
+    plan,
+    runQuery,
+    index: index + 1,
+    lastSnapshot: snapshot,
+  });
+}
+
+/**
+ * Resolve the query plan sequentially until a snapshot yields results.
+ * @param {{ plan: VariantQueryDescriptor[], runQuery: (descriptor: VariantQueryDescriptor) => Promise<{ empty?: boolean }>, index: number, lastSnapshot: unknown }} input Remaining plan execution state.
+ * @returns {Promise<unknown>} Snapshot matching the selection criteria or the last evaluated snapshot.
+ */
+async function resolvePlanStep({ plan, runQuery, index, lastSnapshot }) {
+  if (index >= plan.length) {
+    return lastSnapshot;
+  }
+
+  const snapshot = await runQuery(plan[index]);
+  return selectSnapshotFromStep({ plan, runQuery, index, snapshot });
+}
+
+/**
+ * Create a Firestore-agnostic variant snapshot fetcher.
+ * @param {{ runQuery: (descriptor: VariantQueryDescriptor) => Promise<{ empty?: boolean }> }} deps
+ * Adapter that executes a single query descriptor.
+ * @returns {(randomValue: number) => Promise<unknown>} Function resolving with the first snapshot containing results.
+ */
+export function createVariantSnapshotFetcher({ runQuery }) {
+  return async function getVariantSnapshot(randomValue) {
+    const plan = buildVariantQueryPlan(randomValue);
+    return resolvePlanStep({
+      plan,
+      runQuery,
+      index: 0,
+      lastSnapshot: undefined,
+    });
+  };
+}

--- a/test/cloud-functions/variantSelection.test.js
+++ b/test/cloud-functions/variantSelection.test.js
@@ -1,0 +1,57 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import {
+  buildVariantQueryPlan,
+  createVariantSnapshotFetcher,
+} from '../../infra/cloud-functions/assign-moderation-job/variant-selection.js';
+
+describe('buildVariantQueryPlan', () => {
+  it('returns descriptors in the expected order', () => {
+    const plan = buildVariantQueryPlan(0.5);
+    expect(plan).toEqual([
+      { reputation: 'zeroRated', comparator: '>=', randomValue: 0.5 },
+      { reputation: 'zeroRated', comparator: '<', randomValue: 0.5 },
+      { reputation: 'any', comparator: '>=', randomValue: 0.5 },
+      { reputation: 'any', comparator: '<', randomValue: 0.5 },
+    ]);
+  });
+});
+
+describe('createVariantSnapshotFetcher', () => {
+  it('executes the query plan until a snapshot contains results', async () => {
+    const snapshots = [
+      { empty: true, id: 'zeroRatedForward' },
+      { empty: true, id: 'zeroRatedWrap' },
+      { empty: false, id: 'fallbackForward' },
+      { empty: false, id: 'fallbackWrap' },
+    ];
+    const runQuery = jest.fn().mockImplementation(() => snapshots.shift());
+    const getVariantSnapshot = createVariantSnapshotFetcher({ runQuery });
+
+    const result = await getVariantSnapshot(0.73);
+
+    const [firstCall, secondCall, thirdCall] = runQuery.mock.calls;
+    const plan = buildVariantQueryPlan(0.73);
+
+    expect(runQuery).toHaveBeenCalledTimes(3);
+    expect(firstCall).toEqual([plan[0]]);
+    expect(secondCall).toEqual([plan[1]]);
+    expect(thirdCall).toEqual([plan[2]]);
+    expect(result).toEqual({ empty: false, id: 'fallbackForward' });
+  });
+
+  it('returns the final snapshot when all queries are empty', async () => {
+    const snapshots = [
+      { empty: true, id: 'first' },
+      { empty: true, id: 'second' },
+      { empty: true, id: 'third' },
+      { empty: true, id: 'fourth' },
+    ];
+    const runQuery = jest.fn().mockImplementation(() => snapshots.shift());
+    const getVariantSnapshot = createVariantSnapshotFetcher({ runQuery });
+
+    const result = await getVariantSnapshot(0.12);
+
+    expect(runQuery).toHaveBeenCalledTimes(4);
+    expect(result).toEqual({ empty: true, id: 'fourth' });
+  });
+});


### PR DESCRIPTION
## Summary
- extract a reusable variant selection module that builds a query plan and executes it
- refactor the moderation workflow entrypoint to run the plan through injected Firestore queries
- add unit coverage for the selection plan and query execution order using simple stubs

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cabef3ab14832ea8688b25438ae672