### PR TITLE
Fix Terraform sanitization without regexreplace

### DIFF
--- a/infra/firebase-auth.tf
+++ b/infra/firebase-auth.tf
@@ -46,7 +46,7 @@ data "google_firebase_web_app_config" "frontend" {
 locals {
   identity_platform_authorized_domains = var.identity_platform_authorized_domains
   identity_platform_environment_sanitized = trim(
-    regexreplace(lower(var.environment), "[^a-z0-9-]+", "-"),
+    replace(lower(var.environment), "[^a-z0-9-]+", "-"),
     "-",
   )
   identity_platform_tenant_slug         = length(local.identity_platform_environment_sanitized) > 0 ? local.identity_platform_environment_sanitized : "env"
@@ -56,7 +56,7 @@ locals {
     0,
     min(length(local.identity_platform_tenant_display_full), 20),
   )
-  identity_platform_tenant_display_normalized = regexreplace(
+  identity_platform_tenant_display_normalized = replace(
     local.identity_platform_tenant_display_truncated,
     "-{2,}",
     "-",


### PR DESCRIPTION
## Summary
- replace regexreplace calls in the Firebase Auth locals with replace to maintain compatibility with older Terraform releases

## Testing
- ⚠️ terraform fmt firebase-auth.tf *(fails: terraform CLI is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68da9f90a140832eaf991132c652eb1b