### PR TITLE
Extract CORS origins into shared cloud config

### DIFF
--- a/src/cloud/assign-moderation-job/cors-config.js
+++ b/src/cloud/assign-moderation-job/cors-config.js
@@ -1,0 +1,4 @@
+import config, { allowedOrigins } from '../cors-config.js';
+
+export { allowedOrigins };
+export default config;

--- a/src/cloud/assign-moderation-job/index.js
+++ b/src/cloud/assign-moderation-job/index.js
@@ -2,7 +2,7 @@ import { FieldValue } from 'firebase-admin/firestore';
 import * as functions from 'firebase-functions';
 import express from 'express';
 import cors from 'cors';
-import corsConfig from '../cors-config.json' with { type: 'json' };
+import corsConfig from './cors-config.js';
 import { createAssignModerationWorkflow } from './workflow.js';
 import { createVariantSnapshotFetcher } from './variant-selection.js';
 import {

--- a/src/cloud/assign-moderation-job/index.js
+++ b/src/cloud/assign-moderation-job/index.js
@@ -2,6 +2,7 @@ import { FieldValue } from 'firebase-admin/firestore';
 import * as functions from 'firebase-functions';
 import express from 'express';
 import cors from 'cors';
+import corsConfig from '../cors-config.json' with { type: 'json' };
 import { createAssignModerationWorkflow } from './workflow.js';
 import { createVariantSnapshotFetcher } from './variant-selection.js';
 import {
@@ -41,16 +42,12 @@ function setupCors(appInstance, allowedOrigins) {
  * @param {string[]} allowedOrigins Whitelisted origins.
  * @returns {boolean} True when the origin should be allowed.
  */
-const allowed = [
-  'https://mattheard.net',
-  'https://dendritestories.co.nz',
-  'https://www.dendritestories.co.nz',
-];
+const { allowedOrigins } = corsConfig;
 
 const firebaseResources = createAssignModerationApp(
   initializeFirebaseAppResources,
   setupCors,
-  allowed,
+  allowedOrigins,
   (appInstance) => configureUrlencodedBodyParser(appInstance, express)
 );
 

--- a/src/cloud/copy-to-infra.js
+++ b/src/cloud/copy-to-infra.js
@@ -48,6 +48,13 @@ const fileCopies = {
   files: ['googleAuth.js', 'moderate.js'],
 };
 
+const corsConfigSource = join(srcCloudDir, 'cors-config.js');
+
+const corsConfigCopies = functionDirectories.map(name => ({
+  source: corsConfigSource,
+  target: join(infraFunctionsDir, name, 'cors-config.js'),
+}));
+
 const individualFileCopies = [
   {
     source: join(browserDir, 'admin.js'),
@@ -57,6 +64,7 @@ const individualFileCopies = [
     source: join(srcCoreCloudDir, 'assign-moderation-job', 'core.js'),
     target: join(infraFunctionsDir, 'assign-moderation-job', 'core.js'),
   },
+  ...corsConfigCopies,
 ];
 
 const io = createAsyncFsAdapters();

--- a/src/cloud/cors-config.js
+++ b/src/cloud/cors-config.js
@@ -1,0 +1,9 @@
+export const allowedOrigins = [
+  'https://mattheard.net',
+  'https://dendritestories.co.nz',
+  'https://www.dendritestories.co.nz',
+];
+
+const config = { allowedOrigins };
+
+export default config;

--- a/src/cloud/cors-config.json
+++ b/src/cloud/cors-config.json
@@ -1,0 +1,7 @@
+{
+  "allowedOrigins": [
+    "https://mattheard.net",
+    "https://dendritestories.co.nz",
+    "https://www.dendritestories.co.nz"
+  ]
+}

--- a/src/cloud/cors-config.json
+++ b/src/cloud/cors-config.json
@@ -1,7 +1,0 @@
-{
-  "allowedOrigins": [
-    "https://mattheard.net",
-    "https://dendritestories.co.nz",
-    "https://www.dendritestories.co.nz"
-  ]
-}

--- a/src/cloud/generate-stats/cors-config.js
+++ b/src/cloud/generate-stats/cors-config.js
@@ -1,0 +1,4 @@
+import config, { allowedOrigins } from '../cors-config.js';
+
+export { allowedOrigins };
+export default config;

--- a/src/cloud/generate-stats/index.js
+++ b/src/cloud/generate-stats/index.js
@@ -6,6 +6,7 @@ import { Storage } from '@google-cloud/storage';
 import * as functions from 'firebase-functions';
 import express from 'express';
 import cors from 'cors';
+import corsConfig from '../cors-config.json' with { type: 'json' };
 
 initializeApp();
 const db = getFirestore();
@@ -13,11 +14,7 @@ const auth = getAuth();
 const storage = new Storage();
 
 const ADMIN_UID = 'qcYSrXTaj1MZUoFsAloBwT86GNM2';
-const allowed = [
-  'https://mattheard.net',
-  'https://dendritestories.co.nz',
-  'https://www.dendritestories.co.nz',
-];
+const { allowedOrigins } = corsConfig;
 const PROJECT = process.env.GOOGLE_CLOUD_PROJECT || process.env.GCLOUD_PROJECT;
 const URL_MAP = process.env.URL_MAP || 'prod-dendrite-url-map';
 const CDN_HOST = process.env.CDN_HOST || 'www.dendritestories.co.nz';
@@ -27,7 +24,7 @@ const app = express();
 app.use(
   cors({
     origin: (origin, cb) => {
-      if (!origin || allowed.includes(origin)) {
+      if (!origin || allowedOrigins.includes(origin)) {
         cb(null, true);
       } else {
         cb(new Error('CORS'));

--- a/src/cloud/generate-stats/index.js
+++ b/src/cloud/generate-stats/index.js
@@ -6,7 +6,7 @@ import { Storage } from '@google-cloud/storage';
 import * as functions from 'firebase-functions';
 import express from 'express';
 import cors from 'cors';
-import corsConfig from '../cors-config.json' with { type: 'json' };
+import corsConfig from './cors-config.js';
 
 initializeApp();
 const db = getFirestore();

--- a/src/cloud/get-moderation-variant/cors-config.js
+++ b/src/cloud/get-moderation-variant/cors-config.js
@@ -1,0 +1,4 @@
+import config, { allowedOrigins } from '../cors-config.js';
+
+export { allowedOrigins };
+export default config;

--- a/src/cloud/get-moderation-variant/index.js
+++ b/src/cloud/get-moderation-variant/index.js
@@ -4,21 +4,18 @@ import { getFirestore } from 'firebase-admin/firestore';
 import * as functions from 'firebase-functions';
 import express from 'express';
 import cors from 'cors';
+import corsConfig from '../cors-config.json' with { type: 'json' };
 
 initializeApp();
 const db = getFirestore();
 const auth = getAuth();
 const app = express();
 
-const allowed = [
-  'https://mattheard.net',
-  'https://dendritestories.co.nz',
-  'https://www.dendritestories.co.nz', // static-site domain
-];
+const { allowedOrigins } = corsConfig; // includes static-site domain
 app.use(
   cors({
     origin: (origin, cb) => {
-      if (!origin || allowed.includes(origin)) {
+      if (!origin || allowedOrigins.includes(origin)) {
         cb(null, true);
       } else {
         cb(new Error('CORS'));

--- a/src/cloud/get-moderation-variant/index.js
+++ b/src/cloud/get-moderation-variant/index.js
@@ -4,7 +4,7 @@ import { getFirestore } from 'firebase-admin/firestore';
 import * as functions from 'firebase-functions';
 import express from 'express';
 import cors from 'cors';
-import corsConfig from '../cors-config.json' with { type: 'json' };
+import corsConfig from './cors-config.js';
 
 initializeApp();
 const db = getFirestore();

--- a/src/cloud/mark-variant-dirty/cors-config.js
+++ b/src/cloud/mark-variant-dirty/cors-config.js
@@ -1,0 +1,4 @@
+import config, { allowedOrigins } from '../cors-config.js';
+
+export { allowedOrigins };
+export default config;

--- a/src/cloud/mark-variant-dirty/index.js
+++ b/src/cloud/mark-variant-dirty/index.js
@@ -4,7 +4,7 @@ import { getAuth } from 'firebase-admin/auth';
 import * as functions from 'firebase-functions';
 import express from 'express';
 import cors from 'cors';
-import corsConfig from '../cors-config.json' with { type: 'json' };
+import corsConfig from './cors-config.js';
 import { findPageRef, findPagesSnap, refFromSnap } from './findPageRef.js';
 
 initializeApp();

--- a/src/cloud/mark-variant-dirty/index.js
+++ b/src/cloud/mark-variant-dirty/index.js
@@ -4,6 +4,7 @@ import { getAuth } from 'firebase-admin/auth';
 import * as functions from 'firebase-functions';
 import express from 'express';
 import cors from 'cors';
+import corsConfig from '../cors-config.json' with { type: 'json' };
 import { findPageRef, findPagesSnap, refFromSnap } from './findPageRef.js';
 
 initializeApp();
@@ -12,16 +13,12 @@ const auth = getAuth();
 const app = express();
 
 const ADMIN_UID = 'qcYSrXTaj1MZUoFsAloBwT86GNM2';
-const allowed = [
-  'https://mattheard.net',
-  'https://dendritestories.co.nz',
-  'https://www.dendritestories.co.nz',
-];
+const { allowedOrigins } = corsConfig;
 
 app.use(
   cors({
     origin: (origin, cb) => {
-      if (!origin || allowed.includes(origin)) {
+      if (!origin || allowedOrigins.includes(origin)) {
         cb(null, true);
       } else {
         cb(new Error('CORS'));

--- a/src/cloud/report-for-moderation/cors-config.js
+++ b/src/cloud/report-for-moderation/cors-config.js
@@ -1,0 +1,4 @@
+import config, { allowedOrigins } from '../cors-config.js';
+
+export { allowedOrigins };
+export default config;

--- a/src/cloud/report-for-moderation/index.js
+++ b/src/cloud/report-for-moderation/index.js
@@ -3,7 +3,7 @@ import { getFirestore, FieldValue } from 'firebase-admin/firestore';
 import * as functions from 'firebase-functions';
 import express from 'express';
 import cors from 'cors';
-import corsConfig from '../cors-config.json' with { type: 'json' };
+import corsConfig from './cors-config.js';
 
 initializeApp();
 const db = getFirestore();

--- a/src/cloud/report-for-moderation/index.js
+++ b/src/cloud/report-for-moderation/index.js
@@ -3,20 +3,17 @@ import { getFirestore, FieldValue } from 'firebase-admin/firestore';
 import * as functions from 'firebase-functions';
 import express from 'express';
 import cors from 'cors';
+import corsConfig from '../cors-config.json' with { type: 'json' };
 
 initializeApp();
 const db = getFirestore();
 const app = express();
 
-const allowed = [
-  'https://mattheard.net',
-  'https://dendritestories.co.nz',
-  'https://www.dendritestories.co.nz',
-];
+const { allowedOrigins } = corsConfig;
 app.use(
   cors({
     origin: (origin, cb) => {
-      if (!origin || allowed.includes(origin)) {
+      if (!origin || allowedOrigins.includes(origin)) {
         cb(null, true);
       } else {
         cb(new Error('CORS'));

--- a/src/cloud/submit-moderation-rating/cors-config.js
+++ b/src/cloud/submit-moderation-rating/cors-config.js
@@ -1,0 +1,4 @@
+import config, { allowedOrigins } from '../cors-config.js';
+
+export { allowedOrigins };
+export default config;

--- a/src/cloud/submit-moderation-rating/index.js
+++ b/src/cloud/submit-moderation-rating/index.js
@@ -4,6 +4,7 @@ import { getFirestore, FieldValue } from 'firebase-admin/firestore';
 import * as functions from 'firebase-functions';
 import express from 'express';
 import cors from 'cors';
+import corsConfig from '../cors-config.json' with { type: 'json' };
 import { randomUUID } from 'crypto';
 
 initializeApp();
@@ -11,15 +12,11 @@ const db = getFirestore();
 const auth = getAuth();
 const app = express();
 
-const allowed = [
-  'https://mattheard.net',
-  'https://dendritestories.co.nz',
-  'https://www.dendritestories.co.nz',
-];
+const { allowedOrigins } = corsConfig;
 app.use(
   cors({
     origin: (origin, cb) => {
-      if (!origin || allowed.includes(origin)) {
+      if (!origin || allowedOrigins.includes(origin)) {
         cb(null, true);
       } else {
         cb(new Error('CORS'));

--- a/src/cloud/submit-moderation-rating/index.js
+++ b/src/cloud/submit-moderation-rating/index.js
@@ -4,7 +4,7 @@ import { getFirestore, FieldValue } from 'firebase-admin/firestore';
 import * as functions from 'firebase-functions';
 import express from 'express';
 import cors from 'cors';
-import corsConfig from '../cors-config.json' with { type: 'json' };
+import corsConfig from './cors-config.js';
 import { randomUUID } from 'crypto';
 
 initializeApp();

--- a/src/cloud/submit-new-page/cors-config.js
+++ b/src/cloud/submit-new-page/cors-config.js
@@ -1,0 +1,4 @@
+import config, { allowedOrigins } from '../cors-config.js';
+
+export { allowedOrigins };
+export default config;

--- a/src/cloud/submit-new-page/index.js
+++ b/src/cloud/submit-new-page/index.js
@@ -5,7 +5,7 @@ import { getAuth } from 'firebase-admin/auth';
 import crypto from 'crypto';
 import express from 'express';
 import cors from 'cors';
-import corsConfig from '../cors-config.json' with { type: 'json' };
+import corsConfig from './cors-config.js';
 import {
   parseIncomingOption,
   findExistingOption,

--- a/src/cloud/submit-new-page/index.js
+++ b/src/cloud/submit-new-page/index.js
@@ -5,6 +5,7 @@ import { getAuth } from 'firebase-admin/auth';
 import crypto from 'crypto';
 import express from 'express';
 import cors from 'cors';
+import corsConfig from '../cors-config.json' with { type: 'json' };
 import {
   parseIncomingOption,
   findExistingOption,
@@ -16,15 +17,11 @@ const db = getFirestore();
 const auth = getAuth();
 const app = express();
 
-const allowed = [
-  'https://mattheard.net',
-  'https://dendritestories.co.nz',
-  'https://www.dendritestories.co.nz', // static-site domain
-];
+const { allowedOrigins } = corsConfig; // includes static-site domain
 app.use(
   cors({
     origin: (origin, cb) => {
-      if (!origin || allowed.includes(origin)) {
+      if (!origin || allowedOrigins.includes(origin)) {
         cb(null, true);
       } else {
         cb(new Error('CORS'));

--- a/src/cloud/submit-new-story/cors-config.js
+++ b/src/cloud/submit-new-story/cors-config.js
@@ -1,0 +1,4 @@
+import config, { allowedOrigins } from '../cors-config.js';
+
+export { allowedOrigins };
+export default config;

--- a/src/cloud/submit-new-story/index.js
+++ b/src/cloud/submit-new-story/index.js
@@ -5,7 +5,7 @@ import { getAuth } from 'firebase-admin/auth';
 import crypto from 'crypto';
 import express from 'express';
 import cors from 'cors';
-import corsConfig from '../cors-config.json' with { type: 'json' };
+import corsConfig from './cors-config.js';
 
 initializeApp();
 const db = getFirestore();

--- a/src/cloud/submit-new-story/index.js
+++ b/src/cloud/submit-new-story/index.js
@@ -5,21 +5,18 @@ import { getAuth } from 'firebase-admin/auth';
 import crypto from 'crypto';
 import express from 'express';
 import cors from 'cors';
+import corsConfig from '../cors-config.json' with { type: 'json' };
 
 initializeApp();
 const db = getFirestore();
 const auth = getAuth();
 const app = express();
 
-const allowed = [
-  'https://mattheard.net',
-  'https://dendritestories.co.nz',
-  'https://www.dendritestories.co.nz', // new: static-site domain
-];
+const { allowedOrigins } = corsConfig; // includes static-site domain
 app.use(
   cors({
     origin: (origin, cb) => {
-      if (!origin || allowed.includes(origin)) {
+      if (!origin || allowedOrigins.includes(origin)) {
         cb(null, true);
       } else {
         cb(new Error('CORS'));


### PR DESCRIPTION
## Summary
- add a shared cloud CORS configuration file that lists the approved frontend origins
- update each Cloud Function to import the shared config when registering its cors middleware

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dfbb5b32d4832eb6ffac41e1ff6eeb