### PR TITLE
Add Chromium launch arguments to Playwright configuration

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from '@playwright/test';
+import { chromiumProject } from './test/e2e/playwright.config';
 
 export default defineConfig({
   testDir: './test/e2e',
@@ -6,7 +7,9 @@ export default defineConfig({
     ['list'],
     ['html', { outputFolder: 'playwright-report', open: 'never' }],
   ],
+  projects: [chromiumProject],
   use: {
+    ...chromiumProject.use,
     trace: 'retain-on-failure',
     screenshot: 'on',
   },

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from '@playwright/test';
+
+const chromiumArgs = [
+  '--headless=new',
+  '--disable-gpu',
+  '--disable-dev-shm-usage',
+  '--use-gl=swiftshader',
+];
+
+const extraChromiumArgs = (process.env.CHROMIUM_EXTRA_ARGS || '')
+  .split(' ')
+  .filter(Boolean);
+
+export const chromiumProject = {
+  name: 'chromium',
+  use: {
+    launchOptions: { args: [...chromiumArgs, ...extraChromiumArgs] },
+  },
+};
+
+export default defineConfig({
+  projects: [chromiumProject],
+});


### PR DESCRIPTION
## Summary
- add a Playwright project config under test/e2e with Chromium launch arguments and optional CI overrides
- reuse the Chromium project in the root Playwright config so e2e runs pick up the new launch flags

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e67c6c3cac832e9af510089efef412