### PR TITLE
Fix Playwright job dependencies

### DIFF
--- a/infra/playwright.tf
+++ b/infra/playwright.tf
@@ -56,8 +56,8 @@ resource "google_cloud_run_v2_job" "playwright" {
     }
   }
 
-  depends_on = local.playwright_enabled ? [
-    google_service_account_iam_member.tf_can_actas_playwright[0],
-    google_project_iam_member.tf_run_admin[0],
-  ] : []
+  depends_on = [
+    google_service_account_iam_member.tf_can_actas_playwright,
+    google_project_iam_member.tf_run_admin,
+  ]
 }


### PR DESCRIPTION
## Summary
- remove the conditional from the Playwright Cloud Run job depends_on to satisfy Terraform's static list requirement
- keep gating the resources via count while still depending on the IAM bindings

## Testing
- `terraform fmt playwright.tf` *(fails: terraform not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e26152cee4832ea991c6c49be7a171