### PR TITLE
Allow Google Identity button theming

### DIFF
--- a/infra/dendrite.css
+++ b/infra/dendrite.css
@@ -381,8 +381,7 @@ button.dendrite-button:focus-visible {
   outline: none;
 }
 
-/* Neutralize background for Google sign-in button */
-.g_id_signin,
+/* Neutralize background for legacy Google sign-in iframe button */
 .abcRioButton {
   background: transparent !important;
   border: none !important;


### PR DESCRIPTION
## Summary
- stop forcing a transparent background on the modern Google Identity button so it can render the provider-supplied dark style
- keep the legacy `.abcRioButton` override for iframe-based widgets and confirm the dark-theme option in `infra/googleAuth.js`
- build and serve the static admin page to verify the filled black Google sign-in button in a dark-mode browser session

## Testing
- npm run build
- npm run lint
- npm test
- npx serve infra -l 4173 (manual verification in dark mode)


------
https://chatgpt.com/codex/tasks/task_e_68cafc3f369c832e9abd2ab6abb67b5c