### PR TITLE
Run gcp-test workflow on main pushes

### DIFF
--- a/.github/workflows/gcp-test.yml
+++ b/.github/workflows/gcp-test.yml
@@ -1,6 +1,9 @@
 name: gcp-test
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- configure the gcp-test workflow to run on every push to the main branch while keeping the manual trigger

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e1015c4c7c832e8ec9ccd39b23bcf5