### PR TITLE
Add Terraform outputs for Firestore gating visibility

### DIFF
--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -14,3 +14,18 @@ output "effective_environment" {
   description = "Deployment environment that Terraform evaluated"
   value       = var.environment
 }
+
+output "effective_project_level_environment" {
+  description = "Project-level environment value seen during plan"
+  value       = var.project_level_environment
+}
+
+output "manage_project_level_resources" {
+  description = "Whether project-level resources will be managed"
+  value       = local.manage_project_level_resources
+}
+
+output "manage_firestore_services" {
+  description = "Whether Firestore services are managed in this run"
+  value       = local.manage_firestore_services
+}


### PR DESCRIPTION
## Summary
- expose project-level environment and resource management booleans via Terraform outputs to debug Firestore gating

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d93e5b3690832eacd0413150ad3f5a