### PR TITLE
Add debug workflow for tag triggers

### DIFF
--- a/.github/workflows/debug-tag.yml
+++ b/.github/workflows/debug-tag.yml
@@ -1,0 +1,18 @@
+name: debug-tag
+
+on:
+  push:
+    tags:
+      - '**'
+
+jobs:
+  log-context:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Show GitHub context
+        run: |
+          echo "ref=$GITHUB_REF"
+          echo "ref_name=$GITHUB_REF_NAME"
+          echo "event_name=$GITHUB_EVENT_NAME"
+          echo "sha=$GITHUB_SHA"
+          echo "actor=$GITHUB_ACTOR"


### PR DESCRIPTION
## Summary
- add a debug GitHub Actions workflow that runs on tag pushes
- log contextual information to help diagnose why gcp-test tagging does not trigger gcp-prod

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e25dcec490832e881fcb744ec25af3