### PR TITLE
Avoid recreating Playwright artifact repository during tests

### DIFF
--- a/.github/workflows/gcp-test.yml
+++ b/.github/workflows/gcp-test.yml
@@ -99,8 +99,9 @@ jobs:
           IMAGE: e2e-runner
         run: |
           set -euo pipefail
-          gcloud artifacts repositories create "$AR_REPO" \
-            --repository-format=DOCKER --location="${REGION}" || true
+          if ! gcloud artifacts repositories describe "$AR_REPO" --location="${REGION}" >/dev/null 2>&1; then
+            gcloud artifacts repositories create "$AR_REPO" --repository-format=DOCKER --location="${REGION}"
+          fi
           IMAGE_REF="${REGION}-docker.pkg.dev/${GOOGLE_PROJECT}/${AR_REPO}/${IMAGE}:$GITHUB_SHA"
           docker build -f docker/playwright/Dockerfile -t "$IMAGE_REF" .
           docker push "$IMAGE_REF"


### PR DESCRIPTION
## Summary
- check whether the Playwright Artifact Registry repository already exists before attempting to create it in the gcp-test workflow

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e4bd6acf20832eac991aa82c5cb50a