### PR TITLE
Fix Firestore and Firebase Rules move sources

### DIFF
--- a/infra/moved.tf
+++ b/infra/moved.tf
@@ -27,7 +27,7 @@ moved {
 }
 
 moved {
-  from = google_project_service.apis["firebaserules.googleapis.com"]
+  from = google_project_service.firebaserules
   to   = google_project_service.firebaserules[0]
 }
 
@@ -42,7 +42,7 @@ moved {
 }
 
 moved {
-  from = google_project_service.apis["firestore.googleapis.com"]
+  from = google_project_service.firestore
   to   = google_project_service.firestore[0]
 }
 


### PR DESCRIPTION
## Summary
- point the Firestore and Firebase Rules moved blocks at the legacy singular resources
- keep a single source for each destination service move to prevent duplicate migrations

## Testing
- `terraform plan` *(fails: terraform not installed in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da4d2784f4832e898a7024b3456bf9