### PR TITLE
Use short slug for gcp test workflow resources

### DIFF
--- a/.github/workflows/gcp-test.yml
+++ b/.github/workflows/gcp-test.yml
@@ -21,7 +21,9 @@ jobs:
       - name: Generate environment id
         id: environment
         run: |
-          ENVIRONMENT="test-$(uuidgen | tr 'A-Z' 'a-z')"
+          UUID="$(uuidgen | tr 'A-Z' 'a-z')"
+          SHORT_ID="$(printf '%s' "$UUID" | md5sum | cut -c1-8)"
+          ENVIRONMENT="t-${SHORT_ID}"
           echo "ENVIRONMENT=$ENVIRONMENT" >> "$GITHUB_ENV"
           echo "TF_VAR_environment=$ENVIRONMENT" >> "$GITHUB_ENV"
           echo "environment=$ENVIRONMENT" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- generate a short test environment slug derived from a UUID in the gcp-test workflow
- use the slug when exporting the Terraform environment variables so resource names stay under character limits

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d7f3498020832e8c02d7c9cb9bee4d