### PR TITLE
Normalize Identity Platform tenant display name

### DIFF
--- a/infra/firebase-auth.tf
+++ b/infra/firebase-auth.tf
@@ -45,7 +45,24 @@ data "google_firebase_web_app_config" "frontend" {
 
 locals {
   identity_platform_authorized_domains = var.identity_platform_authorized_domains
-  identity_platform_tenant_display     = format("Dadeto %s", var.environment)
+  identity_platform_environment_sanitized = trim(
+    regexreplace(lower(var.environment), "[^a-z0-9-]+", "-"),
+    "-",
+  )
+  identity_platform_tenant_slug = length(local.identity_platform_environment_sanitized) > 0 ? local.identity_platform_environment_sanitized : "env"
+  identity_platform_tenant_display_full = "Dadeto-${local.identity_platform_tenant_slug}"
+  identity_platform_tenant_display_truncated = substr(
+    local.identity_platform_tenant_display_full,
+    0,
+    min(length(local.identity_platform_tenant_display_full), 20),
+  )
+  identity_platform_tenant_display_normalized = regexreplace(
+    local.identity_platform_tenant_display_truncated,
+    "-{2,}",
+    "-",
+  )
+  identity_platform_tenant_display_clean = trim(local.identity_platform_tenant_display_normalized, "-")
+  identity_platform_tenant_display = length(local.identity_platform_tenant_display_clean) >= 4 ? local.identity_platform_tenant_display_clean : "Dadeto"
 
   firebase_web_app_config = {
     apiKey            = data.google_firebase_web_app_config.frontend.api_key


### PR DESCRIPTION
## Summary
- sanitize the Identity Platform tenant display name so environments resolve to policy-compliant identifiers

## Testing
- terraform init *(fails: missing application default credentials in the local container)*

------
https://chatgpt.com/codex/tasks/task_e_68da7802f07c832ea0f17bbdac69f468