### PR TITLE
Fix Terraform depends_on to use static lists

### DIFF
--- a/infra/functions-v2.tf
+++ b/infra/functions-v2.tf
@@ -33,17 +33,12 @@ resource "google_cloudfunctions2_function" "get_api_key_credit_v2" {
     environment_variables = local.cloud_function_environment
   }
 
-  depends_on = concat(
-    [
-      for key in local.cloud_function_service_keys : google_project_service.project_level[key]
-      if contains(keys(google_project_service.project_level), key)
-    ],
-    [
-      google_project_iam_member.cloudfunctions_access,
-      google_service_account_iam_member.terraform_can_impersonate_runtime,
-      google_service_account_iam_member.terraform_can_impersonate_default_compute,
-    ],
-  )
+  depends_on = [
+    google_project_service.project_level,
+    google_project_iam_member.cloudfunctions_access,
+    google_service_account_iam_member.terraform_can_impersonate_runtime,
+    google_service_account_iam_member.terraform_can_impersonate_default_compute,
+  ]
 }
 
 resource "google_cloud_run_service_iam_member" "get_api_key_credit_v2_public" {

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -393,17 +393,12 @@ resource "google_cloudfunctions_function" "get_api_key_credit" {
   environment_variables = local.cloud_function_environment
 
 
-  depends_on = concat(
-    [
-      for key in ["cloudfunctions", "cloudbuild"] : google_project_service.project_level[key]
-      if contains(keys(google_project_service.project_level), key)
-    ],
-    [
-      google_project_iam_member.cloudfunctions_access,
-      google_service_account_iam_member.terraform_can_impersonate_runtime,
-      google_service_account_iam_member.terraform_can_impersonate_default_compute,
-    ],
-  )
+  depends_on = [
+    google_project_service.project_level,
+    google_project_iam_member.cloudfunctions_access,
+    google_service_account_iam_member.terraform_can_impersonate_runtime,
+    google_service_account_iam_member.terraform_can_impersonate_default_compute,
+  ]
 }
 
 resource "google_cloudfunctions_function_iam_member" "invoker" {
@@ -456,17 +451,12 @@ resource "google_cloudfunctions_function" "submit_new_story" {
   environment_variables = local.cloud_function_environment
 
 
-  depends_on = concat(
-    [
-      for key in ["cloudfunctions", "cloudbuild"] : google_project_service.project_level[key]
-      if contains(keys(google_project_service.project_level), key)
-    ],
-    [
-      google_project_iam_member.cloudfunctions_access,
-      google_service_account_iam_member.terraform_can_impersonate_runtime,
-      google_service_account_iam_member.terraform_can_impersonate_default_compute,
-    ],
-  )
+  depends_on = [
+    google_project_service.project_level,
+    google_project_iam_member.cloudfunctions_access,
+    google_service_account_iam_member.terraform_can_impersonate_runtime,
+    google_service_account_iam_member.terraform_can_impersonate_default_compute,
+  ]
 }
 
 resource "google_cloudfunctions_function" "submit_new_page" {
@@ -483,17 +473,12 @@ resource "google_cloudfunctions_function" "submit_new_page" {
   environment_variables = local.cloud_function_environment
 
 
-  depends_on = concat(
-    [
-      for key in ["cloudfunctions", "cloudbuild"] : google_project_service.project_level[key]
-      if contains(keys(google_project_service.project_level), key)
-    ],
-    [
-      google_project_iam_member.cloudfunctions_access,
-      google_service_account_iam_member.terraform_can_impersonate_runtime,
-      google_service_account_iam_member.terraform_can_impersonate_default_compute,
-    ],
-  )
+  depends_on = [
+    google_project_service.project_level,
+    google_project_iam_member.cloudfunctions_access,
+    google_service_account_iam_member.terraform_can_impersonate_runtime,
+    google_service_account_iam_member.terraform_can_impersonate_default_compute,
+  ]
 }
 
 resource "google_cloudfunctions_function_iam_member" "submit_new_story_invoker" {
@@ -545,17 +530,12 @@ resource "google_cloudfunctions_function" "assign_moderation_job" {
 
   environment_variables = local.cloud_function_environment
 
-  depends_on = concat(
-    [
-      for key in ["cloudfunctions", "cloudbuild"] : google_project_service.project_level[key]
-      if contains(keys(google_project_service.project_level), key)
-    ],
-    [
-      google_project_iam_member.cloudfunctions_access,
-      google_service_account_iam_member.terraform_can_impersonate_runtime,
-      google_service_account_iam_member.terraform_can_impersonate_default_compute,
-    ],
-  )
+  depends_on = [
+    google_project_service.project_level,
+    google_project_iam_member.cloudfunctions_access,
+    google_service_account_iam_member.terraform_can_impersonate_runtime,
+    google_service_account_iam_member.terraform_can_impersonate_default_compute,
+  ]
 }
 
 resource "google_cloudfunctions_function_iam_member" "assign_moderation_job_invoker" {
@@ -595,17 +575,12 @@ resource "google_cloudfunctions_function" "get_moderation_variant" {
 
   environment_variables = local.cloud_function_environment
 
-  depends_on = concat(
-    [
-      for key in ["cloudfunctions", "cloudbuild"] : google_project_service.project_level[key]
-      if contains(keys(google_project_service.project_level), key)
-    ],
-    [
-      google_project_iam_member.cloudfunctions_access,
-      google_service_account_iam_member.terraform_can_impersonate_runtime,
-      google_service_account_iam_member.terraform_can_impersonate_default_compute,
-    ],
-  )
+  depends_on = [
+    google_project_service.project_level,
+    google_project_iam_member.cloudfunctions_access,
+    google_service_account_iam_member.terraform_can_impersonate_runtime,
+    google_service_account_iam_member.terraform_can_impersonate_default_compute,
+  ]
 }
 
 resource "google_cloudfunctions_function_iam_member" "get_moderation_variant_invoker" {
@@ -645,17 +620,12 @@ resource "google_cloudfunctions_function" "submit_moderation_rating" {
 
   environment_variables = local.cloud_function_environment
 
-  depends_on = concat(
-    [
-      for key in ["cloudfunctions", "cloudbuild"] : google_project_service.project_level[key]
-      if contains(keys(google_project_service.project_level), key)
-    ],
-    [
-      google_project_iam_member.cloudfunctions_access,
-      google_service_account_iam_member.terraform_can_impersonate_runtime,
-      google_service_account_iam_member.terraform_can_impersonate_default_compute,
-    ],
-  )
+  depends_on = [
+    google_project_service.project_level,
+    google_project_iam_member.cloudfunctions_access,
+    google_service_account_iam_member.terraform_can_impersonate_runtime,
+    google_service_account_iam_member.terraform_can_impersonate_default_compute,
+  ]
 }
 
 resource "google_cloudfunctions_function_iam_member" "submit_moderation_rating_invoker" {
@@ -696,17 +666,12 @@ resource "google_cloudfunctions_function" "report_for_moderation" {
 
   environment_variables = local.cloud_function_environment
 
-  depends_on = concat(
-    [
-      for key in ["cloudfunctions", "cloudbuild"] : google_project_service.project_level[key]
-      if contains(keys(google_project_service.project_level), key)
-    ],
-    [
-      google_project_iam_member.cloudfunctions_access,
-      google_service_account_iam_member.terraform_can_impersonate_runtime,
-      google_service_account_iam_member.terraform_can_impersonate_default_compute,
-    ],
-  )
+  depends_on = [
+    google_project_service.project_level,
+    google_project_iam_member.cloudfunctions_access,
+    google_service_account_iam_member.terraform_can_impersonate_runtime,
+    google_service_account_iam_member.terraform_can_impersonate_default_compute,
+  ]
 }
 
 resource "google_cloudfunctions_function_iam_member" "report_for_moderation_invoker" {
@@ -753,16 +718,11 @@ resource "google_cloudfunctions_function" "process_new_story" {
     resource   = "${local.firestore_documents_path}/storyFormSubmissions/{subId}"
   }
 
-  depends_on = concat(
-    [
-      for key in ["cloudfunctions", "cloudbuild"] : google_project_service.project_level[key]
-      if contains(keys(google_project_service.project_level), key)
-    ],
-    [
-      google_project_iam_member.cloudfunctions_access,
-      google_service_account_iam_member.terraform_can_impersonate_runtime,
-    ],
-  )
+  depends_on = [
+    google_project_service.project_level,
+    google_project_iam_member.cloudfunctions_access,
+    google_service_account_iam_member.terraform_can_impersonate_runtime,
+  ]
 }
 
 data "archive_file" "prod_update_variant_visibility_src" {
@@ -795,16 +755,11 @@ resource "google_cloudfunctions_function" "prod_update_variant_visibility" {
     resource   = "${local.firestore_documents_path}/moderationRatings/{ratingId}"
   }
 
-  depends_on = concat(
-    [
-      for key in ["cloudfunctions", "cloudbuild"] : google_project_service.project_level[key]
-      if contains(keys(google_project_service.project_level), key)
-    ],
-    [
-      google_project_iam_member.cloudfunctions_access,
-      google_service_account_iam_member.terraform_can_impersonate_runtime,
-    ],
-  )
+  depends_on = [
+    google_project_service.project_level,
+    google_project_iam_member.cloudfunctions_access,
+    google_service_account_iam_member.terraform_can_impersonate_runtime,
+  ]
 }
 
 data "archive_file" "process_page_src" {
@@ -838,16 +793,11 @@ resource "google_cloudfunctions_function" "process_new_page" {
     resource   = "${local.firestore_documents_path}/pageFormSubmissions/{subId}"
   }
 
-  depends_on = concat(
-    [
-      for key in ["cloudfunctions", "cloudbuild"] : google_project_service.project_level[key]
-      if contains(keys(google_project_service.project_level), key)
-    ],
-    [
-      google_project_iam_member.cloudfunctions_access,
-      google_service_account_iam_member.terraform_can_impersonate_runtime,
-    ],
-  )
+  depends_on = [
+    google_project_service.project_level,
+    google_project_iam_member.cloudfunctions_access,
+    google_service_account_iam_member.terraform_can_impersonate_runtime,
+  ]
 }
 
 data "archive_file" "render_variant_src" {
@@ -881,16 +831,11 @@ resource "google_cloudfunctions_function" "render_variant" {
     resource   = "${local.firestore_documents_path}/stories/{storyId}/pages/{pageId}/variants/{variantId}"
   }
 
-  depends_on = concat(
-    [
-      for key in ["cloudfunctions", "cloudbuild"] : google_project_service.project_level[key]
-      if contains(keys(google_project_service.project_level), key)
-    ],
-    [
-      google_project_iam_member.cloudfunctions_access,
-      google_service_account_iam_member.terraform_can_impersonate_runtime,
-    ],
-  )
+  depends_on = [
+    google_project_service.project_level,
+    google_project_iam_member.cloudfunctions_access,
+    google_service_account_iam_member.terraform_can_impersonate_runtime,
+  ]
 }
 
 data "archive_file" "hide_variant_html_src" {
@@ -923,16 +868,11 @@ resource "google_cloudfunctions_function" "hide_variant_html" {
     resource   = "${local.firestore_documents_path}/stories/{storyId}/pages/{pageId}/variants/{variantId}"
   }
 
-  depends_on = concat(
-    [
-      for key in ["cloudfunctions", "cloudbuild"] : google_project_service.project_level[key]
-      if contains(keys(google_project_service.project_level), key)
-    ],
-    [
-      google_project_iam_member.cloudfunctions_access,
-      google_service_account_iam_member.terraform_can_impersonate_runtime,
-    ],
-  )
+  depends_on = [
+    google_project_service.project_level,
+    google_project_iam_member.cloudfunctions_access,
+    google_service_account_iam_member.terraform_can_impersonate_runtime,
+  ]
 }
 
 data "archive_file" "mark_variant_dirty_src" {
@@ -960,17 +900,12 @@ resource "google_cloudfunctions_function" "mark_variant_dirty" {
 
   environment_variables = local.cloud_function_environment
 
-  depends_on = concat(
-    [
-      for key in ["cloudfunctions", "cloudbuild"] : google_project_service.project_level[key]
-      if contains(keys(google_project_service.project_level), key)
-    ],
-    [
-      google_project_iam_member.cloudfunctions_access,
-      google_service_account_iam_member.terraform_can_impersonate_runtime,
-      google_service_account_iam_member.terraform_can_impersonate_default_compute,
-    ],
-  )
+  depends_on = [
+    google_project_service.project_level,
+    google_project_iam_member.cloudfunctions_access,
+    google_service_account_iam_member.terraform_can_impersonate_runtime,
+    google_service_account_iam_member.terraform_can_impersonate_default_compute,
+  ]
 }
 
 resource "google_cloudfunctions_function_iam_member" "mark_variant_dirty_invoker" {
@@ -1010,17 +945,12 @@ resource "google_cloudfunctions_function" "generate_stats" {
 
   environment_variables = local.cloud_function_environment
 
-  depends_on = concat(
-    [
-      for key in ["cloudfunctions", "cloudbuild"] : google_project_service.project_level[key]
-      if contains(keys(google_project_service.project_level), key)
-    ],
-    [
-      google_project_iam_member.cloudfunctions_access,
-      google_service_account_iam_member.terraform_can_impersonate_runtime,
-      google_service_account_iam_member.terraform_can_impersonate_default_compute,
-    ],
-  )
+  depends_on = [
+    google_project_service.project_level,
+    google_project_iam_member.cloudfunctions_access,
+    google_service_account_iam_member.terraform_can_impersonate_runtime,
+    google_service_account_iam_member.terraform_can_impersonate_default_compute,
+  ]
 }
 
 resource "google_cloudfunctions_function_iam_member" "generate_stats_invoker" {
@@ -1046,16 +976,11 @@ resource "google_cloud_scheduler_job" "generate_stats_daily" {
       "X-Appengine-Cron" = "true"
     }
   }
-  depends_on = concat(
-    [
-      for key in ["cloudscheduler"] : google_project_service.project_level[key]
-      if contains(keys(google_project_service.project_level), key)
-    ],
-    [
-      google_cloudfunctions_function.generate_stats,
-      google_project_iam_member.terraform_cloudscheduler_admin,
-    ],
-  )
+  depends_on = [
+    google_project_service.project_level,
+    google_cloudfunctions_function.generate_stats,
+    google_project_iam_member.terraform_cloudscheduler_admin,
+  ]
 }
 
 data "archive_file" "render_contents_src" {
@@ -1089,16 +1014,11 @@ resource "google_cloudfunctions_function" "render_contents" {
     resource   = "${local.firestore_documents_path}/stories/{storyId}"
   }
 
-  depends_on = concat(
-    [
-      for key in ["cloudfunctions", "cloudbuild"] : google_project_service.project_level[key]
-      if contains(keys(google_project_service.project_level), key)
-    ],
-    [
-      google_project_iam_member.cloudfunctions_access,
-      google_service_account_iam_member.terraform_can_impersonate_runtime,
-    ],
-  )
+  depends_on = [
+    google_project_service.project_level,
+    google_project_iam_member.cloudfunctions_access,
+    google_service_account_iam_member.terraform_can_impersonate_runtime,
+  ]
 }
 
 resource "google_cloudfunctions_function" "trigger_render_contents" {
@@ -1114,17 +1034,12 @@ resource "google_cloudfunctions_function" "trigger_render_contents" {
 
   environment_variables = local.cloud_function_environment
 
-  depends_on = concat(
-    [
-      for key in ["cloudfunctions", "cloudbuild"] : google_project_service.project_level[key]
-      if contains(keys(google_project_service.project_level), key)
-    ],
-    [
-      google_project_iam_member.cloudfunctions_access,
-      google_service_account_iam_member.terraform_can_impersonate_runtime,
-      google_service_account_iam_member.terraform_can_impersonate_default_compute,
-    ],
-  )
+  depends_on = [
+    google_project_service.project_level,
+    google_project_iam_member.cloudfunctions_access,
+    google_service_account_iam_member.terraform_can_impersonate_runtime,
+    google_service_account_iam_member.terraform_can_impersonate_default_compute,
+  ]
 }
 
 resource "google_cloudfunctions_function_iam_member" "trigger_render_contents_invoker" {


### PR DESCRIPTION
## Summary
- replace concat-based depends_on expressions with static resource lists for Cloud Functions and the scheduler job
- update the Cloud Functions v2 module to use the same static dependencies

## Testing
- not run (terraform configuration change)


------
https://chatgpt.com/codex/tasks/task_e_68e12e410e78832ea9eb77ebcf539e3b