### PR TITLE
Remove targeted Identity Platform tenant apply

### DIFF
--- a/.github/workflows/gcp-prod.yml
+++ b/.github/workflows/gcp-prod.yml
@@ -59,12 +59,6 @@ jobs:
       - name: Terraform Init
         run: terraform init -migrate-state
 
-      - name: Terraform Targeted Apply (Identity Platform Tenant)
-        run: >-
-          terraform apply -lock-timeout=5m -auto-approve
-          -target=google_identity_platform_tenant.environment
-          -target=google_identity_platform_tenant_default_supported_idp_config.google
-
       - name: Terraform Plan
         run: terraform plan -lock-timeout=5m -input=false -out=tfplan
 

--- a/.github/workflows/gcp-test.yml
+++ b/.github/workflows/gcp-test.yml
@@ -65,13 +65,6 @@ jobs:
         id: terraform_init
         run: terraform init -reconfigure -backend-config="prefix=terraform/test/${ENVIRONMENT}"
 
-      - name: Terraform Targeted Apply (Identity Platform Tenant)
-        run: >-
-          terraform apply -lock-timeout=5m -auto-approve
-          -target=google_identity_platform_tenant.environment
-          -target=google_identity_platform_tenant_default_supported_idp_config.google
-          -var="environment=${ENVIRONMENT}"
-
       - name: Terraform Plan
         run: terraform plan -lock-timeout=5m -input=false -var="environment=${ENVIRONMENT}" -out=tfplan
 


### PR DESCRIPTION
## Summary
- remove the targeted Identity Platform tenant apply step from the prod Terraform workflow
- do the same for the test Terraform workflow so both rely on the normal plan/apply ordering

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e13f801c3c832e90ad4be5a5b3aaca