### PR TITLE
Update Firebase tenant configuration to use computed name

### DIFF
--- a/infra/firebase-auth.tf
+++ b/infra/firebase-auth.tf
@@ -45,7 +45,6 @@ data "google_firebase_web_app_config" "frontend" {
 
 locals {
   identity_platform_authorized_domains = var.identity_platform_authorized_domains
-  identity_platform_tenant_id          = lower("env-${var.environment}")
   identity_platform_tenant_display     = format("Dadeto %s", var.environment)
 
   firebase_web_app_config = {
@@ -57,7 +56,7 @@ locals {
     messagingSenderId = data.google_firebase_web_app_config.frontend.messaging_sender_id
     appId             = google_firebase_web_app.frontend.app_id
     measurementId     = data.google_firebase_web_app_config.frontend.measurement_id
-    tenantId          = google_identity_platform_tenant.environment.tenant_id
+    tenantId          = google_identity_platform_tenant.environment.name
   }
 
   firebase_config_json = jsonencode(local.firebase_web_app_config)
@@ -102,11 +101,10 @@ resource "google_identity_platform_oauth_idp_config" "gis_allowlist" {
 }
 
 resource "google_identity_platform_tenant" "environment" {
-  provider                = google-beta
-  project                 = var.project_id
-  tenant_id               = local.identity_platform_tenant_id
-  display_name            = local.identity_platform_tenant_display
-  allow_password_signup   = false
+  provider                 = google-beta
+  project                  = var.project_id
+  display_name             = local.identity_platform_tenant_display
+  allow_password_signup    = false
   enable_email_link_signin = false
 
   depends_on = [

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -5,7 +5,7 @@ output "firebase_web_app_config" {
 output "identity_platform_tenant" {
   value = {
     name       = google_identity_platform_tenant.environment.name
-    tenant_id  = google_identity_platform_tenant.environment.tenant_id
+    id         = google_identity_platform_tenant.environment.id
     project_id = var.project_id
   }
 }


### PR DESCRIPTION
## Summary
- stop hard-coding the Firebase tenant ID and rely on the resource name instead
- expose the tenant resource name and id from Terraform outputs for downstream consumers

## Testing
- `terraform -chdir=infra init -backend=false`
- `terraform -chdir=infra plan -input=false -lock=false -refresh=false` *(fails: backend requires remote GCS initialization and ADC credentials are unavailable in this environment)*
- `terraform -chdir=infra validate`


------
https://chatgpt.com/codex/tasks/task_e_68d8e61f9b8c832e94be617ed1275293