### PR TITLE
Remove Terraform fmt check from prod workflow

### DIFF
--- a/.github/workflows/gcp-prod.yml
+++ b/.github/workflows/gcp-prod.yml
@@ -52,9 +52,6 @@ jobs:
         with:
           terraform_version: 1.6.6
 
-      - name: Terraform Format Check
-        run: terraform fmt -check -diff -recursive
-
       - name: Terraform Init (Validate)
         run: terraform init -backend=false
 


### PR DESCRIPTION
## Summary
- remove the terraform fmt validation step from the production deployment workflow

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da9594cda8832eafb06ff7e93ce2bf