### PR TITLE
Adjust gcp-prod workflow trigger

### DIFF
--- a/.github/workflows/gcp-prod.yml
+++ b/.github/workflows/gcp-prod.yml
@@ -1,11 +1,15 @@
 name: gcp-prod
 
 on:
-  create:
+  push:
+    branches:
+      - main
+    paths:
+      - 'infra/**'
+      - '.github/workflows/gcp-prod.yml'
   workflow_dispatch:
 jobs:
   terraform:
-    if: github.ref_type == 'tag' && startsWith(github.ref_name, 'gcp-test-')
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
## Summary
- update the gcp-prod workflow to trigger when infra changes land on main
- remove the terraform job guard so production applies run whenever the workflow triggers

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68e27ecafaf8832e8bccc272ae1d3ff6