### PR TITLE
Refactor get API key credit core module

### DIFF
--- a/notes/agents/2025-10-23-get-api-key-credit-core-merge.md
+++ b/notes/agents/2025-10-23-get-api-key-credit-core-merge.md
@@ -1,0 +1,4 @@
+# 2025-10-23 – get API key credit core merge
+
+- **Challenge:** Merging the handler utilities into a single module meant the copy-to-infra script no longer pointed at valid file names, which would have broken the deployment bundle.
+- **Resolution:** Introduced the consolidated `core.js` module and updated the copy script and unit tests to reference it so the function packaging still mirrors the refactored structure.

--- a/src/cloud/copy-to-infra.js
+++ b/src/cloud/copy-to-infra.js
@@ -112,25 +112,15 @@ const reportForModerationHandlerSource = join(
   'handler.js'
 );
 
-const getApiKeyCreditHandlerSource = join(
+const getApiKeyCreditCoreSource = join(
   srcCoreCloudDir,
   'get-api-key-credit',
-  'handler.js'
+  'core.js'
 );
 const getApiKeyCreditCreateFirestoreSource = join(
   srcCoreCloudDir,
   'get-api-key-credit',
   'createFirestore.js'
-);
-const getApiKeyCreditFetchDocumentSource = join(
-  srcCoreCloudDir,
-  'get-api-key-credit',
-  'fetchApiKeyCreditDocument.js'
-);
-const getApiKeyCreditIsMissingDocumentSource = join(
-  srcCoreCloudDir,
-  'get-api-key-credit',
-  'isMissingDocument.js'
 );
 
 const getApiKeyCreditV2HandlerSource = join(
@@ -227,24 +217,12 @@ const individualFileCopies = [
     target: join(infraFunctionsDir, 'report-for-moderation', 'handler.js'),
   },
   {
-    source: getApiKeyCreditHandlerSource,
-    target: join(infraFunctionsDir, 'get-api-key-credit', 'handler.js'),
+    source: getApiKeyCreditCoreSource,
+    target: join(infraFunctionsDir, 'get-api-key-credit', 'core.js'),
   },
   {
     source: getApiKeyCreditCreateFirestoreSource,
     target: join(infraFunctionsDir, 'get-api-key-credit', 'createFirestore.js'),
-  },
-  {
-    source: getApiKeyCreditFetchDocumentSource,
-    target: join(infraFunctionsDir, 'get-api-key-credit', 'fetchApiKeyCreditDocument.js'),
-  },
-  {
-    source: getApiKeyCreditIsMissingDocumentSource,
-    target: join(
-      infraFunctionsDir,
-      'get-api-key-credit',
-      'isMissingDocument.js'
-    ),
   },
   {
     source: getApiKeyCreditV2HandlerSource,

--- a/src/cloud/get-api-key-credit/core.js
+++ b/src/cloud/get-api-key-credit/core.js
@@ -1,0 +1,1 @@
+export * from '../../core/cloud/get-api-key-credit/core.js';

--- a/src/cloud/get-api-key-credit/fetchApiKeyCreditDocument.js
+++ b/src/cloud/get-api-key-credit/fetchApiKeyCreditDocument.js
@@ -1,1 +1,0 @@
-export { fetchApiKeyCreditDocument } from '../../core/cloud/get-api-key-credit/fetchApiKeyCreditDocument.js';

--- a/src/cloud/get-api-key-credit/handler.js
+++ b/src/cloud/get-api-key-credit/handler.js
@@ -1,1 +1,0 @@
-export * from '../../core/cloud/get-api-key-credit/handler.js';

--- a/src/cloud/get-api-key-credit/index.js
+++ b/src/cloud/get-api-key-credit/index.js
@@ -1,8 +1,10 @@
 import { Firestore } from '@google-cloud/firestore';
-import { createGetApiKeyCreditHandler } from './handler.js';
+import {
+  createGetApiKeyCreditHandler,
+  fetchApiKeyCreditDocument,
+  isMissingDocument,
+} from './core.js';
 import { createFirestore } from './createFirestore.js';
-import { fetchApiKeyCreditDocument } from './fetchApiKeyCreditDocument.js';
-import { isMissingDocument } from './isMissingDocument.js';
 
 const firestore = createFirestore(Firestore);
 
@@ -45,4 +47,8 @@ export async function handler(req, res) {
 }
 
 export { createFirestore } from './createFirestore.js';
-export { fetchApiKeyCreditDocument } from './fetchApiKeyCreditDocument.js';
+export {
+  createGetApiKeyCreditHandler,
+  fetchApiKeyCreditDocument,
+  isMissingDocument,
+} from './core.js';

--- a/src/cloud/get-api-key-credit/isMissingDocument.js
+++ b/src/cloud/get-api-key-credit/isMissingDocument.js
@@ -1,1 +1,0 @@
-export { isMissingDocument } from '../../core/cloud/get-api-key-credit/isMissingDocument.js';

--- a/src/core/cloud/get-api-key-credit/core.js
+++ b/src/core/cloud/get-api-key-credit/core.js
@@ -9,6 +9,25 @@ const CREDIT_RESPONSE_BY_VALUE = new Map([
 ]);
 
 /**
+ * Determine whether a Firestore document snapshot is missing.
+ * @param {{ exists?: boolean }} doc Snapshot to inspect for existence.
+ * @returns {boolean} True when the document is absent.
+ */
+export function isMissingDocument(doc) {
+  return !doc?.exists;
+}
+
+/**
+ * Fetch the Firestore document containing API key credit information.
+ * @param {import('@google-cloud/firestore').Firestore} firestoreInstance Firestore client used for queries.
+ * @param {string|number} uuid Identifier for the API key credit document.
+ * @returns {Promise<import('@google-cloud/firestore').DocumentSnapshot>} The matching Firestore document snapshot.
+ */
+export function fetchApiKeyCreditDocument(firestoreInstance, uuid) {
+  return firestoreInstance.collection('api-key-credit').doc(String(uuid)).get();
+}
+
+/**
  * Ensure a dependency is a function before using it.
  * @param {string} name - Name of the dependency for error messaging.
  * @param {*} dependency - Candidate dependency to validate.

--- a/src/core/cloud/get-api-key-credit/fetchApiKeyCreditDocument.js
+++ b/src/core/cloud/get-api-key-credit/fetchApiKeyCreditDocument.js
@@ -1,9 +1,0 @@
-/**
- * Fetch the Firestore document containing API key credit information.
- * @param {import('@google-cloud/firestore').Firestore} firestoreInstance Firestore client used for queries.
- * @param {string|number} uuid Identifier for the API key credit document.
- * @returns {Promise<import('@google-cloud/firestore').DocumentSnapshot>} The matching Firestore document snapshot.
- */
-export function fetchApiKeyCreditDocument(firestoreInstance, uuid) {
-  return firestoreInstance.collection('api-key-credit').doc(String(uuid)).get();
-}

--- a/src/core/cloud/get-api-key-credit/isMissingDocument.js
+++ b/src/core/cloud/get-api-key-credit/isMissingDocument.js
@@ -1,8 +1,0 @@
-/**
- * Determine whether a Firestore document snapshot is missing.
- * @param {{ exists?: boolean }} doc Snapshot to inspect for existence.
- * @returns {boolean} True when the document is absent.
- */
-export function isMissingDocument(doc) {
-  return !doc?.exists;
-}

--- a/test/core/cloud/get-api-key-credit/handler.test.js
+++ b/test/core/cloud/get-api-key-credit/handler.test.js
@@ -1,5 +1,5 @@
 import { jest } from '@jest/globals';
-import { createGetApiKeyCreditHandler } from '../../../../src/core/cloud/get-api-key-credit/handler.js';
+import { createGetApiKeyCreditHandler } from '../../../../src/core/cloud/get-api-key-credit/core.js';
 
 describe('createGetApiKeyCreditHandler', () => {
   const createDependencies = ({

--- a/test/core/cloud/get-api-key-credit/utils.test.js
+++ b/test/core/cloud/get-api-key-credit/utils.test.js
@@ -1,7 +1,9 @@
 import { describe, expect, it, jest } from '@jest/globals';
 import { createFirestore } from '../../../../src/core/cloud/get-api-key-credit/createFirestore.js';
-import { fetchApiKeyCreditDocument } from '../../../../src/core/cloud/get-api-key-credit/fetchApiKeyCreditDocument.js';
-import { isMissingDocument } from '../../../../src/core/cloud/get-api-key-credit/isMissingDocument.js';
+import {
+  fetchApiKeyCreditDocument,
+  isMissingDocument,
+} from '../../../../src/core/cloud/get-api-key-credit/core.js';
 
 describe('createFirestore', () => {
   it('instantiates the provided constructor without arguments', () => {


### PR DESCRIPTION
## Summary
- consolidate the handler, document fetcher, and snapshot guard into `src/core/cloud/get-api-key-credit/core.js`
- update the cloud wrapper, tests, and copy-to-infra script to import from the consolidated module
- capture an agent note about the deployment script adjustments

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68fa5e69bdc0832e8146522ecf37a07c