### PR TITLE
Unify moderation assignment responses

### DIFF
--- a/infra/cloud-functions/assign-moderation-job/index.js
+++ b/infra/cloud-functions/assign-moderation-job/index.js
@@ -53,12 +53,7 @@ function getIdTokenFromRequest(req) {
 async function handleAssignModerationJob(req, res) {
   const { status, body } = await assignModerationWorkflow({ req });
 
-  if (typeof body === 'object') {
-    res.status(status).json(body);
-    return;
-  }
-
-  res.status(status).send(body);
+  res.status(status).send(body ?? '');
 }
 
 /**

--- a/infra/cloud-functions/assign-moderation-job/workflow.js
+++ b/infra/cloud-functions/assign-moderation-job/workflow.js
@@ -16,7 +16,7 @@
 /**
  * Create the moderation assignment workflow.
  * @param {AssignModerationWorkflowDeps} deps Dependencies required by the workflow.
- * @returns {(input: AssignModerationWorkflowInput) => Promise<{ status: number, body: unknown }>}
+ * @returns {(input: AssignModerationWorkflowInput) => Promise<{ status: number, body?: string }>}
  */
 export function createAssignModerationWorkflow({
   runGuards,
@@ -56,6 +56,6 @@ export function createAssignModerationWorkflow({
     const assignment = buildAssignment(variantDoc.ref, createdAt);
     await moderatorRef.set(assignment);
 
-    return { status: 201, body: {} };
+    return { status: 201, body: "" };
   };
 }

--- a/test/cloud-functions/assignModerationWorkflow.test.js
+++ b/test/cloud-functions/assignModerationWorkflow.test.js
@@ -138,6 +138,6 @@ describe('createAssignModerationWorkflow', () => {
     expect(now).toHaveBeenCalledTimes(1);
     expect(buildAssignment).toHaveBeenCalledWith(variantDoc.ref, 'timestamp');
     expect(set).toHaveBeenCalledWith(assignment);
-    expect(response).toEqual({ status: 201, body: {} });
+    expect(response).toEqual({ status: 201, body: '' });
   });
 });


### PR DESCRIPTION
## Summary
- send moderation assignment responses through a single res.send path
- return an empty string for successful workflow results and adjust types/tests accordingly

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cac4d261c0832e917c0c33518ace21