### PR TITLE
Move shared copy directory metadata to core module

### DIFF
--- a/src/core/copy.js
+++ b/src/core/copy.js
@@ -1,3 +1,31 @@
+export const sharedDirectoryPairs = [
+  { key: 'Toys', relativePath: 'toys' },
+  { key: 'Browser', relativePath: 'browser' },
+  { key: 'Utils', relativePath: 'utils' },
+  { key: 'InputHandlers', relativePath: 'inputHandlers' },
+  { key: 'Constants', relativePath: 'constants' },
+  { key: 'Presenters', relativePath: 'presenters' },
+];
+
+export function createSharedDirectoryEntries({
+  path: pathDeps,
+  srcDir,
+  publicDir,
+  pairs = sharedDirectoryPairs,
+}) {
+  const { join } = pathDeps;
+  return pairs.flatMap(({ key, relativePath }) => {
+    const srcKey = `src${key}Dir`;
+    const destKey = `public${key}Dir`;
+    const srcPath = join(srcDir, relativePath);
+    const destPath = join(publicDir, relativePath);
+    return [
+      [srcKey, srcPath],
+      [destKey, destPath],
+    ];
+  });
+}
+
 export function createCopyCore({ directories: dirConfig, path: pathDeps }) {
   const { join, dirname, relative } = pathDeps;
 

--- a/src/generator/copy.js
+++ b/src/generator/copy.js
@@ -3,7 +3,10 @@
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { createCopyCore } from '../core/copy.js';
+import {
+  createCopyCore,
+  createSharedDirectoryEntries,
+} from '../core/copy.js';
 
 // Get __dirname equivalent in ES module scope
 const __filename = fileURLToPath(import.meta.url);
@@ -13,49 +16,28 @@ const __dirname = path.dirname(__filename);
 const projectRoot = path.resolve(__dirname, '../..'); // Adjust based on script location
 const srcDir = path.resolve(projectRoot, 'src');
 const publicDir = path.resolve(projectRoot, 'public');
-const srcToysDir = path.resolve(srcDir, 'toys');
-const srcBrowserDir = path.resolve(srcDir, 'browser');
-const publicBrowserDir = path.join(publicDir, 'browser');
-const srcUtilsDir = path.resolve(srcDir, 'utils');
-const publicUtilsDir = path.join(publicDir, 'utils');
-
-// New directory with handlers used by interactive components
-const srcInputHandlersDir = path.resolve(srcDir, 'inputHandlers');
-const publicInputHandlersDir = path.join(publicDir, 'inputHandlers');
-const srcConstantsDir = path.resolve(srcDir, 'constants');
-const publicConstantsDir = path.join(publicDir, 'constants');
-const srcAssetsDir = path.resolve(srcDir, 'assets');
-const publicAssetsDir = publicDir;
-const srcPresentersDir = path.resolve(srcDir, 'presenters');
-const publicPresentersDir = path.join(publicDir, 'presenters');
-const srcBlogJson = path.join(srcDir, 'blog.json');
-const publicBlogJson = path.join(publicDir, 'blog.json');
-
-const directories = {
-  projectRoot,
-  srcDir,
-  publicDir,
-  srcToysDir,
-  srcBrowserDir,
-  publicBrowserDir,
-  srcUtilsDir,
-  publicUtilsDir,
-  srcInputHandlersDir,
-  publicInputHandlersDir,
-  srcConstantsDir,
-  publicConstantsDir,
-  srcAssetsDir,
-  publicAssetsDir,
-  srcPresentersDir,
-  publicPresentersDir,
-  srcBlogJson,
-  publicBlogJson,
-};
 
 const pathAdapters = {
   join: path.join,
   dirname: path.dirname,
   relative: path.relative,
+};
+
+const sharedDirectoryEntries = createSharedDirectoryEntries({
+  path: { join: pathAdapters.join },
+  srcDir,
+  publicDir,
+});
+
+const directories = {
+  projectRoot,
+  srcDir,
+  publicDir,
+  ...Object.fromEntries(sharedDirectoryEntries),
+  srcAssetsDir: path.resolve(srcDir, 'assets'),
+  publicAssetsDir: publicDir,
+  srcBlogJson: path.join(srcDir, 'blog.json'),
+  publicBlogJson: path.join(publicDir, 'blog.json'),
 };
 
 const thirdParty = {


### PR DESCRIPTION
## Summary
- promote shared copy directory pair metadata to the core copy module
- reuse the core helper in the generator to build directory configuration entries

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d665628f8c832ead13972a5efaeddd