### PR TITLE
Update gcp-prod workflow trigger

### DIFF
--- a/.github/workflows/gcp-prod.yml
+++ b/.github/workflows/gcp-prod.yml
@@ -2,11 +2,8 @@ name: gcp-prod
 
 on:
   push:
-    paths:
-      - 'infra/**'
-      - 'src/cloud/assign-moderation-job/**'
-    branches:
-      - main
+    tags:
+      - gcp-test-*
 
   workflow_dispatch:
 jobs:


### PR DESCRIPTION
## Summary
- update the gcp-prod workflow to run when gcp-test tags are pushed instead of commits to main

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68e102742800832e97ef4f42feb7231f