### PR TITLE
Limit assign moderation middleware IIFE scope

### DIFF
--- a/src/cloud/assign-moderation-job/index.js
+++ b/src/cloud/assign-moderation-job/index.js
@@ -58,13 +58,17 @@ const allowed = [
   'https://www.dendritestories.co.nz',
 ];
 
-const { db, auth, app } = createAssignModerationApp(
+const firebaseResources = createAssignModerationApp(
   initializeFirebaseAppResources,
   setupCors,
   allowed
 );
 
-app.use(express.urlencoded({ extended: false }));
+(() => {
+  firebaseResources.app.use(express.urlencoded({ extended: false }));
+})();
+
+const { db, auth, app } = firebaseResources;
 
 /**
  * Extract the ID token from a request body.


### PR DESCRIPTION
## Summary
- keep assign moderation app creation outside the IIFE and restrict the self-invoked wrapper to the express urlencoded middleware

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc5c0caa04832e926815923e4a669b