### PR TITLE
Add moved block for dendrite_static bucket

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -112,6 +112,11 @@ locals {
   )
 }
 
+moved {
+  from = google_storage_bucket.dendrite_static
+  to   = google_storage_bucket.dendrite_static_prod
+}
+
 resource "google_storage_bucket" "irien_bucket" {
   name     = "irien-hello-world-${var.project_id}${local.environment_suffix}"
   location = var.irien_bucket_location


### PR DESCRIPTION
## Summary
- add a Terraform moved block to map the legacy dendrite_static bucket to dendrite_static_prod

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e22c33f858832e99ce3154989a2c00