### PR TITLE
Centralize Terraform cloud function service account locals

### DIFF
--- a/infra/firebase-auth-iam.tf
+++ b/infra/firebase-auth-iam.tf
@@ -25,7 +25,7 @@ resource "google_project_iam_member" "terraform_identityplatform_admin" {
 resource "google_project_iam_member" "runtime_identityplatform_viewer" {
   project = var.project_id
   role    = "roles/identityplatform.viewer" # just “view” permissions
-  member  = "serviceAccount:${google_service_account.cloud_function_runtime.email}"
+  member  = local.cloud_function_runtime_service_account_member
 
   # optional, but makes the dependency explicit
   depends_on = [

--- a/infra/functions-v2.tf
+++ b/infra/functions-v2.tf
@@ -29,7 +29,7 @@ resource "google_cloudfunctions2_function" "get_api_key_credit_v2" {
     available_memory      = "256M"
     timeout_seconds       = 10
     max_instance_count    = 20
-    service_account_email = google_service_account.cloud_function_runtime.email
+    service_account_email        = local.cloud_function_runtime_service_account_email
     environment_variables = local.cloud_function_environment
   }
 


### PR DESCRIPTION
## Summary
- add locals for the cloud function runtime service account email and member strings
- refactor IAM bindings and function resources to reference the shared locals instead of duplicating literals

## Testing
- ⚠️ `terraform fmt` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dfb7ec74e0832e8ca97c1e3ea7d406