### PR TITLE
chore: upgrade terraform cli used in ci

### DIFF
--- a/.github/workflows/gcp-prod.yml
+++ b/.github/workflows/gcp-prod.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: 1.6.6
+          terraform_version: 1.13.3
 
       - name: Terraform Init (Validate)
         run: terraform init -backend=false

--- a/.github/workflows/gcp-test.yml
+++ b/.github/workflows/gcp-test.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: 1.6.6
+          terraform_version: 1.13.3
 
       - name: Terraform Init
         id: terraform_init


### PR DESCRIPTION
## Summary
- bump the Terraform CLI version used in the production and test deployment workflows to 1.13.3 so newer functions like regexreplace are available

## Testing
- not run (CI workflow version update only)


------
https://chatgpt.com/codex/tasks/task_e_68da9806f92c832e9c3d87f53c5a4a6e