### PR TITLE
Run terraform fmt on infra Terraform files

### DIFF
--- a/infra/load-balancer.tf
+++ b/infra/load-balancer.tf
@@ -62,7 +62,7 @@ resource "google_compute_security_policy" "edge" {
 
 resource "google_compute_backend_bucket" "dendrite_static" {
   provider = google-beta
-  count = local.enable_lb ? 1 : 0
+  count    = local.enable_lb ? 1 : 0
 
   name        = "${local.lb_resource_prefix}-static"
   bucket_name = local.dendrite_static_bucket_name

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -168,10 +168,10 @@ resource "google_storage_bucket" "dendrite_static_nonprod" {
 resource "google_storage_bucket_object" "dendrite_static_files" {
   for_each = local.static_site_objects
 
-  name         = each.value.name
-  bucket       = local.dendrite_static_bucket_name
-  source       = each.value.source
-  content_type = each.value.content_type
+  name          = each.value.name
+  bucket        = local.dendrite_static_bucket_name
+  source        = each.value.source
+  content_type  = each.value.content_type
   cache_control = try(each.value.cache_control, null)
 }
 

--- a/infra/prod.auto.tfvars
+++ b/infra/prod.auto.tfvars
@@ -1,2 +1,2 @@
-project_id = "irien-465710"
+project_id  = "irien-465710"
 environment = "prod"


### PR DESCRIPTION
## Summary
- run `terraform fmt` to align attribute spacing in the load balancer, storage object, and production variable definitions

## Testing
- terraform fmt -recursive

------
https://chatgpt.com/codex/tasks/task_e_68e4cd2c3bd8832ea73efe033ce6d47b