### PR TITLE
Limit dendrite static bucket destroy guard to prod

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -116,7 +116,7 @@ resource "google_storage_bucket" "dendrite_static" {
   }
 
   lifecycle {
-    prevent_destroy = true # prod safety belt
+    prevent_destroy = var.environment == "prod"
   }
 }
 


### PR DESCRIPTION
## Summary
- limit the dendrite static bucket lifecycle destroy guard to production deployments only

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e0e663bec0832e91244e5fe84ebd76