### PR TITLE
Fix Terraform validate step by running init

### DIFF
--- a/.github/workflows/gcp-prod.yml
+++ b/.github/workflows/gcp-prod.yml
@@ -55,6 +55,9 @@ jobs:
       - name: Terraform Format Check
         run: terraform fmt -check -diff -recursive
 
+      - name: Terraform Init (Validate)
+        run: terraform init -backend=false
+
       - name: Terraform Validate
         run: terraform validate
 


### PR DESCRIPTION
## Summary
- add a Terraform init step before validation so providers are installed

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d93916c3f0832eaf690a39092410c5