### PR TITLE
Move ID token helper into core module

### DIFF
--- a/src/cloud/assign-moderation-job/core.js
+++ b/src/cloud/assign-moderation-job/core.js
@@ -2,4 +2,5 @@ export {
   createAssignModerationApp,
   isAllowedOrigin,
   configureUrlencodedBodyParser,
+  getIdTokenFromRequest,
 } from '../../core/cloud/assign-moderation-job/core.js';

--- a/src/cloud/assign-moderation-job/index.js
+++ b/src/cloud/assign-moderation-job/index.js
@@ -8,6 +8,7 @@ import {
   createAssignModerationApp,
   isAllowedOrigin,
   configureUrlencodedBodyParser,
+  getIdTokenFromRequest,
 } from './core.js';
 import { initializeFirebaseAppResources } from './gcf.js';
 
@@ -53,16 +54,6 @@ const firebaseResources = createAssignModerationApp(
 );
 
 const { db, auth, app } = firebaseResources;
-
-/**
- * Extract the ID token from a request body.
- * @param {import('express').Request} req HTTP request object.
- * @returns {string|undefined} The ID token if present.
- */
-function getIdTokenFromRequest(req) {
-  const { id_token: idToken } = req?.body ?? {};
-  return idToken;
-}
 
 /**
  * Assign a random moderation job to the requesting user.

--- a/src/core/cloud/assign-moderation-job/core.js
+++ b/src/core/cloud/assign-moderation-job/core.js
@@ -13,6 +13,16 @@ export function isAllowedOrigin(origin, allowedOrigins) {
 }
 
 /**
+ * Extract the ID token from a request body.
+ * @param {import('express').Request} req HTTP request object.
+ * @returns {string | undefined} The ID token if present.
+ */
+export function getIdTokenFromRequest(req) {
+  const { id_token: idToken } = req?.body ?? {};
+  return idToken;
+}
+
+/**
  * Initialize Firebase resources, configure CORS, and expose dependencies.
  * @param {() => { db: import('firebase-admin/firestore').Firestore,
  *   auth: import('firebase-admin/auth').Auth, app: import('express').Express }} initializeFirebaseApp

--- a/test/cloud/assign-moderation-job/core.test.js
+++ b/test/cloud/assign-moderation-job/core.test.js
@@ -3,6 +3,7 @@ import {
   createAssignModerationApp,
   isAllowedOrigin,
   configureUrlencodedBodyParser,
+  getIdTokenFromRequest,
 } from "../../../src/core/cloud/assign-moderation-job/core.js";
 
 describe("isAllowedOrigin", () => {
@@ -94,5 +95,19 @@ describe("configureUrlencodedBodyParser", () => {
 
     expect(expressModule.urlencoded).toHaveBeenCalledWith({ extended: false });
     expect(use).toHaveBeenCalledWith(middleware);
+  });
+});
+
+describe("getIdTokenFromRequest", () => {
+  test("returns the id token when present on the request body", () => {
+    const req = { body: { id_token: "token-value" } };
+
+    expect(getIdTokenFromRequest(req)).toBe("token-value");
+  });
+
+  test("returns undefined when the request body is missing", () => {
+    const req = {};
+
+    expect(getIdTokenFromRequest(req)).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- expose `getIdTokenFromRequest` from the shared assign moderation core module
- update the cloud function entrypoint to import the shared helper
- cover the helper with unit tests in the core suite

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dfa58d6194832e9a6d74e0a3dbfd7d