### PR TITLE
Add edge case coverage for CSV toys

### DIFF
--- a/test/core/toys/utils/csv.test.js
+++ b/test/core/toys/utils/csv.test.js
@@ -1,0 +1,22 @@
+import { parseCsvLine } from '../../../../src/core/toys/utils/csv.js';
+
+describe('parseCsvLine', () => {
+  it('returns null when provided a non-string input', () => {
+    expect(parseCsvLine()).toBeNull();
+    expect(parseCsvLine(42)).toBeNull();
+  });
+
+  it('splits unquoted comma-separated values', () => {
+    expect(parseCsvLine('alpha,beta,gamma')).toEqual(['alpha', 'beta', 'gamma']);
+  });
+
+  it('handles quoted fields and escaped quotes', () => {
+    const input = '"quoted, field","He said ""Hello"""';
+
+    expect(parseCsvLine(input)).toEqual(['quoted, field', 'He said "Hello"']);
+  });
+
+  it('returns null when a quoted field is not terminated', () => {
+    expect(parseCsvLine('"unterminated,field')).toBeNull();
+  });
+});

--- a/test/toys/2025-10-19/csvToJsonArray.test.js
+++ b/test/toys/2025-10-19/csvToJsonArray.test.js
@@ -44,4 +44,22 @@ describe('csvToJsonArrayToy', () => {
     expect(csvToJsonArrayToy('name,age\nAlice,30\n"Bob,25')).toBe(JSON.stringify([]));
     expect(csvToJsonArrayToy(42)).toBe(JSON.stringify([]));
   });
+
+  it('requires the header row to contain non-empty column names', () => {
+    const input = '   ,  , \nvalue1,value2,value3';
+
+    expect(csvToJsonArrayToy(input)).toBe(JSON.stringify([]));
+  });
+
+  it('fails when the header row cannot be parsed as CSV', () => {
+    const input = '"unterminated header\nvalue1,value2';
+
+    expect(csvToJsonArrayToy(input)).toBe(JSON.stringify([]));
+  });
+
+  it('returns an empty array string when no data rows remain after filtering', () => {
+    const input = 'name,age\n\n\t\n';
+
+    expect(csvToJsonArrayToy(input)).toBe(JSON.stringify([]));
+  });
 });

--- a/test/toys/2025-10-19/csvToJsonObject.test.js
+++ b/test/toys/2025-10-19/csvToJsonObject.test.js
@@ -38,4 +38,12 @@ describe('csvToJsonObjectToy', () => {
     expect(csvToJsonObjectToy('a\n1\n2')).toBe(JSON.stringify({}));
     expect(csvToJsonObjectToy(42)).toBe(JSON.stringify({}));
   });
+
+  it('requires a header row with at least one column', () => {
+    expect(csvToJsonObjectToy('\nvalue')).toBe(JSON.stringify({}));
+  });
+
+  it('requires exactly one data row', () => {
+    expect(csvToJsonObjectToy('name,age\n')).toBe(JSON.stringify({}));
+  });
 });


### PR DESCRIPTION
## Summary
- add focused unit tests for the CSV line parser covering invalid inputs and escaped quotes
- extend the csv-to-JSON toy suites to verify header validation and malformed scenarios

## Testing
- npm test -- --coverage

------
https://chatgpt.com/codex/tasks/task_e_68f62d1e91f8832eb65912bd39604116