### PR TITLE
Fix gcp prod workflow env variable

### DIFF
--- a/.github/workflows/gcp-prod.yml
+++ b/.github/workflows/gcp-prod.yml
@@ -18,7 +18,7 @@ jobs:
     env:
       REGION: europe-west1
       ENVIRONMENT: prod
-      TF_VAR_environment: ${{ env.ENVIRONMENT }}
+      TF_VAR_environment: prod
       TF_VAR_project_level_environment: prod
       TF_VAR_google_oauth_client_id: ${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}
       TF_VAR_google_oauth_client_secret: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}


### PR DESCRIPTION
## Summary
- hardcode the prod environment variable in the gcp-prod workflow to avoid invalid env interpolation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d92a5fff4c832ea656aeb51f6408e8