### PR TITLE
Disable Playwright job deletion protection

### DIFF
--- a/infra/playwright.tf
+++ b/infra/playwright.tf
@@ -39,6 +39,7 @@ resource "google_cloud_run_v2_job" "playwright" {
 
   name     = local.playwright_job_name
   location = var.region
+  deletion_protection = false
 
   template {
     task_count  = 1


### PR DESCRIPTION
## Summary
- disable deletion protection on the Playwright Cloud Run job so it can be destroyed when the test environment is torn down

## Testing
- terraform fmt playwright.tf *(fails: terraform not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e29cc20e94832e8affdd776be2f7eb