### PR TITLE
Ensure test workflow destroys static bucket resources

### DIFF
--- a/.github/workflows/gcp-test.yml
+++ b/.github/workflows/gcp-test.yml
@@ -84,13 +84,6 @@ jobs:
           # Build a list of destroy targets without relying on bash arrays.
           set --
           while IFS= read -r address; do
-            case "$address" in
-              google_storage_bucket.dendrite_static|google_storage_bucket_object.dendrite_*|google_storage_bucket_iam_member.dendrite_*)
-                echo "Skipping static site resource $address"
-                continue
-                ;;
-            esac
-
             set -- "$@" "-target=$address"
           done < /tmp/state.txt
 


### PR DESCRIPTION
## Summary
- update the gcp-test workflow destroy script to include all Terraform resources in the targeted destroy
- remove the exception that previously skipped static bucket assets so temporary environments are fully cleaned up

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e01ad559c8832e8c76ca17aeeda34f