### PR TITLE
Adjust gcp test terraform init flags

### DIFF
--- a/.github/workflows/gcp-test.yml
+++ b/.github/workflows/gcp-test.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Terraform Init
         id: terraform_init
-        run: terraform init -migrate-state -backend-config="prefix=terraform/test/${ENVIRONMENT}"
+        run: terraform init -reconfigure -backend-config="prefix=terraform/test/${ENVIRONMENT}"
 
       - name: Terraform Targeted Apply (Identity Platform Tenant)
         run: >-


### PR DESCRIPTION
## Summary
- remove the deprecated migrate-state flag from the gcp test terraform init step
- reconfigure the backend with the environment-specific prefix during initialization

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dbbb703e58832ea7adcbe153311115