### PR TITLE
Move getVariantSnapshot helper into core

### DIFF
--- a/src/cloud/assign-moderation-job/core.js
+++ b/src/cloud/assign-moderation-job/core.js
@@ -11,4 +11,5 @@ export {
   createHandleAssignModerationJob,
   buildVariantQueryPlan,
   createVariantSnapshotFetcher,
+  createGetVariantSnapshot,
 } from '../../core/cloud/assign-moderation-job/core.js';

--- a/src/cloud/assign-moderation-job/index.js
+++ b/src/cloud/assign-moderation-job/index.js
@@ -10,7 +10,7 @@ import {
   getIdTokenFromRequest,
   selectVariantDoc,
   createHandleAssignModerationJob,
-  createVariantSnapshotFetcher,
+  createGetVariantSnapshot,
 } from './core.js';
 import {
   initializeFirebaseAppResources,
@@ -31,9 +31,7 @@ const { db, auth, app } = firebaseResources;
 
 const runVariantQuery = createRunVariantQuery(db);
 
-const getVariantSnapshot = createVariantSnapshotFetcher({
-  runQuery: runVariantQuery,
-});
+const getVariantSnapshot = createGetVariantSnapshot(runVariantQuery);
 
 /**
  * @typedef {object} GuardError

--- a/src/core/cloud/assign-moderation-job/core.js
+++ b/src/core/cloud/assign-moderation-job/core.js
@@ -237,6 +237,17 @@ export function createVariantSnapshotFetcher({ runQuery }) {
 }
 
 /**
+ * Adapter that produces the getVariantSnapshot helper from a runQuery implementation.
+ * @param {(descriptor: VariantQueryDescriptor) => Promise<{ empty?: boolean }>} runQuery Query executor.
+ * @returns {(randomValue: number) => Promise<unknown>} Function resolving with the first snapshot containing results.
+ */
+export function createGetVariantSnapshot(runQuery) {
+  return createVariantSnapshotFetcher({
+    runQuery,
+  });
+}
+
+/**
  * Build the HTTP handler that assigns a moderation job to the caller.
  * @param {(context: { req: import('express').Request }) => Promise<{ status: number, body?: unknown }>} assignModerationWorkflow
  * Workflow that coordinates guard execution and variant selection.


### PR DESCRIPTION
## Summary
- add a createGetVariantSnapshot helper to the shared moderation core module
- re-export the helper through the cloud-facing core wrapper
- consume the shared helper in the moderation entrypoint

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f1c92ed1c0832e9cef6aee6cc9cccc