### PR TITLE
Move getApiKeyCreditSnapshot helper into core

### DIFF
--- a/notes/agents/2025-12-20-get-api-key-credit-v2-snapshot-core.md
+++ b/notes/agents/2025-12-20-get-api-key-credit-v2-snapshot-core.md
@@ -1,0 +1,4 @@
+# get-api-key-credit-v2 snapshot core extraction
+
+- **Challenge**: Needed to move the Firestore snapshot helper out of the V2 function entry point without breaking the copy-to-infra workflow that mirrors cloud files.
+- **Resolution**: Created a core helper module that mirrors the existing create-db setup and re-exported it from the cloud wrapper so the directory copy still pulls in the helper automatically.

--- a/src/cloud/get-api-key-credit-v2/get-api-key-credit-snapshot.js
+++ b/src/cloud/get-api-key-credit-v2/get-api-key-credit-snapshot.js
@@ -1,0 +1,1 @@
+export { getApiKeyCreditSnapshot } from '../../core/cloud/get-api-key-credit-v2/get-api-key-credit-snapshot.js';

--- a/src/cloud/get-api-key-credit-v2/index.js
+++ b/src/cloud/get-api-key-credit-v2/index.js
@@ -5,18 +5,9 @@ import {
   extractUuid,
 } from './handler.js';
 import { createDb } from './create-db.js';
+import { getApiKeyCreditSnapshot } from './get-api-key-credit-snapshot.js';
 
 const db = createDb(Firestore);
-
-/**
- * Retrieve the Firestore snapshot for an API key credit document.
- * @param {import('@google-cloud/firestore').Firestore} database Firestore instance.
- * @param {string} uuid API key UUID.
- * @returns {Promise<import('@google-cloud/firestore').DocumentSnapshot>} Firestore snapshot.
- */
-export function getApiKeyCreditSnapshot(database, uuid) {
-  return database.collection('api-key-credit').doc(String(uuid)).get();
-}
 
 /**
  * Fetch stored credit for the supplied API key UUID.
@@ -58,3 +49,4 @@ export const getApiKeyCreditV2 = onRequest(async (req, res) => {
 
 export { extractUuid } from './handler.js';
 export { createDb } from './create-db.js';
+export { getApiKeyCreditSnapshot } from './get-api-key-credit-snapshot.js';

--- a/src/core/cloud/get-api-key-credit-v2/get-api-key-credit-snapshot.js
+++ b/src/core/cloud/get-api-key-credit-v2/get-api-key-credit-snapshot.js
@@ -1,0 +1,9 @@
+/**
+ * Retrieve the Firestore snapshot for an API key credit document.
+ * @param {import('@google-cloud/firestore').Firestore} database Firestore instance.
+ * @param {string} uuid API key UUID.
+ * @returns {Promise<import('@google-cloud/firestore').DocumentSnapshot>} Firestore snapshot.
+ */
+export function getApiKeyCreditSnapshot(database, uuid) {
+  return database.collection('api-key-credit').doc(String(uuid)).get();
+}


### PR DESCRIPTION
## Summary
- add a core helper for loading API key credit snapshots and re-export it through the cloud wrapper
- update the get-api-key-credit-v2 entry point to consume the shared helper

## Testing
- npm test -- --runTestsByPath test/cloud/get-api-key-credit-v2/index.test.js test/core/cloud/get-api-key-credit-v2/handler.test.js

------
https://chatgpt.com/codex/tasks/task_e_68f9e65d6c8c832e96caf969d985f37d