### PR TITLE
chore: increase Playwright visibility in gcp-test workflow

### DIFF
--- a/.github/workflows/gcp-test.yml
+++ b/.github/workflows/gcp-test.yml
@@ -200,6 +200,52 @@ jobs:
           fi
           gcloud storage ls "gs://${BUCKET}/${TF_VAR_environment}/${GITHUB_RUN_ID}/" || true
 
+      - name: Download Playwright artifacts
+        if: always()
+        run: |
+          set -euo pipefail
+
+          BUCKET="$(terraform output -raw reports_bucket 2>/dev/null || true)"
+          if [ -z "$BUCKET" ] || [ "$BUCKET" = "null" ]; then
+            echo "No reports bucket configured; skipping download"
+            exit 0
+          fi
+
+          PREFIX="${TF_VAR_environment}/${GITHUB_RUN_ID}"
+          BASE="gs://${BUCKET}/${PREFIX}"
+
+          if ! gcloud storage ls "${BASE}" >/dev/null 2>&1; then
+            echo "No Playwright artifacts found at ${BASE}; skipping"
+            exit 0
+          fi
+
+          if gcloud storage ls "${BASE}/playwright.log" >/dev/null 2>&1; then
+            gcloud storage cp "${BASE}/playwright.log" /tmp/playwright.log
+          else
+            echo "No playwright.log found at ${BASE}; skipping log download"
+          fi
+
+          for dir in playwright-report test-results; do
+            SRC="${BASE}/${dir}"
+            if gcloud storage ls "${SRC}" >/dev/null 2>&1; then
+              rm -rf "${dir}"
+              gcloud storage cp -r "${SRC}" "${dir}"
+            else
+              echo "Artifact ${SRC} missing; skipping"
+            fi
+          done
+
+      - name: Upload Playwright logs and traces
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pw-${{ steps.environment.outputs.environment }}
+          path: |
+            /tmp/playwright.log
+            playwright-report
+            test-results
+          if-no-files-found: warn
+
       - name: Dump Cloud Run job logs
         if: always()
         run: |

--- a/docker/playwright/entrypoint.sh
+++ b/docker/playwright/entrypoint.sh
@@ -1,8 +1,18 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+export FORCE_COLOR=1
+export DEBUG="pw:api,pw:browser*"
+
+# optional debug channels for very verbose wire logs
+# export DEBUG="$DEBUG,pw:channel,pw:websocket"
+
+# serialize execution for easier-to-read logs
+ARGS="--reporter=github,list --workers=1"
+
+# keep traces for failures and upload later
 npx playwright install --with-deps
-npx playwright test --reporter=line,junit,html
+npx playwright test $ARGS --trace=retain-on-failure | tee /tmp/playwright.log
 
 REPORT_BUCKET="${REPORT_BUCKET:-}"
 REPORT_PREFIX="${REPORT_PREFIX:-}"
@@ -21,22 +31,33 @@ upload_with_tool() {
   local tool="$1"
   local src="$2"
 
-  if [ -d "$src" ]; then
-    echo "Uploading $src with $tool to ${DEST}/"
-    if [ "$tool" = "gsutil" ]; then
+  if [ ! -e "$src" ]; then
+    echo "Path $src not found; skipping"
+    return
+  fi
+
+  echo "Uploading $src with $tool to ${DEST}/"
+  if [ "$tool" = "gsutil" ]; then
+    if [ -d "$src" ]; then
       gsutil -m cp -r "$src" "${DEST}/"
     else
-      gcloud storage cp -r "$src" "${DEST}/"
+      gsutil -m cp "$src" "${DEST}/"
     fi
   else
-    echo "Directory $src not found; skipping"
+    if [ -d "$src" ]; then
+      gcloud storage cp -r "$src" "${DEST}/"
+    else
+      gcloud storage cp "$src" "${DEST}/"
+    fi
   fi
 }
 
 if command -v gsutil >/dev/null 2>&1; then
+  upload_with_tool gsutil /tmp/playwright.log
   upload_with_tool gsutil playwright-report
   upload_with_tool gsutil test-results
 elif command -v gcloud >/dev/null 2>&1; then
+  upload_with_tool gcloud /tmp/playwright.log
   upload_with_tool gcloud playwright-report
   upload_with_tool gcloud test-results
 else


### PR DESCRIPTION
## Summary
- enable debug-friendly Playwright execution in the Cloud Run entrypoint and capture stdout into a log for later upload
- fetch Playwright artifacts from Cloud Storage and publish them as GitHub Action artifacts after every test run

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e39900fe40832ead10fdff4fde60a2