### PR TITLE
Grant Terraform tenant management access

### DIFF
--- a/infra/firebase-auth-iam.tf
+++ b/infra/firebase-auth-iam.tf
@@ -14,6 +14,13 @@ resource "google_project_iam_member" "terraform_serviceusage_admin" {
   member  = "serviceAccount:terraform@${var.project_id}.iam.gserviceaccount.com"
 }
 
+resource "google_project_iam_member" "terraform_identityplatform_admin" {
+  count   = local.manage_project_level_resources ? 1 : 0
+  project = var.project_id
+  role    = "roles/identityplatform.admin" # manage tenants & other Identity Platform settings
+  member  = "serviceAccount:terraform@${var.project_id}.iam.gserviceaccount.com"
+}
+
 # Allow the Cloud Function runtime SA to read auth users
 resource "google_project_iam_member" "runtime_identityplatform_viewer" {
   project = var.project_id


### PR DESCRIPTION
## Summary
- grant the Terraform service account Identity Platform Admin to allow tenant creation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68daa0ea7094832eb90b3d5edeff7912