### PR TITLE
Refactor generator copy script into modular helpers

### DIFF
--- a/src/generator/copy.js
+++ b/src/generator/copy.js
@@ -25,28 +25,53 @@ const srcConstantsDir = path.resolve(srcDir, 'constants');
 const publicConstantsDir = path.join(publicDir, 'constants');
 const srcAssetsDir = path.resolve(srcDir, 'assets');
 const publicAssetsDir = publicDir;
-
-// Ensure public directory exists
-if (!fs.existsSync(publicDir)) {
-  fs.mkdirSync(publicDir, { recursive: true });
-}
-
-// Copy src/blog.json to public/blog.json
+const srcPresentersDir = path.resolve(srcDir, 'presenters');
+const publicPresentersDir = path.join(publicDir, 'presenters');
 const srcBlogJson = path.join(srcDir, 'blog.json');
 const publicBlogJson = path.join(publicDir, 'blog.json');
-fs.copyFileSync(srcBlogJson, publicBlogJson);
-console.log('Copied: src/blog.json -> public/blog.json');
 
-// --- Copy Toy Files ---
+const directories = {
+  projectRoot,
+  srcDir,
+  publicDir,
+  srcToysDir,
+  srcBrowserDir,
+  publicBrowserDir,
+  srcUtilsDir,
+  publicUtilsDir,
+  srcInputHandlersDir,
+  publicInputHandlersDir,
+  srcConstantsDir,
+  publicConstantsDir,
+  srcAssetsDir,
+  publicAssetsDir,
+  srcPresentersDir,
+  publicPresentersDir,
+  srcBlogJson,
+  publicBlogJson,
+};
 
-// Predicate to check if an entry is a JS file (excluding .test.js)
+const thirdParty = {
+  directoryExists: target => fs.existsSync(target),
+  createDirectory: target => fs.mkdirSync(target, { recursive: true }),
+  copyFile: (source, destination) => fs.copyFileSync(source, destination),
+  readDirEntries: dir => fs.readdirSync(dir, { withFileTypes: true }),
+};
+
+const logger = {
+  info: message => console.log(message),
+  warn: message => console.warn(message),
+};
+
+// --- Core utilities ------------------------------------------------------
+
 /**
  * Determine if an entry has a valid JavaScript file name.
- * @param {fs.Dirent} entry - Directory entry to check.
+ * @param {string} entryName - Directory entry name to check.
  * @returns {boolean} `true` for non-test `.js` files.
  */
