### PR TITLE
Remove duplicate move blocks for Firestore services

### DIFF
--- a/infra/moved.tf
+++ b/infra/moved.tf
@@ -32,11 +32,6 @@ moved {
 }
 
 moved {
-  from = google_project_service.firebaserules
-  to   = google_project_service.firebaserules[0]
-}
-
-moved {
   from = google_project_service.apis["cloudfunctions.googleapis.com"]
   to   = google_project_service.cloudfunctions[0]
 }
@@ -48,11 +43,6 @@ moved {
 
 moved {
   from = google_project_service.apis["firestore.googleapis.com"]
-  to   = google_project_service.firestore[0]
-}
-
-moved {
-  from = google_project_service.firestore
   to   = google_project_service.firestore[0]
 }
 


### PR DESCRIPTION
## Summary
- remove duplicate state move blocks for the Firestore and Firebase Rules services so each destination has a single source

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da49f1ca00832e8a1fdf7af1035efc