### PR TITLE
Ensure hide variant html preserves undefined variant data

### DIFF
--- a/notes/agents/2026-12-31-dendrite-disposable-refactor.md
+++ b/notes/agents/2026-12-31-dendrite-disposable-refactor.md
@@ -1,0 +1,4 @@
+# Dendrite handler disposable reuse
+
+- Identified that `createDendriteHandler` duplicated the `_dispose` guard already available via `isDisposable` in `disposeHelpers`. Reused the helper to keep the logic consistent across input handlers.
+- Jest suite currently has a pre-existing failure in `test/core/cloud/hide-variant-html/removeVariantHtml.test.js` (expects `variantData` to be `undefined` but receives `null`). Logged it here so it can be investigated separately.

--- a/notes/agents/2027-08-31-variant-data-default.md
+++ b/notes/agents/2027-08-31-variant-data-default.md
@@ -1,0 +1,8 @@
+## Context
+Jest highlighted that `createRemoveVariantHtml` now forwarded `variantData: null` when neither the payload nor the load result supplied variant details. The spec expects `undefined` in that scenario.
+
+## Challenge
+Because the helper defaulted `variantData` to `null`, the tests failed and it risked downstream assumptions that distinguish between "unset" and "explicitly cleared" variant data.
+
+## Resolution
+Adjusted the helper to only substitute the loader's `variant` output when the payload omits the field, preserving `undefined` otherwise. This restored the contract and the test suite now passes.

--- a/src/core/cloud/hide-variant-html/core.js
+++ b/src/core/cloud/hide-variant-html/core.js
@@ -54,9 +54,14 @@ export function createRemoveVariantHtml({
       page = loadResult.page;
     }
 
-    let resolvedVariantData = variantData ?? null;
-    if (resolvedVariantData === null && loadResult && typeof loadResult === 'object') {
-      resolvedVariantData = loadResult.variant ?? null;
+    let resolvedVariantData = variantData;
+    if (
+      resolvedVariantData === undefined &&
+      loadResult &&
+      typeof loadResult === 'object' &&
+      'variant' in loadResult
+    ) {
+      resolvedVariantData = loadResult.variant;
     }
 
     if (!page) {

--- a/src/core/inputHandlers/createDendriteHandler.js
+++ b/src/core/inputHandlers/createDendriteHandler.js
@@ -6,6 +6,7 @@ import {
   maybeRemoveTextarea,
 } from './removeElements.js';
 import { hideAndDisable } from './inputState.js';
+import { isDisposable } from './disposeHelpers.js';
 import { getInputValue, setInputValue } from '../browser/inputValueStore.js';
 
 /**
@@ -20,7 +21,7 @@ export function createDendriteHandler(fields) {
    * @returns {void}
    */
   function disposeIfPossible(node) {
-    if (typeof node._dispose === 'function') {
+    if (isDisposable(node)) {
       node._dispose();
     }
   }


### PR DESCRIPTION
## Summary
- prevent `createRemoveVariantHtml` from coercing undefined `variantData` into null so the downstream contract stays intact
- capture the `variantData` fallback fix in the agent worklog

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68fcb225edb8832ea4e401dd76bc4a8e