### PR TITLE
Lock Playwright jobs to prebuilt browsers

### DIFF
--- a/docker/playwright/entrypoint.sh
+++ b/docker/playwright/entrypoint.sh
@@ -11,11 +11,22 @@ export DEBUG="pw:api,pw:browser*"
 ARGS="--reporter=html,github,list --workers=1"
 
 # keep traces for failures and upload later
-npx playwright install --with-deps
+# browsers already in the base image
+
+PLAYWRIGHT_BIN="./node_modules/.bin/playwright"
+
+if [ ! -x "${PLAYWRIGHT_BIN}" ]; then
+  echo "Playwright binary not found at ${PLAYWRIGHT_BIN}" >&2
+  exit 1
+fi
+
+"${PLAYWRIGHT_BIN}" --version || true
+node -e "console.log('node', process.version)"
+"${PLAYWRIGHT_BIN}" test --list --reporter=list || exit 2
 
 # run tests without aborting the script
 set +e
-npx playwright test $ARGS --trace=retain-on-failure | tee /tmp/playwright.log
+"${PLAYWRIGHT_BIN}" test $ARGS --trace=retain-on-failure | tee /tmp/playwright.log
 PW_STATUS=${PIPESTATUS[0]}   # exit code of playwright, not tee
 set -e
 

--- a/infra/playwright.tf
+++ b/infra/playwright.tf
@@ -99,6 +99,31 @@ resource "google_cloud_run_v2_job" "playwright" {
           value = local.report_prefix
         }
 
+        env {
+          name  = "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD"
+          value = "1"
+        }
+
+        env {
+          name  = "PLAYWRIGHT_BROWSERS_PATH"
+          value = "/ms-playwright"
+        }
+
+        env {
+          name  = "NPM_CONFIG_FUND"
+          value = "false"
+        }
+
+        env {
+          name  = "NPM_CONFIG_AUDIT"
+          value = "false"
+        }
+
+        env {
+          name  = "NPM_CONFIG_PROGRESS"
+          value = "false"
+        }
+
         resources {
           limits = {
             cpu    = "2000m"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "devDependencies": {
         "@babel/preset-env": "^7.26.9",
         "@eslint/js": "^9.23.0",
-        "@playwright/test": "^1.47.0",
+        "@playwright/test": "1.47.0",
         "@stryker-mutator/core": "^8.7.1",
         "@stryker-mutator/jest-runner": "^8.7.1",
         "complexity-report": "^2.0.0-alpha",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@babel/preset-env": "^7.26.9",
     "@eslint/js": "^9.23.0",
-    "@playwright/test": "^1.47.0",
+    "@playwright/test": "1.47.0",
     "@stryker-mutator/core": "^8.7.1",
     "@stryker-mutator/jest-runner": "^8.7.1",
     "complexity-report": "^2.0.0-alpha",


### PR DESCRIPTION
## Summary
- stop installing browsers at runtime and execute tests via the repository Playwright binary with discovery sanity checks
- pin @playwright/test to 1.47.0 and set Cloud Run env vars to use the baked-in browser bundle
- disable npm network features during the job to prevent hangs

## Testing
- Not run (infra changes only)


------
https://chatgpt.com/codex/tasks/task_e_68e4bb0a2970832eb7dd56cd35af6192