### PR TITLE
chore: bump Playwright Docker image

### DIFF
--- a/docker/playwright/Dockerfile
+++ b/docker/playwright/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.5
-FROM mcr.microsoft.com/playwright:v1.47.0-jammy
+FROM mcr.microsoft.com/playwright:v1.56.0-noble
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \


### PR DESCRIPTION
## Summary
- update the Playwright Docker base image to use the v1.56.0 noble tag

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e67b7d06a4832e952f915e1d5905b3