### PR TITLE
Refactor Terraform project service enables

### DIFF
--- a/infra/functions-v2.tf
+++ b/infra/functions-v2.tf
@@ -33,16 +33,17 @@ resource "google_cloudfunctions2_function" "get_api_key_credit_v2" {
     environment_variables = local.cloud_function_environment
   }
 
-  depends_on = [
-    google_project_service.cloudfunctions,
-    google_project_service.cloudbuild,
-    google_project_iam_member.cloudfunctions_access,
-    google_service_account_iam_member.terraform_can_impersonate_runtime,
-    google_service_account_iam_member.terraform_can_impersonate_default_compute,
-    google_project_service.run,
-    google_project_service.artifactregistry,
-    google_project_service.eventarc,
-  ]
+  depends_on = concat(
+    [
+      for key in local.cloud_function_service_keys : google_project_service.project_level[key]
+      if contains(keys(google_project_service.project_level), key)
+    ],
+    [
+      google_project_iam_member.cloudfunctions_access,
+      google_service_account_iam_member.terraform_can_impersonate_runtime,
+      google_service_account_iam_member.terraform_can_impersonate_default_compute,
+    ],
+  )
 }
 
 resource "google_cloud_run_service_iam_member" "get_api_key_credit_v2_public" {

--- a/infra/moved.tf
+++ b/infra/moved.tf
@@ -13,7 +13,7 @@ moved {
 
 moved {
   from = google_project_service.apis["cloudscheduler.googleapis.com"]
-  to   = google_project_service.cloudscheduler[0]
+  to   = google_project_service.project_level["cloudscheduler"]
 }
 
 moved {
@@ -23,7 +23,7 @@ moved {
 
 moved {
   from = google_project_service.apis["eventarc.googleapis.com"]
-  to   = google_project_service.eventarc[0]
+  to   = google_project_service.project_level["eventarc"]
 }
 
 moved {
@@ -33,12 +33,12 @@ moved {
 
 moved {
   from = google_project_service.apis["cloudfunctions.googleapis.com"]
-  to   = google_project_service.cloudfunctions[0]
+  to   = google_project_service.project_level["cloudfunctions"]
 }
 
 moved {
   from = google_project_service.apis["artifactregistry.googleapis.com"]
-  to   = google_project_service.artifactregistry[0]
+  to   = google_project_service.project_level["artifactregistry"]
 }
 
 moved {
@@ -48,7 +48,7 @@ moved {
 
 moved {
   from = google_project_service.apis["run.googleapis.com"]
-  to   = google_project_service.run[0]
+  to   = google_project_service.project_level["run"]
 }
 
 moved {
@@ -58,7 +58,7 @@ moved {
 
 moved {
   from = google_project_service.apis["cloudbuild.googleapis.com"]
-  to   = google_project_service.cloudbuild[0]
+  to   = google_project_service.project_level["cloudbuild"]
 }
 
 moved {


### PR DESCRIPTION
## Summary
- centralize repeated Google Cloud service enablement into a reusable map and for_each configuration
- update Cloud Function dependencies and state move mappings to use the shared project-level service references

## Testing
- terraform fmt infra *(fails: terraform not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e116d7387c832e9c13ae347a8bace0