### PR TITLE
feat: support env-specific terraform resources

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -21,7 +21,15 @@ declared in `variables.tf`.
 Firestore security rules and composite indexes for the Dendrite collections are
 defined in `dendrite-firestore.tf`. The rules file lives in `rules/firestore.rules`
 and is released through Terraform to ensure consistent access control across
-environments.
+environments. Supply `database_id` (defaults to `"(default)"`) to point rules,
+indexes, and Cloud Functions triggers at an alternate Firestore database when
+deploying additional environments inside the same GCP project.
+
+Project-scoped services such as API enablement, Identity Platform configuration,
+and shared IAM bindings are guarded by the `project_level_environment` variable.
+Only the environment that matches this value (default `"prod"`) manages those
+singleton resources, letting other environments create their own per-env assets
+without fighting over project-level state.
 
 ## Remote State
 

--- a/infra/dendrite-firestore.tf
+++ b/infra/dendrite-firestore.tf
@@ -13,14 +13,15 @@ resource "google_firebaserules_ruleset" "firestore" {
       content = data.local_file.firestore_rules.content
     }
   }
-  depends_on = [
-    google_project_service.firebaserules,
-    google_project_iam_member.ci_firebaserules_admin,
-  ]
+  depends_on = concat(
+    local.firebaserules_service_dependency,
+    local.firebaserules_admin_dependency,
+  )
 }
 
 resource "google_firestore_index" "variants_author_created" {
   project     = var.project_id
+  database    = var.database_id
   collection  = "variants"
   query_scope = "COLLECTION"
 
@@ -37,6 +38,7 @@ resource "google_firestore_index" "variants_author_created" {
 # Supports: variants where moderatorReputationSum == 0 and rand >= n
 resource "google_firestore_index" "variants_moderation_rand" {
   project     = var.project_id
+  database    = var.database_id
   collection  = "variants"
   query_scope = "COLLECTION_GROUP"
 
@@ -53,7 +55,7 @@ resource "google_firestore_index" "variants_moderation_rand" {
 resource "google_firestore_field" "pages_all" {
   provider   = google-beta
   project    = var.project_id
-  database   = "(default)"
+  database   = var.database_id
   collection = "pages"
   field      = "__name__"
 
@@ -69,7 +71,7 @@ resource "google_firestore_field" "pages_all" {
 resource "google_firestore_field" "variants_moderation" {
   provider   = google-beta
   project    = var.project_id
-  database   = "(default)"
+  database   = var.database_id
   collection = "variants"
   field      = "moderatorReputationSum"
 
@@ -83,6 +85,7 @@ resource "google_firestore_field" "variants_moderation" {
 
 resource "google_firestore_index" "ratings_by_variant" {
   project     = var.project_id
+  database    = var.database_id
   collection  = "moderationRatings"
   query_scope = "COLLECTION"
 
@@ -99,7 +102,7 @@ resource "google_firestore_index" "ratings_by_variant" {
 resource "google_firestore_field" "pages_number_global" {
   provider   = google-beta
   project    = var.project_id
-  database   = "(default)"
+  database   = var.database_id
   collection = "pages"
   field      = "number"
 

--- a/infra/firebase-api-key.tf
+++ b/infra/firebase-api-key.tf
@@ -6,15 +6,17 @@
 
 # Allow Terraform to create / update / delete API keys
 resource "google_project_iam_member" "terraform_apikeys_admin" {
+  count   = local.manage_project_level_resources ? 1 : 0
   project = var.project_id
   role    = "roles/serviceusage.apiKeysAdmin"
   member  = "serviceAccount:terraform@${var.project_id}.iam.gserviceaccount.com"
 
-  depends_on = [google_project_service.apikeys_api]
+  depends_on = local.apikeys_api_dependency
 }
 resource "google_project_service" "apikeys_api" {
-  project            = var.project_id
-  service            = "apikeys.googleapis.com"
+  count             = local.manage_project_level_resources ? 1 : 0
+  project           = var.project_id
+  service           = "apikeys.googleapis.com"
   disable_on_destroy = false
 }
 

--- a/infra/firebase-auth-iam.tf
+++ b/infra/firebase-auth-iam.tf
@@ -1,12 +1,14 @@
 # Firebase Authentication IAM roles for Terraform
 
 resource "google_project_iam_member" "terraform_firebase_admin" {
+  count   = local.manage_project_level_resources ? 1 : 0
   project = var.project_id
   role    = "roles/firebase.admin"             # can add Firebase to a project & manage web-apps
   member  = "serviceAccount:terraform@${var.project_id}.iam.gserviceaccount.com"
 }
 
 resource "google_project_iam_member" "terraform_serviceusage_admin" {
+  count   = local.manage_project_level_resources ? 1 : 0
   project = var.project_id
   role    = "roles/serviceusage.serviceUsageAdmin"  # turns APIs on/off programmatically
   member  = "serviceAccount:terraform@${var.project_id}.iam.gserviceaccount.com"
@@ -19,8 +21,9 @@ resource "google_project_iam_member" "runtime_identityplatform_viewer" {
   member  = "serviceAccount:${google_service_account.cloud_function_runtime.email}"
 
   # optional, but makes the dependency explicit
-  depends_on = [
-    google_project_service.identitytoolkit       # turned on in firebase-auth.tf
-  ]
+  depends_on = concat(
+    local.identitytoolkit_service_dependency,
+    [google_service_account.cloud_function_runtime],
+  )
 }
 

--- a/infra/moved.tf
+++ b/infra/moved.tf
@@ -3,61 +3,61 @@
 
 moved {
   from = google_project_service.apis["firebase.googleapis.com"]
-  to   = google_project_service.firebase_api
+  to   = google_project_service.firebase_api[0]
 }
 
 moved {
   from = google_project_service.apis["identitytoolkit.googleapis.com"]
-  to   = google_project_service.identitytoolkit
+  to   = google_project_service.identitytoolkit[0]
 }
 
 moved {
   from = google_project_service.apis["cloudscheduler.googleapis.com"]
-  to   = google_project_service.cloudscheduler
+  to   = google_project_service.cloudscheduler[0]
 }
 
 moved {
   from = google_project_service.apis["compute.googleapis.com"]
-  to   = google_project_service.compute
+  to   = google_project_service.compute[0]
 }
 
 moved {
   from = google_project_service.apis["eventarc.googleapis.com"]
-  to   = google_project_service.eventarc
+  to   = google_project_service.eventarc[0]
 }
 
 moved {
   from = google_project_service.apis["firebaserules.googleapis.com"]
-  to   = google_project_service.firebaserules
+  to   = google_project_service.firebaserules[0]
 }
 
 moved {
   from = google_project_service.apis["cloudfunctions.googleapis.com"]
-  to   = google_project_service.cloudfunctions
+  to   = google_project_service.cloudfunctions[0]
 }
 
 moved {
   from = google_project_service.apis["artifactregistry.googleapis.com"]
-  to   = google_project_service.artifactregistry
+  to   = google_project_service.artifactregistry[0]
 }
 
 moved {
   from = google_project_service.apis["firestore.googleapis.com"]
-  to   = google_project_service.firestore
+  to   = google_project_service.firestore[0]
 }
 
 moved {
   from = google_project_service.apis["run.googleapis.com"]
-  to   = google_project_service.run
+  to   = google_project_service.run[0]
 }
 
 moved {
   from = google_project_service.apis["apikeys.googleapis.com"]
-  to   = google_project_service.apikeys_api
+  to   = google_project_service.apikeys_api[0]
 }
 
 moved {
   from = google_project_service.apis["cloudbuild.googleapis.com"]
-  to   = google_project_service.cloudbuild
+  to   = google_project_service.cloudbuild[0]
 }
 

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -39,6 +39,18 @@ variable "environment" {
   default     = "prod"         # keeps prod plans = zero-diff
 }
 
+variable "project_level_environment" {
+  description = "Environment that manages project-level singleton resources"
+  type        = string
+  default     = "prod"
+}
+
+variable "database_id" {
+  description = "Firestore database identifier to target (\"(default)\" or a named database)"
+  type        = string
+  default     = "(default)"
+}
+
 variable "google_oauth_client_id" {
   description = "OAuth client ID for Google sign-in"
   type        = string


### PR DESCRIPTION
## Summary
- add `project_level_environment` and `database_id` variables so Terraform can target env-specific Firestore databases while leaving singleton resources to the primary env
- wrap project-scoped services and IAM bindings in conditional locals and reuse those dependencies across Cloud Functions and load balancer resources
- document the new configuration knobs and update state-move mappings for the conditional project services

## Testing
- not run (terraform CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d834714458832ea0f78a65d6af5515