### PR TITLE
Add move mapping for Firestore database resource

### DIFF
--- a/infra/moved.tf
+++ b/infra/moved.tf
@@ -61,3 +61,8 @@ moved {
   to   = google_project_service.cloudbuild[0]
 }
 
+moved {
+  from = google_firestore_database.default
+  to   = google_firestore_database.database[0]
+}
+


### PR DESCRIPTION
## Summary
- add a Terraform moved block to map the legacy google_firestore_database.default address to google_firestore_database.database[0]

## Testing
- `terraform init -input=false` *(fails: google: could not find default credentials in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da8fd637b4832ea2f11a5a6be375ba