### PR TITLE
Set test Terraform runs to use isolated Firestore DB

### DIFF
--- a/.github/workflows/gcp-test.yml
+++ b/.github/workflows/gcp-test.yml
@@ -26,6 +26,7 @@ jobs:
           ENVIRONMENT="t-${SHORT_ID}"
           echo "ENVIRONMENT=$ENVIRONMENT" >> "$GITHUB_ENV"
           echo "TF_VAR_environment=$ENVIRONMENT" >> "$GITHUB_ENV"
+          echo "TF_VAR_database_id=$ENVIRONMENT" >> "$GITHUB_ENV"
           echo "environment=$ENVIRONMENT" >> "$GITHUB_OUTPUT"
 
       - name: Set up Node.js


### PR DESCRIPTION
## Summary
- export TF_VAR_database_id in the gcp-test workflow so ephemeral environments use their own Firestore database

## Testing
- Not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68df7ff47bb4832ea9f9266603611110