### PR TITLE
Add firebase-admin dependency for API key credit v2 function

### DIFF
--- a/infra/cloud-functions/get-api-key-credit-v2/package.json
+++ b/infra/cloud-functions/get-api-key-credit-v2/package.json
@@ -6,6 +6,7 @@
   "engines": { "node": ">=20" },
   "dependencies": {
     "@google-cloud/firestore": "^7.6.0",
+    "firebase-admin": "^11.10.1",
     "firebase-functions": "^5.0.1"
   }
 }


### PR DESCRIPTION
## Summary
- add firebase-admin to the get-api-key-credit-v2 Cloud Function dependencies to satisfy runtime imports

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6995a514c832e8ce85fb521435087