### PR TITLE
Add env-specific Identity Platform tenant configuration

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -19,17 +19,26 @@ Resources for this function live in `main.tf` and all input variables are
 declared in `variables.tf`.
 
 Firestore security rules and composite indexes for the Dendrite collections are
-defined in `dendrite-firestore.tf`. The rules file lives in `rules/firestore.rules`
-and is released through Terraform to ensure consistent access control across
-environments. Supply `database_id` (defaults to `"(default)"`) to point rules,
-indexes, and Cloud Functions triggers at an alternate Firestore database when
-deploying additional environments inside the same GCP project.
+defined in `dendrite-firestore.tf`. The rules file lives in
+`rules/firestore.rules` and is released through Terraform to ensure consistent
+access control across environments. Supply `database_id` (defaults to
+`"(default)"`) to point rules, indexes, and Cloud Functions triggers at an
+alternate Firestore database when deploying additional environments inside the
+same GCP project. The generated `firebase_web_app_config` output now includes the
+selected `databaseId` and the per-environment Identity Platform tenant so that
+client and backend runtimes can connect to the correct datastore without manual
+configuration.
 
-Project-scoped services such as API enablement, Identity Platform configuration,
-and shared IAM bindings are guarded by the `project_level_environment` variable.
-Only the environment that matches this value (default `"prod"`) manages those
-singleton resources, letting other environments create their own per-env assets
-without fighting over project-level state.
+Identity Platform supports multi-environment isolation via tenants. Terraform
+creates one tenant per `environment`, exposes it as the
+`identity_platform_tenant` output, and enables Google Sign-In within that
+tenant. Customize the allowed callback domains with
+`identity_platform_authorized_domains`. Project-scoped services such as API
+enablement, the global Identity Platform configuration, and shared IAM bindings
+are guarded by the `project_level_environment` variable. Only the environment
+that matches this value (default `"prod"`) manages those singleton resources,
+letting other environments create their own per-env assets without fighting over
+project-level state.
 
 ## Remote State
 

--- a/infra/functions-v2.tf
+++ b/infra/functions-v2.tf
@@ -33,15 +33,16 @@ resource "google_cloudfunctions2_function" "get_api_key_credit_v2" {
     environment_variables = {
       GCLOUD_PROJECT       = var.project_id
       GOOGLE_CLOUD_PROJECT = var.project_id
-      FIREBASE_CONFIG      = jsonencode({ projectId = var.project_id })
+      FIREBASE_CONFIG      = local.firebase_config_json
     }
   }
 
