### PR TITLE
Extract helper for assign moderation job route setup

### DIFF
--- a/src/cloud/assign-moderation-job/index.js
+++ b/src/cloud/assign-moderation-job/index.js
@@ -23,11 +23,22 @@ const firebaseResources = createFirebaseResources(
 
 const { app } = firebaseResources;
 
-registerAssignModerationJobRoute(
+const registerAssignModerationJobRouteHandler = (
+  firebaseResourcesArg,
+  createRunVariantQueryArg,
+  nowArg
+) =>
+  registerAssignModerationJobRoute(
+    firebaseResourcesArg,
+    createRunVariantQueryArg,
+    nowArg,
+    random
+  );
+
+registerAssignModerationJobRouteHandler(
   firebaseResources,
   createRunVariantQuery,
-  now,
-  random
+  now
 );
 
 export const assignModerationJob = createAssignModerationJob(functions, app);


### PR DESCRIPTION
## Summary
- extract a helper that registers the assign moderation job route
- invoke the new helper with the existing firebase resources and dependencies

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f24b509ba4832e984ac9aa1a05e3f1