### PR TITLE
Align entry/core dependency factory naming in docs

### DIFF
--- a/notes/agents/2026-12-31-entry-core-vision-followup.md
+++ b/notes/agents/2026-12-31-entry-core-vision-followup.md
@@ -1,0 +1,3 @@
+# Entry/Core Vision Follow-up Adjustments
+- incorporated reviewer feedback so example cloud function injects the Functions SDK into the core module and lets the core handle `onRequest` wiring.
+- added dedicated browser dependency factory in the note to emphasize reusing shared browser shims instead of redefining them per entry file.

--- a/notes/agents/2026-12-31-entry-core-vision-note.md
+++ b/notes/agents/2026-12-31-entry-core-vision-note.md
@@ -1,0 +1,3 @@
+# Entry/Core Vision Note
+- **Challenge:** Translating a narrative description of the desired dependency-injection pattern into a concise note required double-checking current cloud and browser entry files to avoid misrepresenting their structure.
+- **Resolution:** Reviewed `src/cloud/get-moderation-variant/index.js` and `src/browser/main.js` to confirm the existing bridge/core split before drafting the documentation in `notes/entry-core-dependency-vision.md`.

--- a/notes/agents/2027-12-31-entry-core-vision-comment-followup.md
+++ b/notes/agents/2027-12-31-entry-core-vision-comment-followup.md
@@ -1,0 +1,11 @@
+# Entry/Core vision comment follow-up
+
+## What changed
+- Reworked the documentation examples so entry shims pass their dependency factory functions (`buildGcf`, `createBrowserEnv`) into the core layer instead of instantiating them eagerly.
+- Added a browser core snippet that demonstrates invoking the factory internally to keep DOM and storage access injectable.
+
+## Challenges
+- The original examples implied the entry file owned environment construction, which conflicted with the requested inversion of control. Updating the snippets while keeping them concise required threading the builder pattern through both server and browser sections.
+
+## Verification
+- Reviewed the markdown locally to confirm the inline examples compile conceptually and that the new core snippet reinforces the intended dependency injection contract.

--- a/notes/agents/2027-12-31-entry-core-vision-name-fix.md
+++ b/notes/agents/2027-12-31-entry-core-vision-name-fix.md
@@ -1,0 +1,3 @@
+# Entry/Core Vision Naming Alignment
+- Clarified the documentation examples after feedback that the dependency factories should keep their canonical names (`gcf`, `browser`).
+- Verified that the surrounding narrative still matches the codebase pattern so future readers see consistent naming across snippets.

--- a/notes/entry-core-dependency-vision.md
+++ b/notes/entry-core-dependency-vision.md
@@ -1,0 +1,86 @@
+# Entry/Core Dependency Injection Vision
+
+## Architectural Goals
+- Every deployment surface (Cloud Functions, CDN-hosted pages, admin tooling) should expose a single entry module that imports third-party or platform-specific dependencies and passes them into a pure core module.
+- Core modules live alongside their entry points, export a single factory or handler function, and depend only on the injected environment so they remain unit-testable and context-agnostic.
+- Dependency "bundles" such as `gcf` objects or `browserEnv` maps are the only approved way for core code to talk to Firebase, Express, DOM APIs, or other side-effectful services.
+- Whenever practical, pass dependency *factories* (e.g., `gcf`, `browser`) so the core module controls when the environment is materialized and can defer heavy setup until it is needed.
+
+## Current Progress
+- **Cloud Functions** already conform to the pattern. For example, `src/cloud/get-moderation-variant/index.js` imports Google Cloud dependencies from `get-moderation-variant-gcf.js`, prepares the Firebase + Express environment, and then delegates all logic to factories defined in `get-moderation-variant-core.js`.
+- The build pipeline copies both bridge and core modules for each function (see `src/build/copy-cloud.js`) so the deployment artifacts stay aligned with source structure.
+- **Browser entry points** (e.g. `src/browser/main.js`) have the right separation of concerns conceptually—runtime wiring is handled in the entry file, while behavior is sourced from `src/core/browser/*` modules such as `data.js`, `audio-controls.js`, and `beta.js`.
+
+## High-Level Changes to Pursue
+1. **Formalize Browser Bridges**
+   - Introduce explicit `*-browser.js` bridge files that gather DOM, storage, and fetch dependencies before invoking a `*-core.js` module.
+   - Update existing pages (`public/blog/index.html`, Dendrite static pages) so each script tag points at the new bridge file instead of directly importing scattered helpers.
+2. **Unify Dependency Containers**
+   - Define a shared contract for bridge objects (`gcf`, `browserEnv`) with documented shape via JSDoc typedefs in `src/core/types.js`.
+   - Replace ad-hoc imports inside core modules with injected utilities. For example, refactor `src/core/browser/data.js` to accept `{ fetch, loggers, storage }` rather than importing `fetch` or `localStorage` globally.
+3. **Strengthen Testing Hooks**
+   - Provide factory exports from each core module that accept a dependency bundle and return the operational handler. Example: `export function createHandleGetModerationVariant({ gcf }) { ... }`.
+   - Ensure Jest suites instantiate these factories with mock bundles to keep tests isolated from Firebase/DOM.
+
+## Concrete Examples
+
+```js
+// src/cloud/example-function/index.js
+import { gcf } from './example-function-gcf.js';
+import { registerExampleFunction } from './example-function-core.js';
+
+export const exampleFunction = registerExampleFunction(gcf);
+```
+
+```js
+// src/cloud/example-function-core.js
+export function registerExampleFunction(gcf) {
+  const { functions, express } = gcf();
+  const app = express();
+
+  app.get('/', (req, res) => {
+    res.send('hello from the injected world');
+  });
+
+  return functions.https.onRequest(app);
+}
+```
+
+```js
+// src/browser/example-page-browser.js
+import { browser } from './browser-dependencies.js';
+import { createExamplePage } from '../core/browser/example-page-core.js';
+
+createExamplePage(browser);
+```
+
+```js
+// src/core/browser/example-page-core.js
+export function createExamplePage(browser) {
+  const { dom, fetch, storage } = browser();
+
+  // use injected dependencies instead of globals
+  fetch('/api/example')
+    .then((response) => response.json())
+    .then((data) => {
+      storage.setItem('example-data', JSON.stringify(data));
+      dom.querySelector('#example').textContent = data.message;
+    });
+}
+```
+
+```js
+// src/browser/browser-dependencies.js
+export function browser() {
+  return {
+    dom: document,
+    fetch,
+    storage: window.localStorage,
+  };
+}
+```
+
+## Next Steps
+- Audit every existing entry file under `src/cloud/*/index.js` and `src/browser/*.js` to document the dependencies they pass so the `*-core.js` layer can expose a consistent signature.
+- Update developer docs (e.g. `README.md`, `CLAUDE.md`) once the bridge/core naming convention is standardized.
+- Add lint rules or codemods that flag direct third-party imports inside `src/core/**` to enforce dependency injection over time.


### PR DESCRIPTION
## Summary
- rename the dependency factory examples in the entry/core architecture note to use the canonical `gcf` and `browser` identifiers
- record the clarification in the agent worklog for future reference

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_6900db65c210832e92f5f173c0bb14cf