### PR TITLE
refactor: extract assign moderation core utilities

### DIFF
--- a/src/cloud/assign-moderation-job/core.js
+++ b/src/cloud/assign-moderation-job/core.js
@@ -1,0 +1,35 @@
+/**
+ * Determine whether a request origin is allowed.
+ * @param {string | undefined} origin Request origin header.
+ * @param {string[]} allowedOrigins Whitelisted origins.
+ * @returns {boolean} True when the origin should be allowed.
+ */
+export function isAllowedOrigin(origin, allowedOrigins) {
+  if (!origin) {
+    return true;
+  }
+
+  return allowedOrigins.includes(origin);
+}
+
+/**
+ * Initialize Firebase resources, configure CORS, and expose dependencies.
+ * @param {() => { db: import('firebase-admin/firestore').Firestore,
+ *   auth: import('firebase-admin/auth').Auth, app: import('express').Express }} initializeFirebaseApp
+ * Function that initializes Firebase and returns dependencies.
+ * @param {(appInstance: import('express').Express, allowedOrigins: string[]) => void} configureCors
+ * Function that configures CORS for the Express app.
+ * @param {string[]} allowedOrigins Origins permitted to access the endpoint.
+ * @returns {{ db: import('firebase-admin/firestore').Firestore,
+ *   auth: import('firebase-admin/auth').Auth, app: import('express').Express }} Initialized dependencies.
+ */
+export function createAssignModerationApp(
+  initializeFirebaseApp,
+  configureCors,
+  allowedOrigins
+) {
+  const { db, auth, app } = initializeFirebaseApp();
+  configureCors(app, allowedOrigins);
+
+  return { db, auth, app };
+}

--- a/src/cloud/assign-moderation-job/index.js
+++ b/src/cloud/assign-moderation-job/index.js
@@ -6,6 +6,7 @@ import express from 'express';
 import cors from 'cors';
 import { createAssignModerationWorkflow } from './workflow.js';
 import { createVariantSnapshotFetcher } from './variant-selection.js';
+import { createAssignModerationApp, isAllowedOrigin } from './core.js';
 
 /**
  * Initialize Firebase Admin and supporting services.
@@ -51,36 +52,6 @@ function setupCors(appInstance, allowedOrigins) {
  * @param {string[]} allowedOrigins Whitelisted origins.
  * @returns {boolean} True when the origin should be allowed.
  */
-function isAllowedOrigin(origin, allowedOrigins) {
-  if (!origin) {
-    return true;
-  }
-
-  return allowedOrigins.includes(origin);
-}
-
-/**
- * Initialize Firebase resources, configure CORS, and expose dependencies.
- * @param {() => { db: import('firebase-admin/firestore').Firestore,
- *   auth: import('firebase-admin/auth').Auth, app: import('express').Express }} initializeFirebaseApp
- * Function that initializes Firebase and returns dependencies.
- * @param {(appInstance: import('express').Express, allowedOrigins: string[]) => void} configureCors
- * Function that configures CORS for the Express app.
- * @param {string[]} allowedOrigins Origins permitted to access the endpoint.
- * @returns {{ db: import('firebase-admin/firestore').Firestore,
- *   auth: import('firebase-admin/auth').Auth, app: import('express').Express }} Initialized dependencies.
- */
-function createAssignModerationApp(
-  initializeFirebaseApp,
-  configureCors,
-  allowedOrigins
-) {
-  const { db, auth, app } = initializeFirebaseApp();
-  configureCors(app, allowedOrigins);
-
-  return { db, auth, app };
-}
-
 const allowed = [
   'https://mattheard.net',
   'https://dendritestories.co.nz',


### PR DESCRIPTION
## Summary
- move the assign moderation core helpers into a new core.js module
- import the shared helpers into the index entry point to use them

## Testing
- npm run lint
- npm test -- --runTestsByPath test/cloud-functions/assignModerationWorkflow.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cc5a59e14c832e922a2f6096d8214b