### PR TITLE
Add Playwright test covering Dendrite manual page

### DIFF
--- a/e2e/dendrite-manual.spec.ts
+++ b/e2e/dendrite-manual.spec.ts
@@ -21,5 +21,8 @@ test.describe('dendrite manual static page', () => {
     await expect(page.getByRole('heading', { level: 2, name: 'Reading stories' })).toBeVisible();
     await expect(page.getByRole('heading', { level: 2, name: 'Creating new content' })).toBeVisible();
     await expect(page.getByRole('heading', { level: 2, name: 'Moderation' })).toBeVisible();
+
+    const screenshotPath = test.info().outputPath('dendrite-manual.png');
+    await page.screenshot({ path: screenshotPath, fullPage: true });
   });
 });


### PR DESCRIPTION
## Summary
- add a Playwright end-to-end test that opens the Dendrite manual HTML file
- verify the page title, key headings, navigation links, and introductory copy render as expected

## Testing
- npm run test:e2e *(fails: Playwright browsers are not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3e6c90464832e81915bc7cd59a39a