### PR TITLE
Fix gcp-test tag step to list workflows from repo root

### DIFF
--- a/.github/workflows/gcp-test.yml
+++ b/.github/workflows/gcp-test.yml
@@ -92,7 +92,7 @@ jobs:
           echo "Current HEAD:"
           git rev-parse HEAD
           echo "Workflows at HEAD:"
-          git ls-tree -r HEAD -- .github/workflows || true
+          git -C "$GITHUB_WORKSPACE" ls-tree -r HEAD -- .github/workflows || true
 
           echo "Setting PAT remote:"
           git remote set-url origin "https://x-access-token:${PAT}@github.com/${{ github.repository }}.git"
@@ -101,7 +101,7 @@ jobs:
 
           echo "Creating annotated tag:"
           COMMIT_SHA="$(git rev-parse HEAD)"
-          WF_LIST="$(git ls-tree -r HEAD --name-only .github/workflows || true)"
+          WF_LIST="$(git -C "$GITHUB_WORKSPACE" ls-tree -r HEAD --name-only .github/workflows || true)"
           {
             echo "env: $TAG_NAME"
             echo "commit: $COMMIT_SHA"


### PR DESCRIPTION
## Summary
- ensure the gcp-test tag step runs git ls-tree from the repository root when collecting workflow files

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68e26ad3f310832e82cbbdd733a85c38