### PR TITLE
Log gcloud authentication in GCP workflows

### DIFF
--- a/.github/workflows/gcp-prod.yml
+++ b/.github/workflows/gcp-prod.yml
@@ -45,6 +45,11 @@ jobs:
           project_id: ${{ secrets.GOOGLE_PROJECT }}
           install_components: alpha
 
+      - name: Log Google Cloud authentication details
+        run: |
+          gcloud auth list
+          gcloud config list account
+
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v3
         with:

--- a/.github/workflows/gcp-test.yml
+++ b/.github/workflows/gcp-test.yml
@@ -56,6 +56,11 @@ jobs:
           project_id: ${{ secrets.GOOGLE_PROJECT }}
           install_components: alpha
 
+      - name: Log Google Cloud authentication details
+        run: |
+          gcloud auth list
+          gcloud config list account
+
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v3
         with:


### PR DESCRIPTION
## Summary
- log Google Cloud authentication and account details in the prod workflow after installing the SDK
- add the same authentication logging step to the test workflow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1621a484c832e8256dd912570682a