### PR TITLE
Fix terraform count formatting

### DIFF
--- a/infra/playwright.tf
+++ b/infra/playwright.tf
@@ -35,7 +35,7 @@ resource "google_project_iam_member" "tf_run_admin" {
 }
 
 resource "google_cloud_run_v2_job" "playwright" {
-  count               = local.playwright_enabled ? 1 : 0
+  count = local.playwright_enabled ? 1 : 0
 
   name                = local.playwright_job_name
   location            = var.region


### PR DESCRIPTION
## Summary
- align the `google_cloud_run_v2_job.playwright` count argument with terraform fmt expectations

## Testing
- terraform fmt -check *(fails: terraform command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2a3b564e0832e814fc80634ac8c51