### PR TITLE
Rename deploy Terraform workflow to gcp-prod

### DIFF
--- a/.github/workflows/gcp-prod.yml
+++ b/.github/workflows/gcp-prod.yml
@@ -1,4 +1,4 @@
-name: Deploy Terraform
+name: gcp-prod
 
 on:
   push:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,5 +34,5 @@
 - Ensure generated outputs or reports are up to date, but avoid committing transient build products outside approved directories.
 
 ## Automation & Deployment Notes
-- Terraform changes are applied by `.github/workflows/deploy-terraform.yml`; modify the workflow to adjust behavior instead of running Terraform manually.
+- Terraform changes are applied by `.github/workflows/gcp-prod.yml`; modify the workflow to adjust behavior instead of running Terraform manually.
 - Mutation analysis and quality gates rely on Stryker and Sonar scripts—run `npm run stryker` or `npm run sonar-issues` only when coordinated with maintainers, and capture their reports under `reports/` if shared.

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ npm install
 
 ## Terraform Workflows
 
-Infrastructure is managed with Terraform via GitHub Actions. The **Deploy Terraform**
+Infrastructure is managed with Terraform via GitHub Actions. The **gcp-prod**
 workflow applies changes automatically when commits modify the `infra/` directory.
 After confirming that newly provisioned resources function as expected, run the
 manual **Cleanup Terraform Services** workflow to disable any deprecated services.


### PR DESCRIPTION
## Summary
- rename the deploy-terraform workflow file to gcp-prod and update its displayed name
- refresh repository documentation to reference the gcp-prod workflow path and title

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68d7eb9a9464832e9e193b6923b483b4