### PR TITLE
Name assign moderation app initializer

### DIFF
--- a/src/cloud/assign-moderation-job/index.js
+++ b/src/cloud/assign-moderation-job/index.js
@@ -7,7 +7,7 @@ import cors from 'cors';
 import { createAssignModerationWorkflow } from './workflow.js';
 import { createVariantSnapshotFetcher } from './variant-selection.js';
 
-const { db, auth, app } = (() => {
+const initFirebaseApp = (() => {
   initializeApp();
 
   return {
@@ -16,6 +16,8 @@ const { db, auth, app } = (() => {
     app: express(),
   };
 })();
+
+const { db, auth, app } = initFirebaseApp;
 
 const allowed = [
   'https://mattheard.net',


### PR DESCRIPTION
## Summary
- extract the Firebase initialization IIFE into a named constant for the assign moderation job entrypoint
- reuse the named object when destructuring app, auth, and db instances

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc55e129ac832e991de8709fd1f0c6