### PR TITLE
Align about nav header with mod

### DIFF
--- a/infra/about.html
+++ b/infra/about.html
@@ -23,6 +23,7 @@
         <a href="/mod.html">Moderate</a>
         <a href="/stats.html">Stats</a>
         <a href="/about.html">About</a>
+        <a class="admin-link" href="/admin.html" style="display: none">Admin</a>
         <div id="signinButton"></div>
         <div id="signoutWrap" style="display: none">
           <a id="signoutLink" href="#">Sign out</a>
@@ -54,7 +55,7 @@
             <h3>Moderation</h3>
             <a href="/mod.html">Moderate</a>
             <a href="/stats.html">Stats</a>
-            <a id="adminLink" href="/admin.html" style="display: none">Admin</a>
+            <a class="admin-link" href="/admin.html" style="display: none">Admin</a>
           </div>
 
           <div class="menu-group">


### PR DESCRIPTION
## Summary
- add the hidden Admin link to the about page header to match the moderator navigation
- update the about page mobile menu moderation group to use the same Admin link markup as the moderator page

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e4c5a778d0832ebc6de7cb2d90a2d1