### PR TITLE
Add logging to dendrite manual e2e test

### DIFF
--- a/test/e2e/dendrite-manual.spec.ts
+++ b/test/e2e/dendrite-manual.spec.ts
@@ -5,10 +5,18 @@ const manualPageUrl = `${base}/manual.html`;
 
 test.describe('dendrite manual static page', () => {
   test('shows navigation and core manual content', async ({ page }) => {
+    const log = (message: string) =>
+      console.log(`[dendrite-manual.spec] ${new Date().toISOString()} ${message}`);
+
+    log('Starting dendrite manual page assertions');
+    log(`Navigating to ${manualPageUrl}`);
     await page.goto(manualPageUrl);
+    log('Navigation resolved');
 
     await expect(page).toHaveTitle('Dendrite - User Manual');
+    log('Verified page title');
     await expect(page.getByRole('heading', { level: 1, name: 'User Manual' })).toBeVisible();
+    log('Confirmed primary heading visibility');
 
     await expect(page.getByRole('navigation', { name: 'Primary' })).toBeVisible();
     await expect(page.getByRole('link', { name: 'New story' })).toHaveAttribute('href', '/new-story.html');
@@ -19,11 +27,16 @@ test.describe('dendrite manual static page', () => {
     const manualIntro =
       'Welcome to Dendrite. This guide explains how to read and create branching stories.';
     await expect(page.getByText(manualIntro)).toBeVisible();
+    log('Manual introduction located');
     await expect(page.getByRole('heading', { level: 2, name: 'Reading stories' })).toBeVisible();
+    log('Reading stories section visible');
     await expect(page.getByRole('heading', { level: 2, name: 'Creating new content' })).toBeVisible();
+    log('Creating new content section visible');
     await expect(page.getByRole('heading', { level: 2, name: 'Moderation' })).toBeVisible();
+    log('Moderation section visible');
 
     const screenshotPath = test.info().outputPath('dendrite-manual.png');
     await page.screenshot({ path: screenshotPath, fullPage: true });
+    log(`Saved screenshot to ${screenshotPath}`);
   });
 });


### PR DESCRIPTION
## Summary
- add timestamped debug logging throughout the dendrite manual e2e test
- log navigation, assertion milestones, and screenshot creation to help spot hangs

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e64d1fc630832e83d3a845127cdb53