### PR TITLE
Refactor cloud infra copy script to use shared core modules

### DIFF
--- a/src/core/cloud/copy.js
+++ b/src/core/cloud/copy.js
@@ -1,0 +1,218 @@
+export const DEFAULT_COPYABLE_EXTENSIONS = ['.js', '.json'];
+
+/**
+ * Create helpers for copying Cloud Function assets into the infra directory.
+ * @param {{
+ *   projectRoot: string,
+ *   path: {
+ *     join: typeof import('path').join,
+ *     dirname: typeof import('path').dirname,
+ *     relative: typeof import('path').relative,
+ *     extname: typeof import('path').extname,
+ *   },
+ *   copyableExtensions?: string[],
+ * }} options - Configuration for the copy workflow.
+ * @returns {{
+ *   formatPathForLog: (targetPath: string) => string,
+ *   isCopyableFile: (entry: import('fs').Dirent) => boolean,
+ *   copyFileToTarget: (
+ *     io: {
+ *       copyFile: (source: string, destination: string) => Promise<void>,
+ *     },
+ *     sourceDir: string,
+ *     targetDir: string,
+ *     name: string,
+ *     messageLogger: { info: (message: string) => void },
+ *   ) => Promise<void>,
+ *   copyDirectory: (
+ *     copyPlan: { source: string, target: string },
+ *     io: {
+ *       ensureDirectory: (target: string) => Promise<void>,
+ *       readDirEntries: (dir: string) => Promise<import('fs').Dirent[]>,
+ *     },
+ *     messageLogger: { info: (message: string) => void },
+ *   ) => Promise<void>,
+ *   copyDeclaredFiles: (
+ *     copyPlan: { sourceDir: string, targetDir: string, files: string[] },
+ *     io: {
+ *       ensureDirectory: (target: string) => Promise<void>,
+ *       copyFile: (source: string, destination: string) => Promise<void>,
+ *     },
+ *     messageLogger: { info: (message: string) => void },
+ *   ) => Promise<void>,
+ *   copyIndividualFiles: (
+ *     copies: { source: string, target: string }[],
+ *     io: {
+ *       ensureDirectory: (target: string) => Promise<void>,
+ *       copyFile: (source: string, destination: string) => Promise<void>,
+ *     },
+ *     messageLogger: { info: (message: string) => void },
+ *   ) => Promise<void>,
+ *   runCopyToInfra: ({
+ *     directoryCopies: { source: string, target: string }[],
+ *     fileCopies?: { sourceDir: string, targetDir: string, files: string[] },
+ *     individualFileCopies?: { source: string, target: string }[],
+ *     io: {
+ *       ensureDirectory: (target: string) => Promise<void>,
+ *       readDirEntries: (dir: string) => Promise<import('fs').Dirent[]>,
+ *       copyFile: (source: string, destination: string) => Promise<void>,
+ *     },
+ *     messageLogger: { info: (message: string) => void },
+ *   }) => Promise<void>,
+ * }}
+ */
+export function createCopyToInfraCore({
+  projectRoot,
+  path: pathDeps,
+  copyableExtensions = DEFAULT_COPYABLE_EXTENSIONS,
+}) {
+  const { join, dirname, relative, extname } = pathDeps;
+  const extensionSet = new Set(copyableExtensions);
+
+  /**
+   * Format a path relative to the project root for log output.
+   * @param {string} targetPath - Absolute path to format.
+   * @returns {string} Relative path or the original when outside the project.
+   */
+  function formatPathForLog(targetPath) {
+    const relativePath = relative(projectRoot, targetPath);
+    if (!relativePath) {
+      return '.';
+    }
+    if (relativePath.startsWith('..')) {
+      return targetPath;
+    }
+    return relativePath;
+  }
+
+  /**
+   * Check whether the directory entry represents a copyable file.
+   * @param {import('fs').Dirent} entry - Directory entry to inspect.
+   * @returns {boolean} True when the entry should be copied.
+   */
+  function isCopyableFile(entry) {
+    return entry.isFile() && extensionSet.has(extname(entry.name));
+  }
+
+  /**
+   * Copy a single file and log the operation.
+   * @param {{ copyFile: (source: string, destination: string) => Promise<void> }} io
+   * @param {string} sourceDir - Directory containing the file.
+   * @param {string} targetDir - Destination directory for the file.
+   * @param {string} name - File name to copy.
+   * @param {{ info: (message: string) => void }} messageLogger - Logger to report progress.
+   * @returns {Promise<void>} Resolves when the file is copied.
+   */
+  async function copyFileToTarget(io, sourceDir, targetDir, name, messageLogger) {
+    const sourcePath = join(sourceDir, name);
+    const destinationPath = join(targetDir, name);
+    await io.copyFile(sourcePath, destinationPath);
+    messageLogger.info(
+      `Copied: ${formatPathForLog(sourcePath)} -> ${formatPathForLog(destinationPath)}`,
+    );
+  }
+
+  /**
+   * Copy every supported file from a directory into the target path.
+   * @param {{ source: string, target: string }} copyPlan - Absolute source and target paths.
+   * @param {{
+   *   ensureDirectory: (target: string) => Promise<void>,
+   *   readDirEntries: (dir: string) => Promise<import('fs').Dirent[]>,
+   *   copyFile: (source: string, destination: string) => Promise<void>,
+   * }} io - Filesystem adapters.
+   * @param {{ info: (message: string) => void }} messageLogger - Logger to report progress.
+   * @returns {Promise<void>} Resolves when the directory has been processed.
+   */
+  async function copyDirectory(copyPlan, io, messageLogger) {
+    const { source, target } = copyPlan;
+    await io.ensureDirectory(target);
+
+    const sourceEntries = await io.readDirEntries(source);
+    const sourceFiles = sourceEntries.filter(isCopyableFile);
+    await Promise.all(
+      sourceFiles.map(entry =>
+        copyFileToTarget(io, source, target, entry.name, messageLogger),
+      ),
+    );
+  }
+
+  /**
+   * Copy a declared list of files into the target directory.
+   * @param {{ sourceDir: string, targetDir: string, files: string[] }} copyPlan - Copy configuration.
+   * @param {{ ensureDirectory: (target: string) => Promise<void>, copyFile: (source: string, destination: string) => Promise<void> }} io - Filesystem adapters.
+   * @param {{ info: (message: string) => void }} messageLogger - Logger to report progress.
+   * @returns {Promise<void>} Resolves when all files are copied.
+   */
+  async function copyDeclaredFiles(copyPlan, io, messageLogger) {
+    const { sourceDir, targetDir, files } = copyPlan;
+    await io.ensureDirectory(targetDir);
+
+    await Promise.all(
+      files.map(file => copyFileToTarget(io, sourceDir, targetDir, file, messageLogger)),
+    );
+  }
+
+  /**
+   * Copy files defined by explicit source and target pairs.
+   * @param {{ source: string, target: string }[]} copies - Array of copy instructions.
+   * @param {{ ensureDirectory: (target: string) => Promise<void>, copyFile: (source: string, destination: string) => Promise<void> }} io - Filesystem adapters.
+   * @param {{ info: (message: string) => void }} messageLogger - Logger to report progress.
+   * @returns {Promise<void>} Resolves when all files are copied.
+   */
+  async function copyIndividualFiles(copies, io, messageLogger) {
+    await Promise.all(
+      copies.map(async ({ source, target }) => {
+        await io.ensureDirectory(dirname(target));
+        await io.copyFile(source, target);
+        messageLogger.info(
+          `Copied: ${formatPathForLog(source)} -> ${formatPathForLog(target)}`,
+        );
+      }),
+    );
+  }
+
+  /**
+   * Execute the copy workflow using the provided configuration.
+   * @param {{
+   *   directoryCopies: { source: string, target: string }[],
+   *   fileCopies?: { sourceDir: string, targetDir: string, files: string[] },
+   *   individualFileCopies?: { source: string, target: string }[],
+   *   io: {
+   *     ensureDirectory: (target: string) => Promise<void>,
+   *     readDirEntries: (dir: string) => Promise<import('fs').Dirent[]>,
+   *     copyFile: (source: string, destination: string) => Promise<void>,
+   *   },
+   *   messageLogger: { info: (message: string) => void },
+   * }} options - Copy workflow options.
+   * @returns {Promise<void>} Resolves when all copy steps finish.
+   */
+  async function runCopyToInfra({
+    directoryCopies,
+    fileCopies,
+    individualFileCopies,
+    io,
+    messageLogger,
+  }) {
+    for (const directory of directoryCopies) {
+      await copyDirectory(directory, io, messageLogger);
+    }
+
+    if (fileCopies) {
+      await copyDeclaredFiles(fileCopies, io, messageLogger);
+    }
+
+    if (individualFileCopies?.length) {
+      await copyIndividualFiles(individualFileCopies, io, messageLogger);
+    }
+  }
+
+  return {
+    formatPathForLog,
+    isCopyableFile,
+    copyFileToTarget,
+    copyDirectory,
+    copyDeclaredFiles,
+    copyIndividualFiles,
+    runCopyToInfra,
+  };
+}

