### PR TITLE
Remove redundant generate-stats bucket re-export

### DIFF
--- a/notes/agents/2025-10-25-cloud-core-bucket-refactor.md
+++ b/notes/agents/2025-10-25-cloud-core-bucket-refactor.md
@@ -1,0 +1,4 @@
+# Cloud core bucket refactor
+
+- Challenge: Moving the default bucket name into the shared cloud core module risked breaking the generate-stats copies because the cloud build script previously targeted a non-existent `core.js` file.
+- Resolution: Added a thin re-export for the shared core helpers, updated the copy script to ship both the renamed core file and `cloud-core.js` into the generate-stats function directory, and verified the imports still resolve.

--- a/notes/agents/2025-10-25-generate-stats-reexport-cleanup.md
+++ b/notes/agents/2025-10-25-generate-stats-reexport-cleanup.md
@@ -1,0 +1,4 @@
+# Generate stats re-export cleanup
+
+- **Challenge:** Follow-up review flagged that the generate-stats core bridge did not actually need to re-export the shared bucket constant, so the prior change added unnecessary surface area.
+- **Resolution:** Removed the redundant re-export while keeping the shared import so downstream logic still uses the shared default bucket name.

--- a/src/cloud/copy-to-infra.js
+++ b/src/cloud/copy-to-infra.js
@@ -100,7 +100,7 @@ const cloudCoreSource = join(srcCoreCloudDir, 'cloud-core.js');
 const generateStatsCoreSource = join(
   srcCoreCloudDir,
   'generate-stats',
-  'core.js'
+  'generate-stats-core.js'
 );
 
 const submitNewPageCoreSource = join(
@@ -236,11 +236,29 @@ const individualFileCopies = [
   },
   {
     source: generateStatsCoreSource,
-    target: join(infraDir, 'core', 'cloud', 'generate-stats', 'core.js'),
+    target: join(
+      infraDir,
+      'core',
+      'cloud',
+      'generate-stats',
+      'generate-stats-core.js'
+    ),
   },
   {
     source: generateStatsCoreSource,
-    target: join(infraFunctionsDir, 'generate-stats', 'core.js'),
+    target: join(
+      infraFunctionsDir,
+      'generate-stats',
+      'generate-stats-core.js'
+    ),
+  },
+  {
+    source: cloudCoreSource,
+    target: join(
+      infraFunctionsDir,
+      'generate-stats',
+      'cloud-core.js'
+    ),
   },
   {
     source: submitNewPageCoreSource,

--- a/src/core/cloud/cloud-core.js
+++ b/src/core/cloud/cloud-core.js
@@ -3,3 +3,5 @@ export const productionOrigins = [
   'https://dendritestories.co.nz',
   'https://www.dendritestories.co.nz',
 ];
+
+export const DEFAULT_BUCKET_NAME = 'www.dendritestories.co.nz';

--- a/src/core/cloud/generate-stats/cloud-core.js
+++ b/src/core/cloud/generate-stats/cloud-core.js
@@ -1,0 +1,1 @@
+export * from '../cloud-core.js';

--- a/src/core/cloud/generate-stats/generate-stats-core.js
+++ b/src/core/cloud/generate-stats/generate-stats-core.js
@@ -1,4 +1,5 @@
 import { ADMIN_UID } from './admin-config.js';
+import { DEFAULT_BUCKET_NAME } from './cloud-core.js';
 
 /**
  * Build stats HTML page.
@@ -259,7 +260,6 @@ export function buildHtml(
 
 const DEFAULT_URL_MAP = 'prod-dendrite-url-map';
 const DEFAULT_CDN_HOST = 'www.dendritestories.co.nz';
-const DEFAULT_BUCKET_NAME = 'www.dendritestories.co.nz';
 
 /**
  * Determine whether a Firebase initialization error indicates a duplicate app.


### PR DESCRIPTION
## Summary
- remove the redundant DEFAULT_BUCKET_NAME re-export from the generate-stats core entry point
- document the follow-up change in the agent worklog

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68fd181e44cc832ea19f11c641d58c54