### PR TITLE
Ensure core utilities are copied to public build

### DIFF
--- a/src/browser/createSectionSetter.js
+++ b/src/browser/createSectionSetter.js
@@ -1,5 +1,5 @@
 import { isObject } from './common.js';
-import { deepMerge } from './data.js';
+import { deepMerge } from '../core/state.js';
 import { deepClone } from '../utils/objectUtils.js';
 
 /**

--- a/src/browser/document.js
+++ b/src/browser/document.js
@@ -64,31 +64,10 @@ export const log = (...args) => console.log(...args);
 export const warn = (...args) => console.warn(...args);
 export const logError = (...args) => console.error(...args);
 
-/**
- * Creates a logging function that prefixes messages with the given prefix.
- * Returns a no-op function if the base logger is falsy.
- * @param {Function} logger - The base logging function
- * @param {string} prefix - The prefix string to prepend
- * @returns {Function} The prefixed logger function
- */
-export const createPrefixedLogger = (logger, prefix) => {
-  if (logger) {
-    return (...args) => logger(prefix, ...args);
-  }
-  return () => {};
-};
-
-/**
- * Creates a loggers object with each logger prefixed using the given prefix.
- * @param {object} loggers - Object containing logInfo, logError, and logWarning
- * @param {string} prefix - The prefix string to prepend to all log messages
- * @returns {object} The new loggers object with prefixed functions
- */
-export const createPrefixedLoggers = (loggers, prefix) => ({
-  logInfo: createPrefixedLogger(loggers.logInfo, prefix),
-  logError: createPrefixedLogger(loggers.logError, prefix),
-  logWarning: createPrefixedLogger(loggers.logWarning, prefix),
-});
+export {
+  createPrefixedLogger,
+  createPrefixedLoggers,
+} from '../core/logging.js';
 
 // Utility functions
 export const getClasses = el => Array.from(el.classList);

--- a/src/browser/main.js
+++ b/src/browser/main.js
@@ -5,8 +5,8 @@ import {
   getData,
   setLocalTemporaryData,
   setLocalPermanentData,
-  getEncodeBase64,
 } from './data.js';
