### PR TITLE
refactor: move variant selector to shared core module

### DIFF
--- a/src/cloud/assign-moderation-job/core.js
+++ b/src/cloud/assign-moderation-job/core.js
@@ -3,4 +3,5 @@ export {
   isAllowedOrigin,
   configureUrlencodedBodyParser,
   getIdTokenFromRequest,
+  selectVariantDoc,
 } from '../../core/cloud/assign-moderation-job/core.js';

--- a/src/cloud/assign-moderation-job/index.js
+++ b/src/cloud/assign-moderation-job/index.js
@@ -9,6 +9,7 @@ import {
   isAllowedOrigin,
   configureUrlencodedBodyParser,
   getIdTokenFromRequest,
+  selectVariantDoc,
 } from './core.js';
 import { initializeFirebaseAppResources } from './gcf.js';
 
@@ -65,20 +66,6 @@ async function handleAssignModerationJob(req, res) {
   const { status, body } = await assignModerationWorkflow({ req });
 
   res.status(status).send(body ?? '');
-}
-
-/**
- * Select the first document from a snapshot when available.
- * @param {{ empty: boolean, docs?: unknown[] }} snapshot Query snapshot containing candidate documents.
- * @returns {{ variantDoc?: unknown, errorMessage?: string }} Selected document or an error message.
- */
-function selectVariantDoc(snapshot) {
-  const [variantDoc] = snapshot?.docs ?? [];
-  if (!variantDoc || snapshot?.empty) {
-    return { errorMessage: 'Variant fetch failed 🤷' };
-  }
-
-  return { variantDoc };
 }
 
 const runVariantQuery = ({ reputation, comparator, randomValue }) => {

--- a/src/core/cloud/assign-moderation-job/core.js
+++ b/src/core/cloud/assign-moderation-job/core.js
@@ -58,3 +58,17 @@ export function configureUrlencodedBodyParser(appInstance, expressModule) {
   const urlencodedMiddleware = expressModule.urlencoded({ extended: false });
   appInstance.use(urlencodedMiddleware);
 }
+
+/**
+ * Select the first document from a snapshot when available.
+ * @param {{ empty: boolean, docs?: unknown[] }} snapshot Query snapshot containing candidate documents.
+ * @returns {{ variantDoc?: unknown, errorMessage?: string }} Selected document or an error message.
+ */
+export function selectVariantDoc(snapshot) {
+  const [variantDoc] = snapshot?.docs ?? [];
+  if (!variantDoc || snapshot?.empty) {
+    return { errorMessage: 'Variant fetch failed 🤷' };
+  }
+
+  return { variantDoc };
+}


### PR DESCRIPTION
## Summary
- move the selectVariantDoc helper into the shared core module for assign moderation
- re-export the helper so the Cloud Function index reuses the shared implementation

## Testing
- npm test -- --runTestsByPath test/cloud-functions/assignModerationWorkflow.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dfb91aecf0832e9f19a96e6e3589af