### PR TITLE
Add robots.txt to dendrite static bucket

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -97,6 +97,11 @@ locals {
       source       = "${path.module}/admin.js"
       content_type = "application/javascript"
     }
+    dendrite_robots_txt = {
+      name         = "robots.txt"
+      source       = "${path.module}/robots.txt"
+      content_type = "text/plain"
+    }
     dendrite_css = {
       name         = "dendrite.css"
       source       = "${path.module}/dendrite.css"

--- a/infra/robots.txt
+++ b/infra/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /


### PR DESCRIPTION
## Summary
- add a basic robots.txt file for the dendrite static site
- configure Terraform to upload the robots.txt asset to the dendrite static bucket

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3c5b24f48832eb2083b0d3b54c47e