### PR TITLE
Refactor copy generator to use node adapters

### DIFF
--- a/src/node/fs.js
+++ b/src/node/fs.js
@@ -1,0 +1,19 @@
+import fs from 'fs';
+
+/**
+ * Provide synchronous filesystem helpers required by the copy generator.
+ * @returns {{
+ *   directoryExists: (target: string) => boolean,
+ *   createDirectory: (target: string) => void,
+ *   copyFile: (source: string, destination: string) => void,
+ *   readDirEntries: (dir: string) => fs.Dirent[],
+ * }}
+ */
+export function createFsAdapters() {
+  return {
+    directoryExists: target => fs.existsSync(target),
+    createDirectory: target => fs.mkdirSync(target, { recursive: true }),
+    copyFile: (source, destination) => fs.copyFileSync(source, destination),
+    readDirEntries: dir => fs.readdirSync(dir, { withFileTypes: true }),
+  };
+}

--- a/src/node/path.js
+++ b/src/node/path.js
@@ -1,0 +1,58 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+/**
+ * Determine the directory of the current module using Node-specific helpers.
+ * @param {ImportMeta['url']} moduleUrl - The module URL from import.meta.url.
+ * @returns {string}
+ */
+export function getCurrentDirectory(moduleUrl) {
+  return path.dirname(fileURLToPath(moduleUrl));
+}
+
+/**
+ * Resolve key project directories relative to a given module directory.
+ * @param {string} moduleDirectory - Directory containing the current module.
+ * @returns {{ projectRoot: string, srcDir: string, publicDir: string }}
+ */
+export function resolveProjectDirectories(moduleDirectory) {
+  const projectRoot = path.resolve(moduleDirectory, '../..');
+  const srcDir = path.resolve(projectRoot, 'src');
+  const publicDir = path.resolve(projectRoot, 'public');
+
+  return { projectRoot, srcDir, publicDir };
+}
+
+/**
+ * Provide the subset of Node's path module used by the copy generator.
+ * @returns {{ join: typeof path.join, dirname: typeof path.dirname, relative: typeof path.relative }}
+ */
+export function createPathAdapters() {
+  return {
+    join: path.join,
+    dirname: path.dirname,
+    relative: path.relative,
+  };
+}
+
+/**
+ * Build the directory map used by the copy generator.
+ * @param {{ projectRoot: string, srcDir: string, publicDir: string }} baseDirectories
+ * @param {Iterable<[string, string]>} sharedDirectoryEntries - Shared directories derived from core helpers.
+ * @returns {Record<string, string>}
+ */
+export function createCopyDirectories(baseDirectories, sharedDirectoryEntries) {
+  const { projectRoot, srcDir, publicDir } = baseDirectories;
+  const sharedEntries = Object.fromEntries(sharedDirectoryEntries);
+
+  return {
+    projectRoot,
+    srcDir,
+    publicDir,
+    ...sharedEntries,
+    srcAssetsDir: path.resolve(srcDir, 'assets'),
+    publicAssetsDir: publicDir,
+    srcBlogJson: path.join(srcDir, 'blog.json'),
+    publicBlogJson: path.join(publicDir, 'blog.json'),
+  };
+}


### PR DESCRIPTION
## Summary
- add src/node/path.js to encapsulate path-based directory helpers for the copy script
- add src/node/fs.js to provide filesystem adapters used by the copy workflow
- update src/generator/copy.js to consume the new Node-specific helpers instead of importing fs and path directly

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d67915d56c832e8b3262cd6c07af78