### PR TITLE
Fix moved block target for prod bucket

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -114,7 +114,7 @@ locals {
 
 moved {
   from = google_storage_bucket.dendrite_static
-  to   = google_storage_bucket.dendrite_static_prod
+  to   = google_storage_bucket.dendrite_static_prod[0]
 }
 
 resource "google_storage_bucket" "irien_bucket" {


### PR DESCRIPTION
## Summary
- update the Terraform moved block to point at the indexed prod bucket resource

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2419c0038832e8bb44af8fe9ba4e1