### PR TITLE
Add Playwright Cloud Run job for test runs

### DIFF
--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -29,3 +29,13 @@ output "manage_firestore_services" {
   description = "Whether Firestore services are managed in this run"
   value       = local.manage_firestore_services
 }
+
+output "playwright_job_name" {
+  description = "Name of the Playwright Cloud Run job"
+  value       = local.playwright_enabled ? google_cloud_run_v2_job.playwright[0].name : null
+}
+
+output "playwright_region" {
+  description = "Region for the Playwright Cloud Run job"
+  value       = local.playwright_enabled ? var.region : null
+}

--- a/infra/playwright.tf
+++ b/infra/playwright.tf
@@ -1,0 +1,34 @@
+locals {
+  playwright_enabled = startswith(var.environment, "t-")
+  playwright_job_name = "pw-e2e-${var.environment}"
+}
+
+resource "google_service_account" "playwright" {
+  count = local.playwright_enabled ? 1 : 0
+
+  account_id   = local.playwright_job_name
+  display_name = "Playwright E2E runner (${var.environment})"
+}
+
+resource "google_cloud_run_v2_job" "playwright" {
+  count = local.playwright_enabled ? 1 : 0
+
+  name     = local.playwright_job_name
+  location = var.region
+
+  template {
+    task_count  = 1
+    parallelism = 1
+
+    template {
+      service_account = google_service_account.playwright[0].email
+
+      containers {
+        image = var.playwright_image
+      }
+
+      timeout     = "600s"
+      max_retries = 0
+    }
+  }
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -9,6 +9,12 @@ variable "region" {
   default     = "europe-west1"
 }
 
+variable "playwright_image" {
+  description = "Container image used by the Playwright Cloud Run job"
+  type        = string
+  default     = "gcr.io/cloudrun/hello"
+}
+
 variable "irien_bucket_location" {
   description = "Location for the example irien bucket"
   type        = string


### PR DESCRIPTION
## Summary
- add a configurable Playwright container image variable and expose the job details as outputs
- provision a Playwright Cloud Run job and service account that only deploy when the environment comes from the gcp-test workflow

## Testing
- Not run (Terraform CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e259650994832e8b42cc26ac082db6