### PR TITLE
Refactor body parser helper for moderation workflow

### DIFF
--- a/src/cloud/assign-moderation-job/core.js
+++ b/src/cloud/assign-moderation-job/core.js
@@ -1,4 +1,5 @@
 export {
   createAssignModerationApp,
   isAllowedOrigin,
+  configureUrlencodedBodyParser,
 } from '../../core/cloud/assign-moderation-job/core.js';

--- a/src/cloud/assign-moderation-job/index.js
+++ b/src/cloud/assign-moderation-job/index.js
@@ -7,6 +7,7 @@ import { createVariantSnapshotFetcher } from './variant-selection.js';
 import {
   createAssignModerationApp,
   isAllowedOrigin,
+  configureUrlencodedBodyParser,
 } from './core.js';
 import { initializeFirebaseAppResources } from './gcf.js';
 
@@ -44,20 +45,11 @@ const allowed = [
   'https://www.dendritestories.co.nz',
 ];
 
-/**
- * Register body parsing middleware for moderation requests.
- * @param {import('express').Express} appInstance Express application instance.
- * @returns {void}
- */
-function configureUrlencodedBodyParser(appInstance) {
-  appInstance.use(express.urlencoded({ extended: false }));
-}
-
 const firebaseResources = createAssignModerationApp(
   initializeFirebaseAppResources,
   setupCors,
   allowed,
-  configureUrlencodedBodyParser
+  (appInstance) => configureUrlencodedBodyParser(appInstance, express)
 );
 
 const { db, auth, app } = firebaseResources;

--- a/src/core/cloud/assign-moderation-job/core.js
+++ b/src/core/cloud/assign-moderation-job/core.js
@@ -37,3 +37,14 @@ export function createAssignModerationApp(
 
   return { db, auth, app };
 }
+
+/**
+ * Register body parsing middleware for moderation requests.
+ * @param {{ use: (middleware: unknown) => void }} appInstance Express application instance.
+ * @param {{ urlencoded: (options: { extended: boolean }) => unknown }} expressModule Express module exposing urlencoded.
+ * @returns {void}
+ */
+export function configureUrlencodedBodyParser(appInstance, expressModule) {
+  const urlencodedMiddleware = expressModule.urlencoded({ extended: false });
+  appInstance.use(urlencodedMiddleware);
+}

--- a/test/cloud/assign-moderation-job/core.test.js
+++ b/test/cloud/assign-moderation-job/core.test.js
@@ -2,6 +2,7 @@ import { describe, expect, jest, test } from "@jest/globals";
 import {
   createAssignModerationApp,
   isAllowedOrigin,
+  configureUrlencodedBodyParser,
 } from "../../../src/core/cloud/assign-moderation-job/core.js";
 
 describe("isAllowedOrigin", () => {
@@ -79,5 +80,19 @@ describe("createAssignModerationApp", () => {
       allowedOrigins
     );
     expect(result).toStrictEqual(dependencies);
+  });
+});
+
+describe("configureUrlencodedBodyParser", () => {
+  test("registers the express urlencoded middleware", () => {
+    const middleware = Symbol("middleware");
+    const expressModule = { urlencoded: jest.fn(() => middleware) };
+    const use = jest.fn();
+    const appInstance = { use };
+
+    configureUrlencodedBodyParser(appInstance, expressModule);
+
+    expect(expressModule.urlencoded).toHaveBeenCalledWith({ extended: false });
+    expect(use).toHaveBeenCalledWith(middleware);
   });
 });


### PR DESCRIPTION
## Summary
- move configureUrlencodedBodyParser into the shared core utilities and inject express as a dependency
- update the moderation entry point to call the helper without importing express inside the core layer
- add unit coverage that verifies the middleware registration logic

## Testing
- npm test -- test/cloud/assign-moderation-job/core.test.js

------
https://chatgpt.com/codex/tasks/task_e_68df9fbe6f98832eab7b6a28271f7903