-  depends_on = [
-    google_project_service.run,
-    google_project_service.artifactregistry,
-    # google_project_service.eventarc, # if you added it
-  ]
+  depends_on = concat(
+    local.cloud_function_runtime_dependencies,
+    local.run_service_dependency,
+    local.artifactregistry_service_dependency,
+    local.eventarc_service_dependency,
+  )
 }
 
 resource "google_cloud_run_service_iam_member" "get_api_key_credit_v2_public" {
@@ -50,5 +51,8 @@ resource "google_cloud_run_service_iam_member" "get_api_key_credit_v2_public" {
   role     = "roles/run.invoker"
   member   = "allUsers"
 
-  depends_on = [google_cloudfunctions2_function.get_api_key_credit_v2]
+  depends_on = concat(
+    [google_cloudfunctions2_function.get_api_key_credit_v2],
+    local.cloudfunctions_viewer_dependency,
+  )
 }

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -105,7 +105,7 @@ resource "google_storage_bucket_object" "dendrite_mod" {
   name   = "mod.html"
   bucket = google_storage_bucket.dendrite_static.name
   content = templatefile("${path.module}/mod.html", {
-    firebase_web_app_config = jsonencode(local.firebase_web_app_config)
+    firebase_web_app_config = local.firebase_config_json
   })
   content_type = "text/html"
 }
@@ -387,7 +387,7 @@ resource "google_cloudfunctions_function" "get_api_key_credit" {
   environment_variables = {
     GCLOUD_PROJECT       = var.project_id
     GOOGLE_CLOUD_PROJECT = var.project_id
-    FIREBASE_CONFIG      = jsonencode({ projectId = var.project_id })
+    FIREBASE_CONFIG      = local.firebase_config_json
   }
 
 
@@ -444,7 +444,7 @@ resource "google_cloudfunctions_function" "submit_new_story" {
   environment_variables = {
     GCLOUD_PROJECT       = var.project_id
     GOOGLE_CLOUD_PROJECT = var.project_id
-    FIREBASE_CONFIG      = jsonencode({ projectId = var.project_id })
+    FIREBASE_CONFIG      = local.firebase_config_json
   }
 
 
@@ -465,7 +465,7 @@ resource "google_cloudfunctions_function" "submit_new_page" {
   environment_variables = {
     GCLOUD_PROJECT       = var.project_id
     GOOGLE_CLOUD_PROJECT = var.project_id
-    FIREBASE_CONFIG      = jsonencode({ projectId = var.project_id })
+    FIREBASE_CONFIG      = local.firebase_config_json
   }
 
 
@@ -522,7 +522,7 @@ resource "google_cloudfunctions_function" "assign_moderation_job" {
   environment_variables = {
     GCLOUD_PROJECT       = var.project_id
     GOOGLE_CLOUD_PROJECT = var.project_id
-    FIREBASE_CONFIG      = jsonencode({ projectId = var.project_id })
+    FIREBASE_CONFIG      = local.firebase_config_json
   }
 
   depends_on = local.cloud_function_http_dependencies
@@ -566,7 +566,7 @@ resource "google_cloudfunctions_function" "get_moderation_variant" {
   environment_variables = {
     GCLOUD_PROJECT       = var.project_id
     GOOGLE_CLOUD_PROJECT = var.project_id
-    FIREBASE_CONFIG      = jsonencode({ projectId = var.project_id })
+    FIREBASE_CONFIG      = local.firebase_config_json
   }
 
   depends_on = local.cloud_function_http_dependencies
@@ -610,7 +610,7 @@ resource "google_cloudfunctions_function" "submit_moderation_rating" {
   environment_variables = {
     GCLOUD_PROJECT       = var.project_id
     GOOGLE_CLOUD_PROJECT = var.project_id
-    FIREBASE_CONFIG      = jsonencode({ projectId = var.project_id })
+    FIREBASE_CONFIG      = local.firebase_config_json
   }
 
   depends_on = local.cloud_function_http_dependencies
@@ -655,7 +655,7 @@ resource "google_cloudfunctions_function" "report_for_moderation" {
   environment_variables = {
     GCLOUD_PROJECT       = var.project_id
     GOOGLE_CLOUD_PROJECT = var.project_id
-    FIREBASE_CONFIG      = jsonencode({ projectId = var.project_id })
+    FIREBASE_CONFIG      = local.firebase_config_json
   }
 
   depends_on = local.cloud_function_http_dependencies
@@ -700,7 +700,7 @@ resource "google_cloudfunctions_function" "process_new_story" {
   environment_variables = {
     GCLOUD_PROJECT       = var.project_id
     GOOGLE_CLOUD_PROJECT = var.project_id
-    FIREBASE_CONFIG      = jsonencode({ projectId = var.project_id })
+    FIREBASE_CONFIG      = local.firebase_config_json
   }
 
 
@@ -738,7 +738,7 @@ resource "google_cloudfunctions_function" "prod_update_variant_visibility" {
   environment_variables = {
     GCLOUD_PROJECT       = var.project_id
     GOOGLE_CLOUD_PROJECT = var.project_id
-    FIREBASE_CONFIG      = jsonencode({ projectId = var.project_id })
+    FIREBASE_CONFIG      = local.firebase_config_json
   }
 
   event_trigger {
@@ -775,7 +775,7 @@ resource "google_cloudfunctions_function" "process_new_page" {
   environment_variables = {
     GCLOUD_PROJECT       = var.project_id
     GOOGLE_CLOUD_PROJECT = var.project_id
-    FIREBASE_CONFIG      = jsonencode({ projectId = var.project_id })
+    FIREBASE_CONFIG      = local.firebase_config_json
   }
 
 
@@ -813,7 +813,7 @@ resource "google_cloudfunctions_function" "render_variant" {
   environment_variables = {
     GCLOUD_PROJECT       = var.project_id
     GOOGLE_CLOUD_PROJECT = var.project_id
-    FIREBASE_CONFIG      = jsonencode({ projectId = var.project_id })
+    FIREBASE_CONFIG      = local.firebase_config_json
   }
 
 
@@ -851,7 +851,7 @@ resource "google_cloudfunctions_function" "hide_variant_html" {
   environment_variables = {
     GCLOUD_PROJECT       = var.project_id
     GOOGLE_CLOUD_PROJECT = var.project_id
-    FIREBASE_CONFIG      = jsonencode({ projectId = var.project_id })
+    FIREBASE_CONFIG      = local.firebase_config_json
   }
 
   event_trigger {
@@ -888,7 +888,7 @@ resource "google_cloudfunctions_function" "mark_variant_dirty" {
   environment_variables = {
     GCLOUD_PROJECT       = var.project_id
     GOOGLE_CLOUD_PROJECT = var.project_id
-    FIREBASE_CONFIG      = jsonencode({ projectId = var.project_id })
+    FIREBASE_CONFIG      = local.firebase_config_json
   }
 
   depends_on = local.cloud_function_http_dependencies
@@ -932,7 +932,7 @@ resource "google_cloudfunctions_function" "generate_stats" {
   environment_variables = {
     GCLOUD_PROJECT       = var.project_id
     GOOGLE_CLOUD_PROJECT = var.project_id
-    FIREBASE_CONFIG      = jsonencode({ projectId = var.project_id })
+    FIREBASE_CONFIG      = local.firebase_config_json
   }
 
   depends_on = local.cloud_function_http_dependencies
@@ -994,7 +994,7 @@ resource "google_cloudfunctions_function" "render_contents" {
   environment_variables = {
     GCLOUD_PROJECT       = var.project_id
     GOOGLE_CLOUD_PROJECT = var.project_id
-    FIREBASE_CONFIG      = jsonencode({ projectId = var.project_id })
+    FIREBASE_CONFIG      = local.firebase_config_json
   }
 
 
@@ -1020,7 +1020,7 @@ resource "google_cloudfunctions_function" "trigger_render_contents" {
   environment_variables = {
     GCLOUD_PROJECT       = var.project_id
     GOOGLE_CLOUD_PROJECT = var.project_id
-    FIREBASE_CONFIG      = jsonencode({ projectId = var.project_id })
+    FIREBASE_CONFIG      = local.firebase_config_json
   }
 
   depends_on = local.cloud_function_http_dependencies

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -1,3 +1,11 @@
 output "firebase_web_app_config" {
   value = local.firebase_web_app_config
 }
+
+output "identity_platform_tenant" {
+  value = {
+    name       = google_identity_platform_tenant.environment.name
+    tenant_id  = google_identity_platform_tenant.environment.tenant_id
+    project_id = var.project_id
+  }
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -66,3 +66,14 @@ variable "gis_one_tap_client_id" {
   type        = string
   default     = ""
 }
+
+variable "identity_platform_authorized_domains" {
+  description = "Allowed domains for project-level Identity Platform configuration"
+  type        = list(string)
+  default = [
+    "dendritestories.co.nz",
+    "www.dendritestories.co.nz",
+    "mattheard.net",
+    "localhost",
+  ]
+}


### PR DESCRIPTION
## Summary
- add Identity Platform tenants so each environment gets its own Google Sign-In configuration
- include database and tenant identifiers in the shared Firebase config used by Cloud Functions and static assets
- make project-level auth settings configurable via identity_platform_authorized_domains and reuse them across environments

## Testing
- not run (Terraform-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d8d22dc90c832e8cb92e33cd8fbef0