### PR TITLE
Ensure prod Terraform workflow receives environment

### DIFF
--- a/.github/workflows/gcp-prod.yml
+++ b/.github/workflows/gcp-prod.yml
@@ -18,6 +18,8 @@ jobs:
     env:
       REGION: europe-west1
       ENVIRONMENT: prod
+      TF_VAR_environment: ${{ env.ENVIRONMENT }}
+      TF_VAR_project_level_environment: prod
       TF_VAR_google_oauth_client_id: ${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}
       TF_VAR_google_oauth_client_secret: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
 
@@ -49,6 +51,12 @@ jobs:
         uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: 1.6.6
+
+      - name: Terraform Format Check
+        run: terraform fmt -check
+
+      - name: Terraform Validate
+        run: terraform validate
 
       - name: Terraform Init
         run: terraform init -migrate-state

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -9,3 +9,8 @@ output "identity_platform_tenant" {
     project_id = var.project_id
   }
 }
+
+output "effective_environment" {
+  description = "Deployment environment that Terraform evaluated"
+  value       = var.environment
+}


### PR DESCRIPTION
## Summary
- export Terraform environment gate variables in the prod workflow so Firestore services remain managed
- add fmt and validate checks to the Terraform job for early feedback
- expose the evaluated Terraform environment via a new `effective_environment` output for plan inspection

## Testing
- not run (Terraform CLI is not available in the container)

------
https://chatgpt.com/codex/tasks/task_e_68d928ea0118832e8e846a5fc7809658