### PR TITLE
Ensure Playwright job image uses custom entrypoint

### DIFF
--- a/docker/playwright/Dockerfile
+++ b/docker/playwright/Dockerfile
@@ -19,4 +19,4 @@ RUN --mount=type=cache,target=/root/.npm,sharing=locked npm ci
 COPY test/e2e ./test/e2e
 COPY docker/playwright/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
-CMD ["/entrypoint.sh"]
+ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
## Summary
- switch the Playwright Docker image from CMD to ENTRYPOINT so Cloud Run jobs execute the custom entrypoint script

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e513f1f45c832ebbf88dae04edc1d8