### PR TITLE
Align new story and new page form widths with header

### DIFF
--- a/infra/dendrite.css
+++ b/infra/dendrite.css
@@ -326,6 +326,11 @@ form {
   max-width: 40ch;
 }
 
+form.wide-form {
+  max-width: 72ch;
+  width: 100%;
+}
+
 form > div {
   display: flex;
   flex-direction: column;

--- a/infra/new-page.html
+++ b/infra/new-page.html
@@ -79,6 +79,7 @@
     <main>
       <h1>New page</h1>
       <form
+        class="wide-form"
         action="https://europe-west1-irien-465710.cloudfunctions.net/prod-submit-new-page"
         method="post"
         enctype="application/x-www-form-urlencoded"

--- a/infra/new-story.html
+++ b/infra/new-story.html
@@ -79,6 +79,7 @@
     <main>
       <h1>New story</h1>
       <form
+        class="wide-form"
         action="https://europe-west1-irien-465710.cloudfunctions.net/prod-submit-new-story"
         method="post"
         enctype="application/x-www-form-urlencoded"


### PR DESCRIPTION
## Summary
- add a wide-form modifier to keep form layouts aligned with the site header width
- apply the wide-form styling to the new story and new page forms

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7ec1f0d20832ea1cb3b9604cc6731