### PR TITLE
Refactor Terraform IAM role bindings into shared map

### DIFF
--- a/infra/dendrite-firestore.tf
+++ b/infra/dendrite-firestore.tf
@@ -15,7 +15,7 @@ resource "google_firebaserules_ruleset" "firestore" {
   }
   depends_on = [
     google_project_service.firebaserules,
-    google_project_iam_member.ci_firebaserules_admin,
+    google_project_iam_member.terraform_service_account_roles["ci_firebaserules_admin"],
   ]
 }
 

--- a/infra/functions-v2.tf
+++ b/infra/functions-v2.tf
@@ -35,7 +35,7 @@ resource "google_cloudfunctions2_function" "get_api_key_credit_v2" {
 
   depends_on = [
     google_project_service.project_level,
-    google_project_iam_member.cloudfunctions_access,
+    google_project_iam_member.terraform_service_account_roles["cloudfunctions_access"],
     google_service_account_iam_member.terraform_can_impersonate_runtime,
     google_service_account_iam_member.terraform_can_impersonate_default_compute,
   ]
@@ -49,6 +49,6 @@ resource "google_cloud_run_service_iam_member" "get_api_key_credit_v2_public" {
 
   depends_on = [
     google_cloudfunctions2_function.get_api_key_credit_v2,
-    google_project_iam_member.terraform_cloudfunctions_viewer,
+    google_project_iam_member.terraform_service_account_roles["terraform_cloudfunctions_viewer"],
   ]
 }

--- a/infra/load-balancer.tf
+++ b/infra/load-balancer.tf
@@ -35,8 +35,8 @@ resource "google_compute_backend_bucket" "dendrite_static" {
 
   depends_on = [
     google_project_service.compute,
-    google_project_iam_member.terraform_loadbalancer_admin,
-    google_project_iam_member.terraform_security_admin,
+    google_project_iam_member.terraform_service_account_roles["terraform_loadbalancer_admin"],
+    google_project_iam_member.terraform_service_account_roles["terraform_security_admin"],
   ]
 }
 
@@ -51,7 +51,7 @@ resource "google_compute_managed_ssl_certificate" "dendrite" {
 
   depends_on = [
     google_project_service.compute,
-    google_project_iam_member.terraform_security_admin,
+    google_project_iam_member.terraform_service_account_roles["terraform_security_admin"],
   ]
 }
 
@@ -119,7 +119,7 @@ resource "google_compute_url_map" "dendrite" {
 
   depends_on = [
     google_project_service.compute,
-    google_project_iam_member.terraform_loadbalancer_admin,
+    google_project_iam_member.terraform_service_account_roles["terraform_loadbalancer_admin"],
   ]
 }
 
@@ -132,8 +132,8 @@ resource "google_compute_target_https_proxy" "dendrite" {
 
   depends_on = [
     google_project_service.compute,
-    google_project_iam_member.terraform_loadbalancer_admin,
-    google_project_iam_member.terraform_security_admin,
+    google_project_iam_member.terraform_service_account_roles["terraform_loadbalancer_admin"],
+    google_project_iam_member.terraform_service_account_roles["terraform_security_admin"],
   ]
 }
 
@@ -144,7 +144,7 @@ resource "google_compute_global_address" "dendrite" {
 
   depends_on = [
     google_project_service.compute,
-    google_project_iam_member.terraform_loadbalancer_admin,
+    google_project_iam_member.terraform_service_account_roles["terraform_loadbalancer_admin"],
   ]
 }
 
@@ -158,8 +158,8 @@ resource "google_compute_global_forwarding_rule" "dendrite_https" {
 
   depends_on = [
     google_project_service.compute,
-    google_project_iam_member.terraform_loadbalancer_admin,
-    google_project_iam_member.terraform_security_admin,
+    google_project_iam_member.terraform_service_account_roles["terraform_loadbalancer_admin"],
+    google_project_iam_member.terraform_service_account_roles["terraform_security_admin"],
   ]
 }
 
@@ -174,7 +174,7 @@ resource "google_compute_url_map" "redirect" {
 
   depends_on = [
     google_project_service.compute,
-    google_project_iam_member.terraform_loadbalancer_admin,
+    google_project_iam_member.terraform_service_account_roles["terraform_loadbalancer_admin"],
   ]
 }
 
@@ -186,7 +186,7 @@ resource "google_compute_target_http_proxy" "redirect" {
 
   depends_on = [
     google_project_service.compute,
-    google_project_iam_member.terraform_loadbalancer_admin,
+    google_project_iam_member.terraform_service_account_roles["terraform_loadbalancer_admin"],
   ]
 }
 
@@ -200,6 +200,6 @@ resource "google_compute_global_forwarding_rule" "dendrite_http" {
 
   depends_on = [
     google_project_service.compute,
-    google_project_iam_member.terraform_loadbalancer_admin,
+    google_project_iam_member.terraform_service_account_roles["terraform_loadbalancer_admin"],
   ]
 }


### PR DESCRIPTION
## Summary
- consolidate repeated Terraform IAM bindings for the Terraform service account into a single for_each resource
- reference the consolidated bindings from Cloud Functions, Firestore rules, and load balancer dependencies to reduce duplication

## Testing
- not run (Terraform CLI not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68e3d6bf437c832ebd5de0726e5804f0