### PR TITLE
Capture screenshot in Playwright example test

### DIFF
--- a/e2e/example.spec.ts
+++ b/e2e/example.spec.ts
@@ -9,4 +9,9 @@ test('renders a page with a title', async ({ page }) => {
     </html>
   `);
   await expect(page).toHaveTitle('Hello World');
+  const screenshot = await page.screenshot();
+  await test.info().attach('page-screenshot', {
+    body: screenshot,
+    contentType: 'image/png',
+  });
 });


### PR DESCRIPTION
## Summary
- capture a screenshot from the Playwright example test and attach it to the test results

## Testing
- npm run test:e2e *(fails: SyntaxError: The requested module '@jest/globals' does not provide an export named 'describe')*

------
https://chatgpt.com/codex/tasks/task_e_68e3c57eae34832e9bc04434364928b7