### PR TITLE
Remove double-quote preference from AGENTS instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@
 - `./tcr.sh "message"` runs the TCR workflow; use it when practicing test-driven iterations.
 
 ## Coding Style & Naming Conventions
-- Follow `CLAUDE.md`: two-space indentation, ES modules, camelCase functions, UPPER_SNAKE_CASE constants, and double quotes for strings/HTML attributes.
+- Follow `CLAUDE.md`: two-space indentation, ES modules, camelCase functions, and UPPER_SNAKE_CASE constants.
 - Keep generator utilities composable, documented with JSDoc, and defensive (null checks, `escapeHtml` for user content).
 - Run Prettier through the configured ESLint integration; never add `eslint-disable` comments.
 


### PR DESCRIPTION
## Summary
- remove the double-quote string literal preference from the repository guidance

## Testing
- not run (not needed)


------
https://chatgpt.com/codex/tasks/task_e_68d660eeec60832eb812d40a236fa067