### PR TITLE
Ensure Cloud Armor policy attaches via beta backend bucket

### DIFF
--- a/infra/load-balancer.tf
+++ b/infra/load-balancer.tf
@@ -61,6 +61,7 @@ resource "google_compute_security_policy" "edge" {
 }
 
 resource "google_compute_backend_bucket" "dendrite_static" {
+  provider = google-beta
   count = local.enable_lb ? 1 : 0
 
   name        = "${local.lb_resource_prefix}-static"


### PR DESCRIPTION
## Summary
- configure the load balancer backend bucket resource to use the google-beta provider so the Cloud Armor edge security policy attachment is honored

## Testing
- not run (terraform CLI not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e4ca705f58832e85e985b7c7862d6c