### PR TITLE
Ensure identity platform tenant waits for config

### DIFF
--- a/infra/firebase-auth.tf
+++ b/infra/firebase-auth.tf
@@ -131,6 +131,7 @@ resource "google_identity_platform_tenant" "environment" {
   depends_on = [
     google_project_service.identitytoolkit,
     google_firebase_project.core,
+    google_identity_platform_config.auth,
   ]
 }
 


### PR DESCRIPTION
## Summary
- add the identity platform config resource as a dependency for the tenant so multi-tenant support is ready before creation

## Testing
- terraform -chdir=infra plan *(fails: terraform not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dae0d445a8832e819c3bc5eab4b2ab