### PR TITLE
Move copy workflow orchestration into core

### DIFF
--- a/src/core/copy.js
+++ b/src/core/copy.js
@@ -252,6 +252,14 @@ export function createCopyCore({ directories: dirConfig, path: pathDeps }) {
     });
   }
 
+  function runCopyWorkflow({ directories: dirs, io, messageLogger }) {
+    ensureDirectoryExists(io, dirs.publicDir);
+    copyBlogJson(dirs, io, messageLogger);
+    copyToyFiles(dirs, io, messageLogger);
+    copyPresenterFiles(dirs, io, messageLogger);
+    copySupportingDirectories(dirs, io, messageLogger);
+  }
+
   return {
     formatPathForLog,
     isCorrectJsFileEnding,
@@ -273,6 +281,7 @@ export function createCopyCore({ directories: dirConfig, path: pathDeps }) {
     copyToyFiles,
     copyPresenterFiles,
     copySupportingDirectories,
+    runCopyWorkflow,
   };
 }
 

--- a/src/generator/copy.js
+++ b/src/generator/copy.js
@@ -36,26 +36,13 @@ const logger = {
   warn: message => console.warn(message),
 };
 
-const {
-  ensureDirectoryExists,
-  copyBlogJson,
-  copyToyFiles,
-  copyPresenterFiles,
-  copySupportingDirectories,
-} = createCopyCore({ directories, path: pathAdapters });
+const { runCopyWorkflow } = createCopyCore({
+  directories,
+  path: pathAdapters,
+});
 
-/**
- * Execute the copy workflow.
- * @param {typeof thirdParty} io - File system helpers.
- * @param {typeof logger} messageLogger - Logger for status updates.
- * @returns {void}
- */
-function main(io, messageLogger) {
-  ensureDirectoryExists(io, directories.publicDir);
-  copyBlogJson(directories, io, messageLogger);
-  copyToyFiles(directories, io, messageLogger);
-  copyPresenterFiles(directories, io, messageLogger);
-  copySupportingDirectories(directories, io, messageLogger);
-}
-
-main(thirdParty, logger);
+runCopyWorkflow({
+  directories,
+  io: thirdParty,
+  messageLogger: logger,
+});

--- a/test/core/copy.test.js
+++ b/test/core/copy.test.js
@@ -274,6 +274,29 @@ describe('createCopyCore', () => {
     });
   });
 
+  describe('runCopyWorkflow', () => {
+    it('executes the copy pipeline with injected directories', () => {
+      const io = {
+        directoryExists: jest.fn().mockReturnValue(true),
+        createDirectory: jest.fn(),
+        copyFile: jest.fn(),
+        readDirEntries: jest.fn().mockReturnValue([]),
+      };
+      const logger = { info: jest.fn(), warn: jest.fn() };
+
+      core.runCopyWorkflow({ directories, io, messageLogger: logger });
+
+      expect(io.directoryExists).toHaveBeenCalledWith(directories.publicDir);
+      expect(io.copyFile).toHaveBeenCalledWith(
+        directories.srcBlogJson,
+        directories.publicBlogJson
+      );
+      expect(logger.info).toHaveBeenCalledWith(
+        'Copied: src/blog.json -> public/blog.json'
+      );
+    });
+  });
+
   describe('directory handling', () => {
     it('handles directory and file entries', () => {
       const io = {


### PR DESCRIPTION
## Summary
- add a `runCopyWorkflow` helper to the core copy module so the orchestration logic lives in core
- update the generator entry point to delegate to the new core workflow and inject directories explicitly
- expand core copy tests to cover the orchestrated workflow using injected dependencies

## Testing
- npm test -- --runTestsByPath test/core/copy.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d67ca66cdc832e885198dc03dadccb