### PR TITLE
Inline default environment handling in assign moderation job

### DIFF
--- a/notes/agents/2024-05-assign-moderation-inline.md
+++ b/notes/agents/2024-05-assign-moderation-inline.md
@@ -1,0 +1,4 @@
+## Assign moderation environment inlining
+
+- Challenge: Removing the shared `defaultEnvironment` constant risked breaking the logic that detects custom dependency injection in `getFirestoreInstance`.
+- Resolution: Default the destructured `environment` to `undefined`, lazily fetch `getEnvironmentVariables()` when it isn't provided, and switch the custom dependency check to look for an explicit override instead of comparing object identity.

--- a/src/cloud/assign-moderation-job/index.js
+++ b/src/cloud/assign-moderation-job/index.js
@@ -20,8 +20,6 @@ import {
 
 let cachedDb = null;
 
-const defaultEnvironment = getEnvironmentVariables();
-
 const firebaseInitialization = createFirebaseInitialization();
 
 /**
@@ -40,7 +38,7 @@ const defaultEnsureFirebaseApp = () => {};
  * @param {Record<string, unknown>} environment Process environment variables.
  * @returns {string | null} The configured database identifier when available.
  */
-function resolveFirestoreDatabaseId(environment = defaultEnvironment) {
+function resolveFirestoreDatabaseId(environment = getEnvironmentVariables()) {
   const rawConfig = environment?.FIREBASE_CONFIG;
 
   if (typeof rawConfig !== 'string' || rawConfig.trim() === '') {
@@ -96,8 +94,13 @@ function getFirestoreInstance(options = {}) {
   const {
     ensureAppFn = defaultEnsureFirebaseApp,
     getFirestoreFn = getAdminFirestore,
-    environment = defaultEnvironment,
+    environment: providedEnvironment,
   } = options;
+
+  const environment =
+    providedEnvironment !== undefined
+      ? providedEnvironment
+      : getEnvironmentVariables();
 
   ensureAppFn();
 
@@ -105,7 +108,7 @@ function getFirestoreInstance(options = {}) {
   const useCustomDependencies =
     ensureAppFn !== defaultEnsureFirebaseApp ||
     getFirestoreFn !== getAdminFirestore ||
-    environment !== defaultEnvironment;
+    providedEnvironment !== undefined;
 
   if (useCustomDependencies) {
     return getFirestoreForDatabase(getFirestoreFn, undefined, databaseId);


### PR DESCRIPTION
## Summary
- inline the assign moderation job's default environment retrieval instead of caching it in a module-level constant
- ensure custom dependency detection keys off explicit environment overrides after the refactor
- add an agent note describing the dependency detection adjustment

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fe5de408d8832e81ceb8a8f81e06fc