### PR TITLE
Add JSDoc params to re-exports test helper

### DIFF
--- a/notes/agents/2025-07-06-reexports-jsdoc-params.md
+++ b/notes/agents/2025-07-06-reexports-jsdoc-params.md
@@ -1,0 +1,6 @@
+# Re-exports test JSDoc params
+
+- **Hurdle:** The lint run sprayed hundreds of pre-existing warnings, which made it tricky to confirm whether our target test picked up new issues. I double-checked the eslint output to ensure nothing referenced the re-exports test specifically before proceeding.
+- **Approach:** After updating the helper's comment with explicit `@param` annotations and a short description, I reran `npm run lint`. The output still included the usual complexity warnings elsewhere, but no mentions of the re-exports test, confirming the fix.
+- **Takeaway:** When looking for lint regressions in this repo, search the report for the exact path you're touching rather than expecting a clean run—historic complexity warnings are normal noise.
+- **Follow-up question:** Would it be worth scripting a filtered lint step that focuses on the touched files so contributors can spot relevant issues faster?

--- a/test/core/toys/2025-07-05/reExports.test.js
+++ b/test/core/toys/2025-07-05/reExports.test.js
@@ -6,9 +6,10 @@ import * as reExportedValidation from '../../../../src/core/toys/2025-07-05/vali
 
 describe('add dendrite page re-exports', () => {
   /**
+   * Assert that the exports from a re-exported module match the base module.
    *
-   * @param baseModule
-   * @param reExportedModule
+   * @param {Record<string, unknown>} baseModule - The canonical module whose exports serve as the baseline.
+   * @param {Record<string, unknown>} reExportedModule - The module under test that should mirror the base exports.
    */
   function expectModuleExportsToMatch(baseModule, reExportedModule) {
     const baseKeys = Object.keys(baseModule).sort();


### PR DESCRIPTION
## Summary
- add JSDoc @param annotations with types and descriptions to the re-exports test helper
- capture the lint-noise context in a new agent retrospective note

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_69036619b384832e89aabd13f6981000