+import { getEncodeBase64 } from '../core/encoding.js';
 import {
   createOutputDropdownHandler,
   createInputDropdownHandler,

--- a/src/core/copy.js
+++ b/src/core/copy.js
@@ -5,6 +5,7 @@ export const sharedDirectoryPairs = [
   { key: 'InputHandlers', relativePath: 'inputHandlers' },
   { key: 'Constants', relativePath: 'constants' },
   { key: 'Presenters', relativePath: 'presenters' },
+  { key: 'Core', relativePath: 'core' },
 ];
 
 export function createSharedDirectoryEntries({
@@ -227,6 +228,14 @@ export function createCopyCore({ directories: dirConfig, path: pathDeps }) {
         successMessage: 'Constants files copied successfully!',
         missingMessage: `Warning: constants directory not found at ${formatPathForLog(
           dirs.srcConstantsDir
+        )}`,
+      },
+      {
+        src: dirs.srcCoreDir,
+        dest: dirs.publicCoreDir,
+        successMessage: 'Core files copied successfully!',
+        missingMessage: `Warning: core directory not found at ${formatPathForLog(
+          dirs.srcCoreDir
         )}`,
       },
       {

--- a/src/core/encoding.js
+++ b/src/core/encoding.js
@@ -1,0 +1,15 @@
+/**
+ * Returns a Base64 encoding function using the provided btoa and
+ * encodeURIComponent helpers. This avoids the deprecated unescape by manually
+ * converting percent-encoded bytes back to a binary string.
+ * @param {Function} btoa - The btoa function
+ * @param {Function} encodeURIComponentFn - The encodeURIComponent function
+ * @returns {Function} encodeBase64 - Function that encodes a string to Base64
+ */
+export function getEncodeBase64(btoa, encodeURIComponentFn) {
+  const toBinary = str =>
+    encodeURIComponentFn(str).replace(/%([0-9A-F]{2})/g, (_, hex) =>
+      String.fromCharCode(parseInt(hex, 16))
+    );
+  return str => btoa(toBinary(str));
+}

--- a/src/core/logging.js
+++ b/src/core/logging.js
@@ -1,0 +1,25 @@
+/**
+ * Creates a logging function that prefixes messages with the given prefix.
+ * Returns a no-op function if the base logger is falsy.
+ * @param {Function} logger - The base logging function
+ * @param {string} prefix - The prefix string to prepend
+ * @returns {Function} The prefixed logger function
+ */
+export const createPrefixedLogger = (logger, prefix) => {
+  if (logger) {
+    return (...args) => logger(prefix, ...args);
+  }
+  return () => {};
+};
+
+/**
+ * Creates a loggers object with each logger prefixed using the given prefix.
+ * @param {object} loggers - Object containing logInfo, logError, and logWarning
+ * @param {string} prefix - The prefix string to prepend to all log messages
+ * @returns {object} The new loggers object with prefixed functions
+ */
+export const createPrefixedLoggers = (loggers, prefix) => ({
+  logInfo: createPrefixedLogger(loggers.logInfo, prefix),
+  logError: createPrefixedLogger(loggers.logError, prefix),
+  logWarning: createPrefixedLogger(loggers.logWarning, prefix),
+});

--- a/src/core/state.js
+++ b/src/core/state.js
@@ -1,0 +1,44 @@
+/**
+ * Check if a value is a non-null object.
+ * @param {*} value - Value to test.
+ * @returns {boolean} True when the value is a non-null object.
+ */
+export function isNonNullObject(value) {
+  return Boolean(value) && typeof value === 'object';
+}
+
+function bothAreNotArrays(a, b) {
+  return !Array.isArray(a) && !Array.isArray(b);
+}
+
+function bothAreNonNullObjects(a, b) {
+  return isNonNullObject(a) && isNonNullObject(b);
+}
+
+function shouldDeepMerge(targetValue, sourceValue) {
+  return (
+    bothAreNonNullObjects(targetValue, sourceValue) &&
+    bothAreNotArrays(targetValue, sourceValue)
+  );
+}
+
+/**
+ * Deeply merges two objects, producing a new object.
+ * @param {object} target - Destination object.
+ * @param {object} source - Source object to merge.
+ * @returns {object} The merged object.
+ */
+export function deepMerge(target, source) {
+  const output = { ...target };
+  const mergeKey = key => {
+    const targetValue = target[key];
+    const sourceValue = source[key];
+    if (shouldDeepMerge(targetValue, sourceValue)) {
+      output[key] = deepMerge(targetValue, sourceValue);
+    } else {
+      output[key] = sourceValue;
+    }
+  };
+  Object.keys(source).forEach(mergeKey);
+  return output;
+}

--- a/test/core/copy.test.js
+++ b/test/core/copy.test.js
@@ -21,6 +21,8 @@ const createDirectories = () => {
     publicInputHandlersDir: posix.join(publicDir, 'inputHandlers'),
     srcConstantsDir: posix.join(srcDir, 'constants'),
     publicConstantsDir: posix.join(publicDir, 'constants'),
+    srcCoreDir: posix.join(srcDir, 'core'),
+    publicCoreDir: posix.join(publicDir, 'core'),
     srcAssetsDir: posix.join(srcDir, 'assets'),
     publicAssetsDir: publicDir,
     srcPresentersDir: posix.join(srcDir, 'presenters'),
@@ -548,6 +550,9 @@ describe('createCopyCore', () => {
       );
       expect(logger.warn).toHaveBeenCalledWith(
         'Warning: constants directory not found at src/constants'
+      );
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Warning: core directory not found at src/core'
       );
       expect(logger.warn).toHaveBeenCalledWith(
         'Warning: assets directory not found at src/assets'


### PR DESCRIPTION
## Summary
- move the Base64 encoder and deep merge helpers into new `src/core` modules and re-export them for existing callers
- point browser data handling, section setters, and main initialization at the new shared utilities
- re-export logging helpers from `src/core/logging.js` for the document helpers
- update the copy pipeline so `src/core` modules are published with the browser bundle

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d688d4e644832e886c022175a7e537