### PR TITLE
Fix Terraform destroy resource filter

### DIFF
--- a/.github/workflows/gcp-test.yml
+++ b/.github/workflows/gcp-test.yml
@@ -85,9 +85,7 @@ jobs:
           set --
           while IFS= read -r address; do
             case "$address" in
-              google_storage_bucket.dendrite_static|
-              google_storage_bucket_object.dendrite_*|
-              google_storage_bucket_iam_member.dendrite_*)
+              google_storage_bucket.dendrite_static|google_storage_bucket_object.dendrite_*|google_storage_bucket_iam_member.dendrite_*)
                 echo "Skipping static site resource $address"
                 continue
                 ;;


### PR DESCRIPTION
## Summary
- combine the Terraform destroy case pattern onto a single line so bash parses it correctly during the test workflow

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e000033774832ebe58280aaaf485dc