### PR TITLE
Increase Cloud Run memory for Playwright job

### DIFF
--- a/infra/playwright.tf
+++ b/infra/playwright.tf
@@ -98,6 +98,13 @@ resource "google_cloud_run_v2_job" "playwright" {
           name  = "REPORT_PREFIX"
           value = local.report_prefix
         }
+
+        resources {
+          limits = {
+            cpu    = "2000m"
+            memory = "2Gi"
+          }
+        }
       }
 
       timeout     = "600s"


### PR DESCRIPTION
## Summary
- raise the Cloud Run Playwright job's CPU and memory limits to prevent OOM kills during browser setup

## Testing
- Not Run (infra change)


------
https://chatgpt.com/codex/tasks/task_e_68e3b7c718cc832e9f75c80e2722a5c4