### PR TITLE
Fix assign moderation job import path for deployment

### DIFF
--- a/src/cloud/assign-moderation-job/core.js
+++ b/src/cloud/assign-moderation-job/core.js
@@ -1,39 +1,4 @@
-/**
- * Determine whether a request origin is allowed.
- * @param {string | undefined} origin Request origin header.
- * @param {string[]} allowedOrigins Whitelisted origins.
- * @returns {boolean} True when the origin should be allowed.
- */
-export function isAllowedOrigin(origin, allowedOrigins) {
-  if (!origin) {
-    return true;
-  }
-
-  return allowedOrigins.includes(origin);
-}
-
-/**
- * Initialize Firebase resources, configure CORS, and expose dependencies.
- * @param {() => { db: import('firebase-admin/firestore').Firestore,
- *   auth: import('firebase-admin/auth').Auth, app: import('express').Express }} initializeFirebaseApp
- * Function that initializes Firebase and returns dependencies.
- * @param {(appInstance: import('express').Express, allowedOrigins: string[]) => void} configureCors
- * Function that configures CORS for the Express app.
- * @param {string[]} allowedOrigins Origins permitted to access the endpoint.
- * @param {(appInstance: import('express').Express) => void} [configureApp]
- * Optional callback invoked with the Express app for additional configuration.
- * @returns {{ db: import('firebase-admin/firestore').Firestore,
- *   auth: import('firebase-admin/auth').Auth, app: import('express').Express }} Initialized dependencies.
- */
-export function createAssignModerationApp(
-  initializeFirebaseApp,
-  configureCors,
-  allowedOrigins,
-  configureApp = () => {}
-) {
-  const { db, auth, app } = initializeFirebaseApp();
-  configureCors(app, allowedOrigins);
-  configureApp(app);
-
-  return { db, auth, app };
-}
+export {
+  createAssignModerationApp,
+  isAllowedOrigin,
+} from '../../core/cloud/assign-moderation-job/core.js';

--- a/src/cloud/assign-moderation-job/index.js
+++ b/src/cloud/assign-moderation-job/index.js
@@ -4,7 +4,10 @@ import express from 'express';
 import cors from 'cors';
 import { createAssignModerationWorkflow } from './workflow.js';
 import { createVariantSnapshotFetcher } from './variant-selection.js';
-import { createAssignModerationApp, isAllowedOrigin } from './core.js';
+import {
+  createAssignModerationApp,
+  isAllowedOrigin,
+} from './core.js';
 import { initializeFirebaseAppResources } from './gcf.js';
 
 /**

--- a/src/cloud/copy-to-infra.js
+++ b/src/cloud/copy-to-infra.js
@@ -16,6 +16,7 @@ const infraDir = resolve(projectRoot, 'infra');
 const srcCloudDir = resolve(srcDir, 'cloud');
 const infraFunctionsDir = resolve(infraDir, 'cloud-functions');
 const browserDir = resolve(srcDir, 'browser');
+const srcCoreCloudDir = resolve(srcDir, 'core', 'cloud');
 
 const functionDirectories = [
   'assign-moderation-job',
@@ -51,6 +52,10 @@ const individualFileCopies = [
   {
     source: join(browserDir, 'admin.js'),
     target: join(infraDir, 'admin.js'),
+  },
+  {
+    source: join(srcCoreCloudDir, 'assign-moderation-job', 'core.js'),
+    target: join(infraFunctionsDir, 'assign-moderation-job', 'core.js'),
   },
 ];
 

--- a/src/core/cloud/assign-moderation-job/core.js
+++ b/src/core/cloud/assign-moderation-job/core.js
@@ -1,0 +1,39 @@
+/**
+ * Determine whether a request origin is allowed.
+ * @param {string | undefined} origin Request origin header.
+ * @param {string[]} allowedOrigins Whitelisted origins.
+ * @returns {boolean} True when the origin should be allowed.
+ */
+export function isAllowedOrigin(origin, allowedOrigins) {
+  if (!origin) {
+    return true;
+  }
+
+  return allowedOrigins.includes(origin);
+}
+
+/**
+ * Initialize Firebase resources, configure CORS, and expose dependencies.
+ * @param {() => { db: import('firebase-admin/firestore').Firestore,
+ *   auth: import('firebase-admin/auth').Auth, app: import('express').Express }} initializeFirebaseApp
+ * Function that initializes Firebase and returns dependencies.
+ * @param {(appInstance: import('express').Express, allowedOrigins: string[]) => void} configureCors
+ * Function that configures CORS for the Express app.
+ * @param {string[]} allowedOrigins Origins permitted to access the endpoint.
+ * @param {(appInstance: import('express').Express) => void} [configureApp]
+ * Optional callback invoked with the Express app for additional configuration.
+ * @returns {{ db: import('firebase-admin/firestore').Firestore,
+ *   auth: import('firebase-admin/auth').Auth, app: import('express').Express }} Initialized dependencies.
+ */
+export function createAssignModerationApp(
+  initializeFirebaseApp,
+  configureCors,
+  allowedOrigins,
+  configureApp = () => {}
+) {
+  const { db, auth, app } = initializeFirebaseApp();
+  configureCors(app, allowedOrigins);
+  configureApp(app);
+
+  return { db, auth, app };
+}

--- a/test/cloud/assign-moderation-job/core.test.js
+++ b/test/cloud/assign-moderation-job/core.test.js
@@ -2,7 +2,7 @@ import { describe, expect, jest, test } from "@jest/globals";
 import {
   createAssignModerationApp,
   isAllowedOrigin,
-} from "../../../src/cloud/assign-moderation-job/core.js";
+} from "../../../src/core/cloud/assign-moderation-job/core.js";
 
 describe("isAllowedOrigin", () => {
   test("allows missing origin headers", () => {


### PR DESCRIPTION
## Summary
- add a local core re-export alongside the assign moderation job function entrypoint to keep imports working from tests
- point the cloud function entrypoint at the colocated core helper so the deployed bundle can resolve it

## Testing
- npm test -- test/cloud/assign-moderation-job/core.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d692a614e4832eadef92db526f928d