### PR TITLE
Add targeted tenant apply step to GCP workflows

### DIFF
--- a/.github/workflows/gcp-prod.yml
+++ b/.github/workflows/gcp-prod.yml
@@ -61,6 +61,13 @@ jobs:
 
       - name: Terraform Init
         run: terraform init -migrate-state
+
+      - name: Terraform Targeted Apply (Identity Platform Tenant)
+        run: >-
+          terraform apply -lock-timeout=5m -auto-approve
+          -target=google_identity_platform_tenant.environment
+          -target=google_identity_platform_tenant_default_supported_idp_config.google
+
       - name: Terraform Plan
         run: terraform plan -lock-timeout=5m -input=false -out=tfplan
 

--- a/.github/workflows/gcp-test.yml
+++ b/.github/workflows/gcp-test.yml
@@ -57,6 +57,12 @@ jobs:
         id: terraform_init
         run: terraform init -migrate-state -backend-config="prefix=terraform/test/${ENVIRONMENT}"
 
+      - name: Terraform Targeted Apply (Identity Platform Tenant)
+        run: >-
+          terraform apply -lock-timeout=5m -auto-approve
+          -target=google_identity_platform_tenant.environment
+          -target=google_identity_platform_tenant_default_supported_idp_config.google
+
       - name: Terraform Plan
         run: terraform plan -lock-timeout=5m -input=false -var="environment=${ENVIRONMENT}" -out=tfplan
 


### PR DESCRIPTION
## Summary
- add a targeted apply step in the prod workflow to create the Identity Platform tenant before the full plan/apply
- run the same targeted apply in the test workflow so ephemeral environments avoid provider bugs

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68dae419ec18832e853eca73aca91ec2