### PR TITLE
Update Matt Heard info on Dendrite about page

### DIFF
--- a/infra/about.html
+++ b/infra/about.html
@@ -123,24 +123,23 @@
       <h1>Contributors</h1>
       <h2>Developer</h2>
       <p>
-        Matthew Heard: software developer behind Dendrite. He began working on
-        Dendrite in 2013. Matthew's primary motivation for Dendrite is to build
-        a creative environment which gets better when more people create
-        stories, as he wants to explore how network effects and organic user
+        Matt Heard: software developer behind Dendrite. He began working on
+        Dendrite in 2013. Matt's primary motivation for Dendrite is to build a
+        creative environment which gets better when more people create stories,
+        as he wants to explore how network effects and organic user
         contributions can combine to bloom new communities.
       </p>
       <p>
-        Matthew has optimised Dendrite to run well on multiple platforms and
+        Matt has optimised Dendrite to run well on multiple platforms and
         browsers, as he considers that accessibility is pivotal to obtaining
         collaboration from a wide variety of users.
       </p>
       <p>
-        Matthew is a sustaining software developer for Oracle in New Zealand. He
-        primarily works with C++, Java, and SQL to find bugs and provide
-        software patches for the telecommunication networks of Oracle customers.
+        Matt leads the team responsible for the mobile app and website at
+        <a href="https://www.outfittery.de">Outfittery</a> in Berlin.
       </p>
       <p>
-        Matthew writes a blog at
+        Matt writes a blog at
         <a href="https://MattHeard.net">MattHeard.net</a>.
       </p>
       <h2>Major contributors</h2>


### PR DESCRIPTION
## Summary
- update the Dendrite about page to use Matt Heard's preferred name throughout the developer section
- refresh Matt's bio to reflect his Berlin-based role leading the mobile app and website team at [Outfittery](https://www.outfittery.de)

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cafbb6402c832e988fb1287dd66d3c