### PR TITLE
Extract Firebase initialization helper

### DIFF
--- a/src/cloud/assign-moderation-job/gcf.js
+++ b/src/cloud/assign-moderation-job/gcf.js
@@ -1,0 +1,20 @@
+import { initializeApp } from 'firebase-admin/app';
+import { getAuth } from 'firebase-admin/auth';
+import { getFirestore } from 'firebase-admin/firestore';
+import express from 'express';
+
+/**
+ * Initialize Firebase Admin and supporting services.
+ * @returns {{ db: import('firebase-admin/firestore').Firestore,
+ *   auth: import('firebase-admin/auth').Auth, app: import('express').Express }}
+ * Firebase resources required by the moderation workflow.
+ */
+export function initializeFirebaseAppResources() {
+  initializeApp();
+
+  return {
+    db: getFirestore(),
+    auth: getAuth(),
+    app: express(),
+  };
+}

--- a/src/cloud/assign-moderation-job/index.js
+++ b/src/cloud/assign-moderation-job/index.js
@@ -1,28 +1,11 @@
-import { initializeApp } from 'firebase-admin/app';
-import { getAuth } from 'firebase-admin/auth';
-import { getFirestore, FieldValue } from 'firebase-admin/firestore';
+import { FieldValue } from 'firebase-admin/firestore';
 import * as functions from 'firebase-functions';
 import express from 'express';
 import cors from 'cors';
 import { createAssignModerationWorkflow } from './workflow.js';
 import { createVariantSnapshotFetcher } from './variant-selection.js';
 import { createAssignModerationApp, isAllowedOrigin } from './core.js';
-
-/**
- * Initialize Firebase Admin and supporting services.
- * @returns {{ db: import('firebase-admin/firestore').Firestore,
- *   auth: import('firebase-admin/auth').Auth, app: import('express').Express }}
- * Firebase resources required by the moderation workflow.
- */
-function initializeFirebaseAppResources() {
-  initializeApp();
-
-  return {
-    db: getFirestore(),
-    auth: getAuth(),
-    app: express(),
-  };
-}
+import { initializeFirebaseAppResources } from './gcf.js';
 
 /**
  * Configure CORS middleware for the moderation Express app.


### PR DESCRIPTION
## Summary
- extract the Firebase Admin initialization into a dedicated `gcf.js` helper for the assign moderation job
- update the cloud function entry point to import the shared initializer

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc6cf8cdb0832e874dfdcdacc70f69