### PR TITLE
Configure Playwright to produce HTML reports in CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "test": "node --experimental-vm-modules ./node_modules/.bin/jest --coverage",
-    "test:e2e": "playwright test --reporter=list",
+    "test:e2e": "playwright test",
     "generate": "node src/scripts/generate.js",
     "test-watch": "node --experimental-vm-modules ./node_modules/.bin/jest --watchAll",
     "tcr": "./tcr.sh",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  reporter: [
+    ['list'],
+    ['html', { outputFolder: 'playwright-report', open: 'never' }],
+  ],
+  use: {
+    trace: 'retain-on-failure',
+    screenshot: 'on',
+  },
+});


### PR DESCRIPTION
## Summary
- add a Playwright configuration that scopes tests to the e2e folder and generates HTML reports in playwright-report
- enable trace capture on failures and always save screenshots so CI artifacts include them
- update the npm test:e2e script to rely on the shared Playwright reporter configuration

## Testing
- npm run test:e2e *(fails: Playwright browsers are not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e3d1378288832ead13232c20095ce7