### PR TITLE
Gate default Firestore creation in prod workflow

### DIFF
--- a/.github/workflows/gcp-prod.yml
+++ b/.github/workflows/gcp-prod.yml
@@ -22,6 +22,7 @@ jobs:
       TF_VAR_project_level_environment: prod
       TF_VAR_google_oauth_client_id: ${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}
       TF_VAR_google_oauth_client_secret: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
+      TF_VAR_create_default_firestore_database: 'false'
 
     steps:
       - name: Checkout repo

--- a/infra/README.md
+++ b/infra/README.md
@@ -24,10 +24,12 @@ defined in `dendrite-firestore.tf`. The rules file lives in
 access control across environments. Supply `database_id` (defaults to
 `"(default)"`) to point rules, indexes, and Cloud Functions triggers at an
 alternate Firestore database when deploying additional environments inside the
-same GCP project. The generated `firebase_web_app_config` output now includes the
-selected `databaseId` and the per-environment Identity Platform tenant so that
-client and backend runtimes can connect to the correct datastore without manual
-configuration.
+same GCP project. If the default database already exists, disable
+`create_default_firestore_database` (defaults to `true`) so Terraform skips the
+singleton creation while continuing to manage rules and indexes. The generated
+`firebase_web_app_config` output now includes the selected `databaseId` and the
+per-environment Identity Platform tenant so that client and backend runtimes can
+connect to the correct datastore without manual configuration.
 
 Identity Platform supports multi-environment isolation via tenants. Terraform
 creates one tenant per `environment`, exposes it as the

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -234,7 +234,7 @@ resource "google_project_service" "eventarc" {
 }
 
 resource "google_firestore_database" "database" {
-  count       = var.database_id == "(default)" ? (local.manage_project_level_resources ? 1 : 0) : 1
+  count       = var.database_id == "(default)" ? (local.manage_project_level_resources && var.create_default_firestore_database ? 1 : 0) : 1
   project     = var.project_id
   name        = var.database_id
   location_id = var.region

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -51,6 +51,12 @@ variable "database_id" {
   default     = "(default)"
 }
 
+variable "create_default_firestore_database" {
+  description = "Whether Terraform should attempt to create the default Firestore database when managing project-level resources"
+  type        = bool
+  default     = true
+}
+
 variable "google_oauth_client_id" {
   description = "OAuth client ID for Google sign-in"
   type        = string


### PR DESCRIPTION
## Summary
- add a toggle to skip provisioning the default Firestore database when it already exists
- document the new Terraform variable for the database gate
- configure the gcp-prod workflow to disable default database creation

## Testing
- not run (workflow and Terraform configuration change)


------
https://chatgpt.com/codex/tasks/task_e_68dacbb70f44832e84e142a3ba51109c