-function isCorrectJsFileEnding(entry) {
-  return entry.name.endsWith('.js') && !entry.name.endsWith('.test.js');
+function isCorrectJsFileEnding(entryName) {
+  return entryName.endsWith('.js') && !entryName.endsWith('.test.js');
 }
 
 /**
@@ -55,30 +80,7 @@ function isCorrectJsFileEnding(entry) {
  * @returns {boolean} Whether the entry is a JS file.
  */
 function isJsFile(entry) {
-  return entry.isFile() && isCorrectJsFileEnding(entry);
-}
-
-// Function to recursively find JS files in a directory (excluding .test.js)
-/**
- * Read directory entries with type information.
- * @param {string} dir - Directory path.
- * @returns {fs.Dirent[]} Array of directory entries.
- */
-function getDirEntries(dir) {
-  return fs.readdirSync(dir, { withFileTypes: true });
-}
-
-/**
- * Resolve the files represented by a directory entry.
- * @param {fs.Dirent} entry - Directory entry.
- * @param {string} fullPath - Full path to the entry.
- * @returns {string[]} New file paths discovered.
- */
-function getActualNewFiles(entry, fullPath) {
-  if (entry.isDirectory()) {
-    return findJsFiles(fullPath);
-  }
-  return [fullPath];
+  return entry.isFile() && isCorrectJsFileEnding(entry.name);
 }
 
 /**
@@ -91,14 +93,29 @@ function shouldCheckEntry(entry) {
 }
 
 /**
+ * Resolve the files represented by a directory entry.
+ * @param {fs.Dirent} entry - Directory entry.
+ * @param {string} fullPath - Full path to the entry.
+ * @param {(dir: string) => fs.Dirent[]} listEntries - Function to read directory contents.
+ * @returns {string[]} New file paths discovered.
+ */
+function getActualNewFiles(entry, fullPath, listEntries) {
+  if (entry.isDirectory()) {
+    return findJsFiles(fullPath, listEntries);
+  }
+  return [fullPath];
+}
+
+/**
  * Get potential JavaScript files from an entry.
  * @param {fs.Dirent} entry - Directory entry.
  * @param {string} fullPath - Full path to the entry.
+ * @param {(dir: string) => fs.Dirent[]} listEntries - Function to read directory contents.
  * @returns {string[]} File paths to include.
  */
-function getPossibleNewFiles(entry, fullPath) {
+function getPossibleNewFiles(entry, fullPath, listEntries) {
   if (shouldCheckEntry(entry)) {
-    return getActualNewFiles(entry, fullPath);
+    return getActualNewFiles(entry, fullPath, listEntries);
   }
   return [];
 }
@@ -108,124 +125,112 @@ function getPossibleNewFiles(entry, fullPath) {
  * @param {string[]} jsFiles - Array of discovered files.
  * @param {fs.Dirent} entry - Current directory entry.
  * @param {string} dir - Directory being scanned.
+ * @param {(dir: string) => fs.Dirent[]} listEntries - Function to read directory contents.
  * @returns {string[]} Updated array of file paths.
  */
-function accumulateJsFiles(jsFiles, entry, dir) {
+function accumulateJsFiles(jsFiles, entry, dir, listEntries) {
   const fullPath = path.join(dir, entry.name);
-  const newFiles = getPossibleNewFiles(entry, fullPath);
+  const newFiles = getPossibleNewFiles(entry, fullPath, listEntries);
   return jsFiles.concat(newFiles);
 }
 
 /**
  * Recursively find JavaScript files in a directory.
  * @param {string} dir - Directory to search.
+ * @param {(dir: string) => fs.Dirent[]} listEntries - Function to read directory contents.
  * @returns {string[]} All JS file paths.
  */
-function findJsFiles(dir) {
-  const entries = getDirEntries(dir);
+function findJsFiles(dir, listEntries) {
+  const entries = listEntries(dir);
   return entries.reduce(
-    (jsFiles, entry) => accumulateJsFiles(jsFiles, entry, dir),
+    (jsFiles, entry) => accumulateJsFiles(jsFiles, entry, dir, listEntries),
     []
   );
 }
 
-// Find all JS files in src/toys
-const toyFiles = findJsFiles(srcToysDir);
-
-// Copy each toy file to the corresponding path in public
-toyFiles.forEach(filePath => {
-  const relativePath = path.relative(srcToysDir, filePath);
-  const destPath = path.join(publicDir, relativePath);
-  const destDir = path.dirname(destPath);
-
-  // Ensure the destination directory exists
-  if (!fs.existsSync(destDir)) {
-    fs.mkdirSync(destDir, { recursive: true });
-  }
-
-  // Copy the file
-  fs.copyFileSync(filePath, destPath);
-  console.log(`Copied: ${filePath} -> ${destPath}`);
-});
-
-console.log('Toy files copied successfully!');
-
-// --- Copy Presenter Files ---
-const srcPresentersDir = path.resolve(srcDir, 'presenters');
-const publicPresentersDir = path.join(publicDir, 'presenters');
-
-if (fs.existsSync(srcPresentersDir)) {
-  const presenterFiles = findJsFiles(srcPresentersDir);
-  presenterFiles.forEach(filePath => {
-    const relativePath = path.relative(srcPresentersDir, filePath);
-    const destPath = path.join(publicPresentersDir, relativePath);
-    const destDir = path.dirname(destPath);
-
-    if (!fs.existsSync(destDir)) {
-      fs.mkdirSync(destDir, { recursive: true });
-    }
-    fs.copyFileSync(filePath, destPath);
-    console.log(`Copied presenter: ${filePath} -> ${destPath}`);
-  });
-  console.log('Presenter files copied successfully!');
-} else {
-  console.warn(
-    `Warning: presenters directory not found at ${srcPresentersDir}`
-  );
+/**
+ * Convert absolute file paths into copy pairs relative to the provided source.
+ * @param {string[]} files - Absolute file paths.
+ * @param {string} sourceRoot - Root directory to compute relative paths from.
+ * @param {string} destinationRoot - Destination root directory.
+ * @returns {{source: string, destination: string}[]} Copy pair definitions.
+ */
+function createCopyPairs(files, sourceRoot, destinationRoot) {
+  return files.map(filePath => ({
+    source: filePath,
+    destination: path.join(
+      destinationRoot,
+      path.relative(sourceRoot, filePath)
+    ),
+  }));
 }
 
-// --- Copy src/utils to public/utils ---
-if (fs.existsSync(srcUtilsDir)) {
-  copyDirRecursive(srcUtilsDir, publicUtilsDir);
-  console.log('Utils files copied successfully!');
-} else {
-  console.warn(`Warning: utils directory not found at ${srcUtilsDir}`);
-}
-
-// --- Copy src/inputHandlers to public/inputHandlers ---
-if (fs.existsSync(srcInputHandlersDir)) {
-  copyDirRecursive(srcInputHandlersDir, publicInputHandlersDir);
-  console.log('Input handler files copied successfully!');
-} else {
-  console.warn(
-    `Warning: inputHandlers directory not found at ${srcInputHandlersDir}`
-  );
-}
-
-// --- Copy src/constants to public/constants ---
-if (fs.existsSync(srcConstantsDir)) {
-  copyDirRecursive(srcConstantsDir, publicConstantsDir);
-  console.log('Constants files copied successfully!');
-} else {
-  console.warn(`Warning: constants directory not found at ${srcConstantsDir}`);
-}
-
-// --- Copy src/assets to public/ ---
-if (fs.existsSync(srcAssetsDir)) {
-  copyDirRecursive(srcAssetsDir, publicAssetsDir);
-  console.log('Asset files copied successfully!');
-} else {
-  console.warn(`Warning: assets directory not found at ${srcAssetsDir}`);
-}
-
-// --- Copy src/browser to public/browser ---
+// --- Third-party dependent helpers --------------------------------------
 
 /**
- * Copy a directory entry to the destination path.
+ * Ensure a directory exists by creating it when missing.
+ * @param {typeof thirdParty} io - File system helpers.
+ * @param {string} targetDir - Directory path to verify.
+ * @returns {void}
+ */
+function ensureDirectoryExists(io, targetDir) {
+  if (!io.directoryExists(targetDir)) {
+    io.createDirectory(targetDir);
+  }
+}
+
+/**
+ * Copy a file and guarantee the destination directory exists.
+ * @param {typeof thirdParty} io - File system helpers.
+ * @param {string} source - Source file path.
+ * @param {string} destination - Destination file path.
+ * @param {typeof logger} messageLogger - Logger for status updates.
+ * @param {string} [message] - Optional custom log message.
+ * @returns {void}
+ */
+function copyFileWithDirectories(
+  io,
+  source,
+  destination,
+  messageLogger,
+  message
+) {
+  ensureDirectoryExists(io, path.dirname(destination));
+  io.copyFile(source, destination);
+  const logMessage = message ?? `Copied: ${source} -> ${destination}`;
+  messageLogger.info(logMessage);
+}
+
+/**
+ * Copy each file pair using the provided I/O helpers.
+ * @param {{source: string, destination: string}[]} copyPairs - Files to copy.
+ * @param {typeof thirdParty} io - File system helpers.
+ * @param {typeof logger} messageLogger - Logger for status updates.
+ * @returns {void}
+ */
+function copyFilePairs(copyPairs, io, messageLogger) {
+  copyPairs.forEach(({ source, destination }) => {
+    copyFileWithDirectories(io, source, destination, messageLogger);
+  });
+}
+
+/**
+ * Process a directory entry during recursive copy.
  * @param {fs.Dirent} entry - Entry to copy.
  * @param {string} src - Source directory path.
  * @param {string} dest - Destination directory path.
+ * @param {typeof thirdParty} io - File system helpers.
+ * @param {typeof logger} messageLogger - Logger for status updates.
  * @returns {void}
  */
-function handleDirectoryEntry(entry, src, dest) {
+function handleDirectoryEntry(entry, src, dest, io, messageLogger) {
   const srcPath = path.join(src, entry.name);
   const destPath = path.join(dest, entry.name);
   if (entry.isDirectory()) {
-    copyDirRecursive(srcPath, destPath);
-  } else {
-    fs.copyFileSync(srcPath, destPath);
-    console.log(`Copied: ${srcPath} -> ${destPath}`);
+    copyDirRecursive(srcPath, destPath, io, messageLogger);
+    return;
   }
+  copyFileWithDirectories(io, srcPath, destPath, messageLogger);
 }
 
 /**
@@ -233,31 +238,170 @@ function handleDirectoryEntry(entry, src, dest) {
  * @param {fs.Dirent[]} entries - Directory entries.
  * @param {string} src - Source directory path.
  * @param {string} dest - Destination directory path.
+ * @param {typeof thirdParty} io - File system helpers.
+ * @param {typeof logger} messageLogger - Logger for status updates.
  * @returns {void}
  */
-function processDirectoryEntries(entries, src, dest) {
-  for (const entry of entries) {
-    handleDirectoryEntry(entry, src, dest);
-  }
+function processDirectoryEntries(entries, src, dest, io, messageLogger) {
+  entries.forEach(entry => {
+    handleDirectoryEntry(entry, src, dest, io, messageLogger);
+  });
 }
 
 /**
  * Recursively copy a directory to a destination.
  * @param {string} src - Source directory.
  * @param {string} dest - Destination directory.
+ * @param {typeof thirdParty} io - File system helpers.
+ * @param {typeof logger} messageLogger - Logger for status updates.
  * @returns {void}
  */
-function copyDirRecursive(src, dest) {
-  if (!fs.existsSync(dest)) {
-    fs.mkdirSync(dest, { recursive: true });
-  }
-  const entries = fs.readdirSync(src, { withFileTypes: true });
-  processDirectoryEntries(entries, src, dest);
+function copyDirRecursive(src, dest, io, messageLogger) {
+  ensureDirectoryExists(io, dest);
+  const entries = io.readDirEntries(src);
+  processDirectoryEntries(entries, src, dest, io, messageLogger);
 }
 
-if (fs.existsSync(srcBrowserDir)) {
-  copyDirRecursive(srcBrowserDir, publicBrowserDir);
-  console.log('Browser files copied successfully!');
-} else {
-  console.warn(`Warning: browser directory not found at ${srcBrowserDir}`);
+/**
+ * Copy a directory tree when the source exists, otherwise warn.
+ * @param {{src: string, dest: string, successMessage: string, missingMessage: string}} plan - Copy plan definition.
+ * @param {typeof thirdParty} io - File system helpers.
+ * @param {typeof logger} messageLogger - Logger for status updates.
+ * @returns {void}
+ */
+function copyDirectoryTreeIfExists(plan, io, messageLogger) {
+  const { src, dest, successMessage, missingMessage } = plan;
+  if (!io.directoryExists(src)) {
+    messageLogger.warn(missingMessage);
+    return;
+  }
+  copyDirRecursive(src, dest, io, messageLogger);
+  messageLogger.info(successMessage);
 }
+
+// --- Workflows combining core + third-party helpers ----------------------
+
+/**
+ * Copy src/blog.json into public/blog.json.
+ * @param {typeof directories} dirs - Project directory paths.
+ * @param {typeof thirdParty} io - File system helpers.
+ * @param {typeof logger} messageLogger - Logger for status updates.
+ * @returns {void}
+ */
+function copyBlogJson(dirs, io, messageLogger) {
+  copyFileWithDirectories(
+    io,
+    dirs.srcBlogJson,
+    dirs.publicBlogJson,
+    messageLogger,
+    'Copied: src/blog.json -> public/blog.json'
+  );
+}
+
+/**
+ * Copy toy JavaScript files into the public directory.
+ * @param {typeof directories} dirs - Project directory paths.
+ * @param {typeof thirdParty} io - File system helpers.
+ * @param {typeof logger} messageLogger - Logger for status updates.
+ * @returns {void}
+ */
+function copyToyFiles(dirs, io, messageLogger) {
+  const toyFiles = findJsFiles(dirs.srcToysDir, io.readDirEntries);
+  const copyPairs = createCopyPairs(toyFiles, dirs.srcToysDir, dirs.publicDir);
+  copyFilePairs(copyPairs, io, messageLogger);
+  messageLogger.info('Toy files copied successfully!');
+}
+
+/**
+ * Copy presenter JavaScript files when the directory exists.
+ * @param {typeof directories} dirs - Project directory paths.
+ * @param {typeof thirdParty} io - File system helpers.
+ * @param {typeof logger} messageLogger - Logger for status updates.
+ * @returns {void}
+ */
+function copyPresenterFiles(dirs, io, messageLogger) {
+  if (!io.directoryExists(dirs.srcPresentersDir)) {
+    messageLogger.warn(
+      `Warning: presenters directory not found at ${dirs.srcPresentersDir}`
+    );
+    return;
+  }
+  const presenterFiles = findJsFiles(dirs.srcPresentersDir, io.readDirEntries);
+  const presenterPairs = createCopyPairs(
+    presenterFiles,
+    dirs.srcPresentersDir,
+    dirs.publicPresentersDir
+  );
+  presenterPairs.forEach(({ source, destination }) => {
+    copyFileWithDirectories(
+      io,
+      source,
+      destination,
+      messageLogger,
+      `Copied presenter: ${source} -> ${destination}`
+    );
+  });
+  messageLogger.info('Presenter files copied successfully!');
+}
+
+/**
+ * Copy supporting directories (utils, handlers, constants, assets, browser).
+ * @param {typeof directories} dirs - Project directory paths.
+ * @param {typeof thirdParty} io - File system helpers.
+ * @param {typeof logger} messageLogger - Logger for status updates.
+ * @returns {void}
+ */
+function copySupportingDirectories(dirs, io, messageLogger) {
+  const plans = [
+    {
+      src: dirs.srcUtilsDir,
+      dest: dirs.publicUtilsDir,
+      successMessage: 'Utils files copied successfully!',
+      missingMessage: `Warning: utils directory not found at ${dirs.srcUtilsDir}`,
+    },
+    {
+      src: dirs.srcInputHandlersDir,
+      dest: dirs.publicInputHandlersDir,
+      successMessage: 'Input handler files copied successfully!',
+      missingMessage: `Warning: inputHandlers directory not found at ${dirs.srcInputHandlersDir}`,
+    },
+    {
+      src: dirs.srcConstantsDir,
+      dest: dirs.publicConstantsDir,
+      successMessage: 'Constants files copied successfully!',
+      missingMessage: `Warning: constants directory not found at ${dirs.srcConstantsDir}`,
+    },
+    {
+      src: dirs.srcAssetsDir,
+      dest: dirs.publicAssetsDir,
+      successMessage: 'Asset files copied successfully!',
+      missingMessage: `Warning: assets directory not found at ${dirs.srcAssetsDir}`,
+    },
+    {
+      src: dirs.srcBrowserDir,
+      dest: dirs.publicBrowserDir,
+      successMessage: 'Browser files copied successfully!',
+      missingMessage: `Warning: browser directory not found at ${dirs.srcBrowserDir}`,
+    },
+  ];
+
+  plans.forEach(plan => {
+    copyDirectoryTreeIfExists(plan, io, messageLogger);
+  });
+}
+
+/**
+ * Execute the copy workflow.
+ * @param {typeof thirdParty} io - File system helpers.
+ * @param {typeof logger} messageLogger - Logger for status updates.
+ * @returns {void}
+ */
+function main(io, messageLogger) {
+  ensureDirectoryExists(io, directories.publicDir);
+  copyBlogJson(directories, io, messageLogger);
+  copyToyFiles(directories, io, messageLogger);
+  copyPresenterFiles(directories, io, messageLogger);
+  copySupportingDirectories(directories, io, messageLogger);
+}
+
+main(thirdParty, logger);


### PR DESCRIPTION
## Summary
- organize generator copy script paths, IO helpers, and logging to clarify third-party dependencies
- extract pure file-discovery utilities for JavaScript assets that operate via injected directory readers
- add IO-oriented helpers and orchestrators to copy blog data, toys, presenters, and supporting directories through a single main workflow

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d56eed30d0832ebca1cd955d72c121