### PR TITLE
feat: add private gcs proxy for e2e tests

### DIFF
--- a/infra/cloud-functions/gcs-proxy/index.js
+++ b/infra/cloud-functions/gcs-proxy/index.js
@@ -1,0 +1,36 @@
+// CFv2 HTTP. Streams from GCS using runtime SA. No public access.
+import { Storage } from '@google-cloud/storage';
+
+const storage = new Storage();
+const BUCKET = process.env.BUCKET;
+const INDEX = process.env.WEBSITE_INDEX || 'index.html';
+const NOT_FOUND = process.env.WEBSITE_404 || '404.html';
+
+export const gcsProxy = async (req, res) => {
+  try {
+    const rawPath = decodeURIComponent((req.path || '/').replace(/^\/+/, ''));
+    const path = rawPath === '' ? INDEX : rawPath;
+    const file = storage.bucket(BUCKET).file(path);
+
+    const [exists] = await file.exists();
+    if (!exists) {
+      const nf = storage.bucket(BUCKET).file(NOT_FOUND);
+      const [nfExists] = await nf.exists();
+      res.status(nfExists ? 404 : 404);
+      (nfExists ? nf : file).createReadStream()
+        .on('error', () => res.end())
+        .pipe(res);
+      return;
+    }
+
+    const [meta] = await file.getMetadata();
+    if (meta.contentType) res.setHeader('Content-Type', meta.contentType);
+    file.createReadStream()
+      .on('error', () => {
+        res.status(500).end();
+      })
+      .pipe(res);
+  } catch {
+    res.status(500).end();
+  }
+};

--- a/infra/functions-v2.tf
+++ b/infra/functions-v2.tf
@@ -52,3 +52,61 @@ resource "google_cloud_run_service_iam_member" "get_api_key_credit_v2_public" {
     google_project_iam_member.terraform_service_account_roles["terraform_cloudfunctions_viewer"],
   ]
 }
+
+# Zip source
+data "archive_file" "gcs_proxy_src" {
+  type        = "zip"
+  source_dir  = "${path.module}/cloud-functions/gcs-proxy"
+  output_path = "${path.module}/build/gcs-proxy.zip"
+}
+
+# Upload bundle
+resource "google_storage_bucket_object" "gcs_proxy_zip" {
+  name   = "${var.environment}-gcs-proxy-${data.archive_file.gcs_proxy_src.output_sha256}.zip"
+  bucket = google_storage_bucket.gcf_source_bucket.name
+  source = data.archive_file.gcs_proxy_src.output_path
+}
+
+# CFv2 function
+resource "google_cloudfunctions2_function" "gcs_proxy" {
+  name     = "${var.environment}-gcs-proxy"
+  location = var.region
+
+  build_config {
+    runtime     = "nodejs22"
+    entry_point = "gcsProxy"
+    source {
+      storage_source {
+        bucket = google_storage_bucket.gcf_source_bucket.name
+        object = google_storage_bucket_object.gcs_proxy_zip.name
+      }
+    }
+  }
+
+  service_config {
+    available_memory      = "256M"
+    timeout_seconds       = 30
+    service_account_email = local.cloud_function_runtime_service_account_email
+    environment_variables = {
+      BUCKET        = local.dendrite_static_bucket_name
+      WEBSITE_INDEX = "index.html"
+      WEBSITE_404   = "404.html"
+    }
+  }
+
+  depends_on = [
+    google_project_service.project_level,
+    google_service_account.cloud_function_runtime,
+  ]
+}
+
+# Only the Playwright runner may invoke
+resource "google_cloud_run_service_iam_member" "gcs_proxy_invoker_pw" {
+  count = local.playwright_enabled ? 1 : 0
+
+  location = google_cloudfunctions2_function.gcs_proxy.location
+  service  = google_cloudfunctions2_function.gcs_proxy.name
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${google_service_account.playwright[0].email}"
+  depends_on = [google_cloudfunctions2_function.gcs_proxy]
+}

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -185,6 +185,7 @@ resource "google_storage_bucket_object" "dendrite_mod" {
 }
 
 resource "google_storage_bucket_iam_member" "dendrite_public_read_access" {
+  count  = var.environment == "prod" ? 1 : 0
   bucket = local.dendrite_static_bucket_name
   role   = "roles/storage.objectViewer"
   member = local.all_users_member

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -44,3 +44,8 @@ output "lb_ip" {
   description = "Global LB IPv4"
   value       = local.enable_lb ? google_compute_global_address.dendrite[0].address : null
 }
+
+output "e2e_origin" {
+  description = "Base URL for private static site proxy"
+  value       = try(google_cloudfunctions2_function.gcs_proxy.service_config[0].uri, null)
+}

--- a/infra/playwright.tf
+++ b/infra/playwright.tf
@@ -89,13 +89,12 @@ resource "google_cloud_run_v2_job" "playwright" {
       containers {
         image = var.playwright_image
 
-        dynamic "env" {
-          for_each = local.enable_lb ? [google_compute_global_address.dendrite[0].address] : []
-
-          content {
-            name  = "BASE_URL"
-            value = "http://${env.value}"
-          }
+        env {
+          name  = "BASE_URL"
+          value = try(
+            "http://${element(google_compute_global_address.dendrite[*].address, 0)}",
+            google_cloudfunctions2_function.gcs_proxy.service_config[0].uri
+          )
         }
 
         env {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     ['html', { outputFolder: 'playwright-report', open: 'never' }],
   ],
   use: {
+    baseURL: process.env.BASE_URL || process.env.E2E_ORIGIN,
     trace: 'retain-on-failure',
     screenshot: 'on',
   },


### PR DESCRIPTION
## Summary
- make the dendrite static bucket world-readable only in production
- add a Cloud Functions Gen 2 proxy that streams objects from GCS and grant invoke rights to the Playwright runner
- expose the proxy URL to Terraform outputs and wire Playwright infrastructure/configuration to consume it

## Testing
- npm test *(fails: Jest cannot parse test/e2e/example.spec.ts because it uses ESM imports)*

------
https://chatgpt.com/codex/tasks/task_e_68e67b60b488832e844553bfb224a765