### PR TITLE
Update gcp-prod workflow trigger

### DIFF
--- a/.github/workflows/gcp-prod.yml
+++ b/.github/workflows/gcp-prod.yml
@@ -1,13 +1,11 @@
 name: gcp-prod
 
 on:
-  push:
-    tags:
-      - gcp-test-*
-
+  create:
   workflow_dispatch:
 jobs:
   terraform:
+    if: github.ref_type == 'tag' && startsWith(github.ref_name, 'gcp-test-')
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
## Summary
- switch the gcp-prod workflow to run on create events
- guard execution so only gcp-test-* tags trigger the terraform job

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e279dd0034832e9b194802ab237fd6