### PR TITLE
Log copied files in cloud build script

### DIFF
--- a/src/cloud/copy-assign-moderation-job.js
+++ b/src/cloud/copy-assign-moderation-job.js
@@ -6,7 +6,6 @@ const targetDir = join(
   process.cwd(),
   "infra/cloud-functions/assign-moderation-job"
 );
-
 async function copyAssignModerationJob() {
   await mkdir(targetDir, { recursive: true });
   const [sourceEntries, targetEntries] = await Promise.all([
@@ -31,6 +30,7 @@ async function copyAssignModerationJob() {
       const sourcePath = join(sourceDir, file.name);
       const destinationPath = join(targetDir, file.name);
       await copyFile(sourcePath, destinationPath);
+      console.log(`Copied: ${sourcePath} -> ${destinationPath}`);
     })
   );
 }


### PR DESCRIPTION
## Summary
- log each JavaScript file copied by the assign moderation cloud build script so builds show copied assets

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cae444b4bc832eb6a18f76fbe054a2