--- a/src/node/fs.js
+++ b/src/node/fs.js
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import { promises as fsPromises } from 'fs';
 
 /**
  * Provide synchronous filesystem helpers required by the copy generator.
@@ -15,5 +16,30 @@ export function createFsAdapters() {
     createDirectory: target => fs.mkdirSync(target, { recursive: true }),
     copyFile: (source, destination) => fs.copyFileSync(source, destination),
     readDirEntries: dir => fs.readdirSync(dir, { withFileTypes: true }),
+  };
+}
+
+/**
+ * Provide asynchronous filesystem helpers used by copy-to-infra scripts.
+ * @returns {{
+ *   readDirEntries: (dir: string) => Promise<fs.Dirent[]>,
+ *   ensureDirectory: (target: string) => Promise<void>,
+ *   copyFile: (source: string, destination: string) => Promise<void>,
+ * }}
+ */
+export function createAsyncFsAdapters() {
+  return {
+    async readDirEntries(dir) {
+      try {
+        return await fsPromises.readdir(dir, { withFileTypes: true });
+      } catch (error) {
+        if (error?.code === 'ENOENT') {
+          return [];
+        }
+        throw error;
+      }
+    },
+    ensureDirectory: target => fsPromises.mkdir(target, { recursive: true }),
+    copyFile: (source, destination) => fsPromises.copyFile(source, destination),
   };
 }

--- a/src/node/path.js
+++ b/src/node/path.js
@@ -24,14 +24,22 @@ export function resolveProjectDirectories(moduleDirectory) {
 }
 
 /**
- * Provide the subset of Node's path module used by the copy generator.
- * @returns {{ join: typeof path.join, dirname: typeof path.dirname, relative: typeof path.relative }}
+ * Provide the subset of Node's path module used by copy utilities.
+ * @returns {{
+ *   join: typeof path.join,
+ *   dirname: typeof path.dirname,
+ *   relative: typeof path.relative,
+ *   resolve: typeof path.resolve,
+ *   extname: typeof path.extname,
+ * }}
  */
 export function createPathAdapters() {
   return {
     join: path.join,
     dirname: path.dirname,
     relative: path.relative,
+    resolve: path.resolve,
+    extname: path.extname,
   };
 }
 


### PR DESCRIPTION
## Summary
- extract the Cloud Function copy workflow into a reusable core/cloud module
- add async filesystem adapters and expanded path helpers for infra copy scripts
- update copy-to-infra to consume the shared core logic and node adapters

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d67e530cc0832eac3d6b8d2cb84a32