### PR TITLE
Enable multi-tenant Identity Platform config

### DIFF
--- a/infra/firebase-auth.tf
+++ b/infra/firebase-auth.tf
@@ -85,6 +85,10 @@ resource "google_identity_platform_config" "auth" {
   project                    = var.project_id
   autodelete_anonymous_users = true
 
+  multi_tenant {
+    allow_tenants = true
+  }
+
   authorized_domains = local.identity_platform_authorized_domains
 }
 


### PR DESCRIPTION
## Summary
- enable multi-tenant support in the Identity Platform project configuration so tenants can be created

## Testing
- `terraform -chdir=infra plan` *(fails: terraform CLI not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dad423673c832eacee83925091805e