### PR TITLE
Inject middleware configuration into moderation app

### DIFF
--- a/src/cloud/assign-moderation-job/core.js
+++ b/src/cloud/assign-moderation-job/core.js
@@ -20,16 +20,20 @@ export function isAllowedOrigin(origin, allowedOrigins) {
  * @param {(appInstance: import('express').Express, allowedOrigins: string[]) => void} configureCors
  * Function that configures CORS for the Express app.
  * @param {string[]} allowedOrigins Origins permitted to access the endpoint.
+ * @param {(appInstance: import('express').Express) => void} [configureApp]
+ * Optional callback invoked with the Express app for additional configuration.
  * @returns {{ db: import('firebase-admin/firestore').Firestore,
  *   auth: import('firebase-admin/auth').Auth, app: import('express').Express }} Initialized dependencies.
  */
 export function createAssignModerationApp(
   initializeFirebaseApp,
   configureCors,
-  allowedOrigins
+  allowedOrigins,
+  configureApp = () => {}
 ) {
   const { db, auth, app } = initializeFirebaseApp();
   configureCors(app, allowedOrigins);
+  configureApp(app);
 
   return { db, auth, app };
 }

--- a/src/cloud/assign-moderation-job/index.js
+++ b/src/cloud/assign-moderation-job/index.js
@@ -58,15 +58,21 @@ const allowed = [
   'https://www.dendritestories.co.nz',
 ];
 
+/**
+ * Register body parsing middleware for moderation requests.
+ * @param {import('express').Express} appInstance Express application instance.
+ * @returns {void}
+ */
+function configureUrlencodedBodyParser(appInstance) {
+  appInstance.use(express.urlencoded({ extended: false }));
+}
+
 const firebaseResources = createAssignModerationApp(
   initializeFirebaseAppResources,
   setupCors,
-  allowed
+  allowed,
+  configureUrlencodedBodyParser
 );
-
-(() => {
-  firebaseResources.app.use(express.urlencoded({ extended: false }));
-})();
 
 const { db, auth, app } = firebaseResources;
 


### PR DESCRIPTION
## Summary
- allow createAssignModerationApp to accept an optional Express configuration callback
- pass configureUrlencodedBodyParser directly into the moderation app factory so middleware is registered during initialization

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc5f3989d4832e8b8e5dbb60a2f1e7