### PR TITLE
Fix Terraform formatting drift

### DIFF
--- a/infra/firebase-api-key.tf
+++ b/infra/firebase-api-key.tf
@@ -16,9 +16,9 @@ resource "google_project_iam_member" "terraform_apikeys_admin" {
   ]
 }
 resource "google_project_service" "apikeys_api" {
-  count             = local.manage_project_level_resources ? 1 : 0
-  project           = var.project_id
-  service           = "apikeys.googleapis.com"
+  count              = local.manage_project_level_resources ? 1 : 0
+  project            = var.project_id
+  service            = "apikeys.googleapis.com"
   disable_on_destroy = false
 }
 

--- a/infra/firebase-auth-iam.tf
+++ b/infra/firebase-auth-iam.tf
@@ -3,21 +3,21 @@
 resource "google_project_iam_member" "terraform_firebase_admin" {
   count   = local.manage_project_level_resources ? 1 : 0
   project = var.project_id
-  role    = "roles/firebase.admin"             # can add Firebase to a project & manage web-apps
+  role    = "roles/firebase.admin" # can add Firebase to a project & manage web-apps
   member  = "serviceAccount:terraform@${var.project_id}.iam.gserviceaccount.com"
 }
 
 resource "google_project_iam_member" "terraform_serviceusage_admin" {
   count   = local.manage_project_level_resources ? 1 : 0
   project = var.project_id
-  role    = "roles/serviceusage.serviceUsageAdmin"  # turns APIs on/off programmatically
+  role    = "roles/serviceusage.serviceUsageAdmin" # turns APIs on/off programmatically
   member  = "serviceAccount:terraform@${var.project_id}.iam.gserviceaccount.com"
 }
 
 # Allow the Cloud Function runtime SA to read auth users
 resource "google_project_iam_member" "runtime_identityplatform_viewer" {
   project = var.project_id
-  role    = "roles/identityplatform.viewer"   # just “view” permissions
+  role    = "roles/identityplatform.viewer" # just “view” permissions
   member  = "serviceAccount:${google_service_account.cloud_function_runtime.email}"
 
   # optional, but makes the dependency explicit

--- a/infra/prod.auto.tfvars
+++ b/infra/prod.auto.tfvars
@@ -1,3 +1,3 @@
-project_id = "irien-465710"
+project_id  = "irien-465710"
 environment = "prod"
 

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -36,7 +36,7 @@ variable "https_security_level" {
 variable "environment" {
   description = "Deployment environment identifier, e.g. prod, e2e"
   type        = string
-  default     = "prod"         # keeps prod plans = zero-diff
+  default     = "prod" # keeps prod plans = zero-diff
 }
 
 variable "project_level_environment" {


### PR DESCRIPTION
## Summary
- adjust spacing in firebase API key resource to match `terraform fmt`
- normalize inline comment spacing for Firebase IAM resources
- align tfvars and variable defaults with the formatter output

## Testing
- `terraform fmt -recursive` *(fails: terraform not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d935c23ce8832eafb6e81464008557