### PR TITLE
Move generate script into scripts directory

### DIFF
--- a/notes/core-adapter-reorg-plan.md
+++ b/notes/core-adapter-reorg-plan.md
@@ -2,7 +2,7 @@
 
 ## Current State Overview
 - The `src/generator` tree mixes pure string-building utilities (`html.js`, `head.js`, `full-width.js`, etc.) with orchestration logic in `generator.js`; these operate on plain data and return markup without touching the filesystem or browser APIs.
-- Environment-facing behaviors live in sibling folders: browser bootstrapping and DOM helpers (`src/browser`), UI input handlers/presenters (`src/inputHandlers`, `src/presenters`), Firebase Cloud Functions (`src/cloud`), and Node-based build scripts (`generate.js`, `src/generator/copy.js`, `src/cloud/copy-to-infra.js`).
+- Environment-facing behaviors live in sibling folders: browser bootstrapping and DOM helpers (`src/browser`), UI input handlers/presenters (`src/inputHandlers`, `src/presenters`), Firebase Cloud Functions (`src/cloud`), and Node-based build scripts (`src/scripts/generate.js`, `src/generator/copy.js`, `src/cloud/copy-to-infra.js`).
 - Shared utilities (`src/utils`) and constants (`src/constants`) are pure helpers already, while tests mirror the current layout and import modules by their existing paths.
 - Build automation assumes today’s folder names: Netlify publishes `public/`, `npm run build:browser` copies assets from `src` before generating HTML, and `npm run build:cloud` mirrors Cloud Function sources into `infra` for Google Cloud deployments.
 
@@ -33,7 +33,7 @@ This split makes `core` explicitly dependency-free, while adapters handle DOM, N
 
 ## Adapter Boundaries
 - Consolidate DOM-oriented modules (`src/browser`, `src/inputHandlers`, `src/presenters`) under `src/adapters/browser`. They manipulate the document, window, and localStorage, which are browser-specific concerns unsuitable for the core layer.
-- Keep Node scripts such as `generate.js` and `src/generator/copy.js` inside `src/adapters/scripts`. They interact with the filesystem, Prettier, and process APIs to prepare Netlify artifacts, so they naturally belong to the build adapter layer.
+- Keep Node scripts such as `src/scripts/generate.js` and `src/generator/copy.js` grouped with the adapter-focused build tools (e.g., under `src/adapters/scripts`). They interact with the filesystem, Prettier, and process APIs to prepare Netlify artifacts, so they naturally belong to the build adapter layer.
 - Relocate Firebase/Express handlers under `src/adapters/cloud` and introduce thin entry files that import pure business rules from `src/core`. That allows you to isolate logic for validation, rate limiting, or moderation state changes in the core while leaving the HTTP and Firestore wiring inside the adapter.
 - Move `src/browser/admin.js` into `src/adapters/browser/admin` (or similar) to highlight its external dependencies on hosted Firebase scripts and Cloud Function endpoints.
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "test": "node --experimental-vm-modules ./node_modules/.bin/jest --coverage",
-    "generate": "node generate.js",
+    "generate": "node src/scripts/generate.js",
     "test-watch": "node --experimental-vm-modules ./node_modules/.bin/jest --watchAll",
     "tcr": "./tcr.sh",
     "build-and-tcr": "npm run build:browser && npm run tcr",

--- a/src/generator/README.md
+++ b/src/generator/README.md
@@ -14,6 +14,6 @@ This directory contains the logic used to build the static HTML blog. Each file 
 
 ## Usage
 
-The `generate.js` script at the repository root demonstrates invoking `generateBlogOuter` with the blog JSON data and writing the formatted HTML to `public/index.html`.
+The `src/scripts/generate.js` script demonstrates invoking `generateBlogOuter` with the blog JSON data and writing the formatted HTML to `public/index.html`.
 
 Run `npm run generate` to create the blog output. Interactive component files can be copied by running `node src/generator/copy.js`.

--- a/src/scripts/generate.js
+++ b/src/scripts/generate.js
@@ -3,7 +3,7 @@
 // This CLI script demonstrates how to call the generateBlogOuter function from the command line.
 // Make sure your package.json has "type": "module" if you're using ES modules.
 
-import { generateBlogOuter } from './src/generator/generator.js';
+import { generateBlogOuter } from '../generator/generator.js';
 import { createRequire } from 'module';
 import fs from 'fs';
 import prettier from 'prettier';
@@ -11,7 +11,7 @@ import prettier from 'prettier';
 const require = createRequire(import.meta.url);
 
 // Construct a sample blog object
-const blog = require('./src/blog.json');
+const blog = require('../blog.json');
 
 // Generate the HTML using generateBlogOuter
 const outputHTML = generateBlogOuter(blog);


### PR DESCRIPTION
## Summary
- relocate the generate CLI entry point into src/scripts to keep scripts together
- update imports, npm script, and docs to reflect the new location
- refresh architecture notes so they reference the moved script path

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d69344bb88832eb8bbd5533f794fb9