### PR TITLE
Fix get API key credit create-db copy source

### DIFF
--- a/notes/agents/2026-02-15-create-db-import-fix.md
+++ b/notes/agents/2026-02-15-create-db-import-fix.md
@@ -1,0 +1,12 @@
+# Cloud function create-db import rewrite
+
+- **Surprise:** The legacy `get-api-key-credit` function's generated bundle only contains its own directory, so the `create-db.js`
+  re-export pointing at `../get-api-key-credit-v2/create-db.js` broke once Terraform deployed it. Locally the module graph works
+  because the core files live side-by-side. I assumed the build step would keep that layout for the Cloud Function too.
+- **Diagnosis:** The Terraform error log showed the module resolution jumping to `/get-api-key-credit-v2/create-db.js`, which
+  happens when the relative import walks above `/workspace`. Inspecting the generated `infra/cloud-functions/get-api-key-credit`
+  folder confirmed it only held the re-export stub with no sibling directory.
+- **Resolution:** Instead of teaching the function to reach across directories, I updated `src/build/copy-cloud.js` so the v1
+  function copies the v2 `create-db` implementation directly. That keeps both bundles in sync without new rewrite rules.
+- **Next time:** When sharing helpers between Cloud Functions, double-check how the archive is assembled (see
+  `src/build/copy-cloud.js`) to avoid assuming other directories ship together.

--- a/src/build/copy-cloud.js
+++ b/src/build/copy-cloud.js
@@ -157,7 +157,7 @@ const getApiKeyCreditCoreSource = join(
 );
 const getApiKeyCreditCreateDbSource = join(
   srcCoreCloudDir,
-  'get-api-key-credit',
+  'get-api-key-credit-v2',
   'create-db.js'
 );
 const getApiKeyCreditValidationSource = join(srcCoreDir, 'validation.js');


### PR DESCRIPTION
## Summary
- adjust the cloud build script so the get-api-key-credit function copies the shared create-db implementation from the v2 core module
- document the troubleshooting surprise and resolution in a new agent note

## Testing
- npm run build:cloud

------
https://chatgpt.com/codex/tasks/task_e_6904a7ef9538832ea50ba5d26f98392c