### PR TITLE
Remove conflicting network reference from Playwright VPC connector

### DIFF
--- a/infra/gcs-proxy.tf
+++ b/infra/gcs-proxy.tf
@@ -19,7 +19,6 @@ resource "google_vpc_access_connector" "playwright" {
 
   name    = "${var.environment}-svpc"
   region  = var.region
-  network = google_compute_network.playwright[0].name
   subnet {
     name = google_compute_subnetwork.playwright[0].name
   }


### PR DESCRIPTION
## Summary
- remove the explicit network attribute from the Playwright VPC access connector because the subnet block already specifies the network

## Testing
- not run (terraform configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68e9024c39ec832ebe148397513db666