### PR TITLE
Add state move blocks for Firestore services

### DIFF
--- a/infra/moved.tf
+++ b/infra/moved.tf
@@ -32,6 +32,11 @@ moved {
 }
 
 moved {
+  from = google_project_service.firebaserules
+  to   = google_project_service.firebaserules[0]
+}
+
+moved {
   from = google_project_service.apis["cloudfunctions.googleapis.com"]
   to   = google_project_service.cloudfunctions[0]
 }
@@ -43,6 +48,11 @@ moved {
 
 moved {
   from = google_project_service.apis["firestore.googleapis.com"]
+  to   = google_project_service.firestore[0]
+}
+
+moved {
+  from = google_project_service.firestore
   to   = google_project_service.firestore[0]
 }
 


### PR DESCRIPTION
## Summary
- add state move blocks to map legacy Firestore service resources to their counted addresses

## Testing
- not run (terraform CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d956c159d4832e96ce4cbaa58241ec