### PR TITLE
Remove legacy moved block from prod Terraform

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -112,11 +112,6 @@ locals {
   )
 }
 
-moved {
-  from = google_storage_bucket.dendrite_static
-  to   = google_storage_bucket.dendrite_static_prod[0]
-}
-
 resource "google_storage_bucket" "irien_bucket" {
   name     = "irien-hello-world-${var.project_id}${local.environment_suffix}"
   location = var.irien_bucket_location


### PR DESCRIPTION
## Summary
- remove the obsolete moved block from the GCP prod Terraform configuration

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e244410810832e984041d616216fd1