### PR TITLE
Remove sample hello world bucket from Terraform

### DIFF
--- a/infra/hello-world.txt
+++ b/infra/hello-world.txt
@@ -1,1 +1,0 @@
-hello, irien!

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -112,23 +112,6 @@ locals {
   )
 }
 
-resource "google_storage_bucket" "irien_bucket" {
-  name     = "irien-hello-world-${var.project_id}${local.environment_suffix}"
-  location = var.irien_bucket_location
-}
-
-resource "google_storage_bucket_object" "hello_world" {
-  name   = "hello-world.txt"
-  bucket = google_storage_bucket.irien_bucket.name
-  source = "${path.module}/hello-world.txt"
-}
-
-resource "google_storage_bucket_iam_member" "public_read_access" {
-  bucket = google_storage_bucket.irien_bucket.name
-  role   = "roles/storage.objectViewer"
-  member = "allUsers"
-}
-
 resource "google_storage_bucket" "dendrite_static_prod" {
   count = var.environment == "prod" ? 1 : 0
 

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -15,12 +15,6 @@ variable "playwright_image" {
   default     = "gcr.io/cloudrun/hello"
 }
 
-variable "irien_bucket_location" {
-  description = "Location for the example irien bucket"
-  type        = string
-  default     = "EU"
-}
-
 variable "static_site_bucket_name" {
   description = "Bucket name for the Dendrite static website"
   type        = string


### PR DESCRIPTION
## Summary
- remove the example hello world storage bucket, object, and IAM bindings from the Terraform configuration
- drop the unused irien bucket location variable and associated file artifact

## Testing
- not run (infrastructure-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e2be034420832e991f110ed2df58f1