### PR TITLE
Add Cozy House Adventure toy and publish entry

### DIFF
--- a/docs/toys/cozy-house-adventure/acceptance.md
+++ b/docs/toys/cozy-house-adventure/acceptance.md
@@ -1,0 +1,16 @@
+# Cozy House Adventure Acceptance
+
+## Machine-Checkable Criteria
+- [ ] `npm test -- --watchman=false --runInBand test/toys/2026-04-19/cozyHouseAdventure.test.js` exits with status 0.
+- [ ] `npm run lint` exits with status 0 and reports no lint warnings for new toy files.
+- [ ] `npm run check` exits with status 0.
+
+## Evidence Collection
+- Command log path: terminal transcript for this loop.
+- Generated artifacts:
+  - N/A (text adventure toy only).
+- Test report path (if applicable): Jest stdout coverage report.
+
+## Pass/Fail Rules
+- Pass when all checklist commands succeed with no warnings/errors in output.
+- Fail when any command exits non-zero or reports unresolved warnings/errors.

--- a/docs/toys/cozy-house-adventure/failure-modes.md
+++ b/docs/toys/cozy-house-adventure/failure-modes.md
@@ -1,0 +1,33 @@
+# Cozy House Adventure Failure Modes
+
+## Initial Predicted Failure Classes
+- Setup/configuration mismatch:
+  - Missing env dependencies (`getData`, `setLocalTemporaryData`, etc.).
+- Invalid or missing inputs:
+  - Player enters unrelated text while in a stage and cannot progress.
+- Dependency/service unavailable:
+  - Not applicable (no network/service calls).
+- Non-deterministic timing or ordering:
+  - Random flavor line can appear/disappear based on `getRandomNumber`.
+- Environment-specific behavior:
+  - Time stamp string format varies by `getCurrentTime` provider.
+
+## Detection Signals
+- Error signatures/log lines:
+  - `SYSTEM ERROR: fireplace smoke in the command line`.
+- Observable symptoms:
+  - Toy repeatedly prompts for command and never advances.
+- Failing command(s):
+  - `npm test -- --watchman=false --runInBand test/toys/2026-04-19/cozyHouseAdventure.test.js`
+
+## First-Response Playbook
+1. Confirm state writes under `temporary.COZY1` include `name`, `state`, `inventory`, and `progress`.
+2. Re-run targeted toy tests and inspect expected command prompts for each stage.
+3. If dependency lookup fails, validate env map keys against required names.
+
+## Promoted from Real Failures
+- Date: 2026-04-19
+- Failure observed: None during initial implementation loop.
+- Root cause: N/A.
+- Fix implemented: N/A.
+- Guardrail added (test/doc/harness): Added focused Jest suite for start/build/completion/error paths.

--- a/docs/toys/cozy-house-adventure/harness.md
+++ b/docs/toys/cozy-house-adventure/harness.md
@@ -1,0 +1,21 @@
+# Cozy House Adventure Harness
+
+## Local Run Instructions
+1. Install prerequisites: `npm install`
+2. Prepare fixtures/config: `npm run build`
+3. Run harness command: `npm test -- --watchman=false --runInBand test/toys/2026-04-19/cozyHouseAdventure.test.js`
+
+## Expected Observable Outputs
+- Terminal output should include:
+  - `PASS test/toys/2026-04-19/cozyHouseAdventure.test.js`
+  - `cozyHouseAdventure`
+- Artifacts written to:
+  - `coverage/lcov-report/index.html`
+  - `coverage/coverage-summary.json`
+- Exit code:
+  - `0`
+
+## Troubleshooting Hooks
+- Verbose mode command: `npm test -- --watchman=false --runInBand --verbose test/toys/2026-04-19/cozyHouseAdventure.test.js`
+- Log location: terminal stdout.
+- Cleanup command: `rm -rf coverage`

--- a/docs/toys/cozy-house-adventure/spec.md
+++ b/docs/toys/cozy-house-adventure/spec.md
@@ -1,0 +1,41 @@
+# Cozy House Adventure Spec
+
+## Summary
+- Toy name: Cozy House Adventure (`COZY1`)
+- Owner: agent loop
+- Last updated: 2026-04-19
+
+## Problem Statement
+- Provide a relaxing text adventure toy that models tiny-house construction with small, readable command loops.
+
+## Boundary
+- Exercises the browser toy text-adventure contract: text input + environment map in, narrative text out, temporary state persisted by toy key.
+
+## Scope
+- In scope:
+  - Name capture and start prompt.
+  - Multi-step build loop for foundation/materials/roof/garden.
+  - Temporary progression persistence under `temporary.COZY1`.
+- Out of scope:
+  - New UI presenters.
+  - Multiplayer state.
+  - Persisting game progress to permanent storage.
+
+## Actors and Interfaces
+- Primary actor(s): blog reader using the toy form.
+- Inputs: free-text commands such as `build`, `foundation`, `level soil`, `plant herbs`.
+- Outputs: narrative response strings and progress prompts.
+
+## Assumptions and Constraints
+- Assumptions:
+  - Runtime provides `getData`, `setLocalTemporaryData`, `getCurrentTime`, and `getRandomNumber`.
+- Constraints:
+  - Toy must remain synchronous and return text.
+  - State key must not collide with existing toy keys.
+
+## Dependencies
+- Internal dependencies:
+  - `public/blog.json` toy registration.
+  - Jest toy test suite under `test/toys/2026-04-19`.
+- External dependencies:
+  - None.

--- a/notes/agents/2026-04-19-cozy-house-adventure.md
+++ b/notes/agents/2026-04-19-cozy-house-adventure.md
@@ -1,0 +1,6 @@
+# 2026-04-19 — Cozy house adventure toy + check cleanup
+
+- Unexpected hurdle: creating a new text-adventure toy by cloning the cyberpunk file would risk triggering duplication checks in `npm run check`.
+- Diagnosis path: reviewed current toy and check scripts, then designed a smaller state machine with distinct command flow and wording.
+- Chosen fix: implemented a fresh `cozyHouseAdventure` module with lightweight handlers and added focused Jest coverage for progression, completion, random flavor line, and dependency errors.
+- Next-time guidance: for “similar toy” requests, prefer reusing the same interface contract while changing structure and command vocabulary to keep duplication tooling green.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10942,9 +10942,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.3.tgz",
-      "integrity": "sha512-sildjKwVqOI2kmFDiXQ6aEB0fjYTafpEvIBs8tOR8qI4spuL9OPROLVu2qZqi/xgCfsHIwVqlaF8JBjWFHnKbw==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",

--- a/public/blog.json
+++ b/public/blog.json
@@ -1,6 +1,26 @@
 {
   "posts": [
     {
+      "key": "COZY1",
+      "title": "Cozy House Adventure",
+      "publicationDate": "2026-04-19",
+      "content": [
+        "A cozy text adventure where you build a tiny house one warm task at a time.",
+        "Start with `build`, then rotate through foundation, materials, roof, and garden commands to complete your home.",
+        "Progress is stored in temporary toy state so each command continues the same construction run."
+      ],
+      "illustration": {
+        "fileType": "png",
+        "fileName": "2025-03-30",
+        "altText": "a warm illustrated tiny house build site at dusk with stacked timber, herb planters, soft lantern light, and a calm cottagecore atmosphere"
+      },
+      "toy": {
+        "modulePath": "/core/browser/toys/2026-04-19/cozyHouseAdventure.js",
+        "functionName": "cozyHouseAdventure"
+      },
+      "tags": ["toy", "game", "text-adventure", "cozy", "construction"]
+    },
+    {
       "key": "REAL1",
       "title": "Real Hourly Wage",
       "publicationDate": "2026-04-03",

--- a/src/core/browser/toys/2026-04-19/cozyHouseAdventure.js
+++ b/src/core/browser/toys/2026-04-19/cozyHouseAdventure.js
@@ -1,0 +1,480 @@
+/**
+ * Cozy state names supported by the text adventure.
+ * @typedef {'intro'|'yard'|'foundation'|'materials'|'roof'|'garden'} CozyState
+ */
+
+/**
+ * Saved per-player state for this toy.
+ * @typedef {object} CozyScopedState
+ * @property {string} [name] Player name captured on first command.
+ * @property {CozyState} [state] Last persisted story state.
+ * @property {string[]} [inventory] Collected cozy items and milestones.
+ * @property {string[]} [progress] Completed construction milestones.
+ */
+
+/**
+ * Data envelope returned by `getData`.
+ * @typedef {object} CozyDataEnvelope
+ * @property {{COZY1?: CozyScopedState}} [temporary] Temporary storage bucket.
+ */
+
+/**
+ * Environment map passed to toys.
+ * @typedef {Map<'getRandomNumber'|'getCurrentTime'|'getData'|'setLocalTemporaryData', Function>} CozyEnvironment
+ */
+
+/**
+ * Runtime context used while processing one command.
+ * @typedef {object} CozyRuntimeContext
+ * @property {string} name Player name.
+ * @property {CozyState} state Current state.
+ * @property {string} lowerInput Normalized lowercase input.
+ * @property {string[]} inventory Current inventory copy.
+ * @property {string[]} progress Current progress copy.
+ * @property {() => string} getCurrentTime Current time provider.
+ * @property {() => number} getRandomNumber Random provider.
+ * @property {(data: CozyDataEnvelope) => void} setLocalTemporaryData Temporary state writer.
+ */
+
+const COZY_KEY = 'COZY1';
+
+const BUILD_REQUIREMENTS = {
+  foundation: {
+    command: 'level soil',
+    prompt:
+      '> You mark out the footprint and set cedar beams. Type `level soil` to finish the foundation.',
+    reward: 'The foundation settles perfectly and smells like fresh cedar.',
+  },
+  materials: {
+    command: 'pack insulation',
+    prompt:
+      '> You check the supply wagon. Type `pack insulation` to stock cozy materials.',
+    reward:
+      'You stack wool insulation, linen curtains, and reclaimed pine flooring.',
+  },
+  roof: {
+    command: 'lay shingles',
+    prompt: '> You climb the scaffold. Type `lay shingles` to finish the roof.',
+    reward: 'The roof clicks into place, and rain now sounds soft and musical.',
+  },
+  garden: {
+    command: 'plant herbs',
+    prompt:
+      '> You kneel beside raised beds. Type `plant herbs` to complete the garden.',
+    reward:
+      'Mint, thyme, and lavender line the windows beneath the porch rail.',
+  },
+};
+
+const REQUIRED_STAGES = ['foundation', 'materials', 'roof', 'garden'];
+
+/**
+ * Read a required helper from the environment map.
+ * @template {Function} T
+ * @param {CozyEnvironment} env Environment map from toy runtime.
+ * @param {'getRandomNumber'|'getCurrentTime'|'getData'|'setLocalTemporaryData'} key Dependency name.
+ * @param {string} label Human-readable dependency label.
+ * @returns {T} Retrieved helper function.
+ */
+function requireEnvFunction(env, key, label) {
+  const dependency = /** @type {T | undefined} */ (env.get(key));
+  if (!dependency) {
+    throw new Error(`Missing ${label} dependency for cozy house adventure.`);
+  }
+
+  return dependency;
+}
+
+/**
+ * Resolve the COZY1 state bucket from the env data object.
+ * @param {CozyDataEnvelope} data Toy data envelope.
+ * @returns {CozyScopedState} Saved state for this toy.
+ */
+function getScopedState(data) {
+  if (!data.temporary) {
+    return {};
+  }
+
+  return getTemporaryState(data.temporary);
+}
+
+/**
+ * Resolve the scoped toy state from the temporary bucket.
+ * @param {{COZY1?: CozyScopedState}} temporary Temporary storage bucket.
+ * @returns {CozyScopedState} Saved state for this toy.
+ */
+function getTemporaryState(temporary) {
+  if (!temporary[COZY_KEY]) {
+    return {};
+  }
+
+  return temporary[COZY_KEY];
+}
+
+/**
+ * Build the first message shown to a new player.
+ * @param {string} name Player name.
+ * @returns {string} Introductory narrative.
+ */
+function introMessage(name) {
+  return [
+    `> Welcome home, ${name}.`,
+    '> A gentle rain taps the porch while your tiny-house project waits in the yard.',
+    "> Type 'build' when you're ready to start laying out your cozy home.",
+  ].join('\n');
+}
+
+/**
+ * Build the yard command hub message.
+ * @param {string} time Current time string.
+ * @returns {string} Hub prompt text.
+ */
+function yardMessage(time) {
+  return [
+    `> ${time} — You stand in the yard with tea in hand and a warm checklist.`,
+    '> Next tasks: foundation / materials / roof / garden.',
+    '> What would you like to do?',
+  ].join('\n');
+}
+
+/**
+ * Determine the stage command selected while in the yard.
+ * @param {string} lowerInput Normalized command text.
+ * @returns {CozyState|'yard'} Selected stage name or `yard` when no match exists.
+ */
+function resolveYardSelection(lowerInput) {
+  const stages = Object.keys(BUILD_REQUIREMENTS);
+  const match = stages.find(stage => lowerInput.includes(stage));
+  if (!match) {
+    return 'yard';
+  }
+
+  return /** @type {CozyState} */ (match);
+}
+
+/**
+ * Handle commands entered while the player is at the yard hub.
+ * @param {CozyRuntimeContext} context Runtime context.
+ * @returns {{output: string, state: CozyState, inventory: string[], progress: string[]}} Story transition payload.
+ */
+function handleYard(context) {
+  const selection = resolveYardSelection(context.lowerInput);
+  if (selection === 'yard') {
+    return {
+      output: '> The plan is simple: foundation / materials / roof / garden.',
+      state: 'yard',
+      inventory: context.inventory,
+      progress: context.progress,
+    };
+  }
+
+  return {
+    output: BUILD_REQUIREMENTS[selection].prompt,
+    state: selection,
+    inventory: context.inventory,
+    progress: context.progress,
+  };
+}
+
+/**
+ * Add a completed stage to inventory and progress when missing.
+ * @param {{inventory: string[], progress: string[]}} value Existing state lists.
+ * @param {string} stage Stage name to add.
+ * @returns {{inventory: string[], progress: string[]}} Updated state lists.
+ */
+function addCompletedStage(value, stage) {
+  const nextInventory = appendIfMissing(value.inventory, stage);
+  const nextProgress = appendIfMissing(value.progress, stage);
+
+  return { inventory: nextInventory, progress: nextProgress };
+}
+
+/**
+ * Return a copied array with the item appended only when missing.
+ * @param {string[]} list Existing list value.
+ * @param {string} item Item to ensure exists.
+ * @returns {string[]} Updated list copy.
+ */
+function appendIfMissing(list, item) {
+  const next = [...list];
+  if (!next.includes(item)) {
+    next.push(item);
+  }
+
+  return next;
+}
+
+/**
+ * Determine whether all construction milestones are complete.
+ * @param {string[]} progress Completed milestones.
+ * @returns {boolean} True when all required stages are complete.
+ */
+function isHouseComplete(progress) {
+  return REQUIRED_STAGES.every(stage => progress.includes(stage));
+}
+
+/**
+ * Build the completion status line shown after a successful stage command.
+ * @param {string[]} progress Completed milestones.
+ * @returns {string} Completion status message.
+ */
+function getCompletionLine(progress) {
+  if (isHouseComplete(progress)) {
+    return '> The tiny house glows with lantern light. You built a peaceful home!';
+  }
+
+  return '> Nice work. Return to the yard for the next cozy task.';
+}
+
+/**
+ * Handle a single construction stage.
+ * @param {CozyRuntimeContext} context Runtime context.
+ * @param {'foundation'|'materials'|'roof'|'garden'} stage Stage name.
+ * @returns {{output: string, state: CozyState, inventory: string[], progress: string[]}} Story transition payload.
+ */
+function handleBuildStage(context, stage) {
+  const requirement = BUILD_REQUIREMENTS[stage];
+  if (!context.lowerInput.includes(requirement.command)) {
+    return {
+      output: `> Not quite. Try \`${requirement.command}\` to finish ${stage}.`,
+      state: stage,
+      inventory: context.inventory,
+      progress: context.progress,
+    };
+  }
+
+  const updated = addCompletedStage(context, stage);
+  return {
+    output: `> ${requirement.reward}\n${getCompletionLine(updated.progress)}`,
+    state: 'yard',
+    inventory: updated.inventory,
+    progress: updated.progress,
+  };
+}
+
+/**
+ * Build a runtime context object from scoped saved state and env functions.
+ * @param {string} input Raw player input.
+ * @param {CozyScopedState} scoped Saved toy state.
+ * @param {CozyEnvironment} env Environment map.
+ * @returns {CozyRuntimeContext} Prepared runtime context.
+ */
+function createRuntimeContext(input, scoped, env) {
+  const getCurrentTime = /** @type {() => string} */ (
+    requireEnvFunction(env, 'getCurrentTime', 'time provider')
+  );
+  const getRandomNumber = /** @type {() => number} */ (
+    requireEnvFunction(env, 'getRandomNumber', 'random number generator')
+  );
+  const setLocalTemporaryData =
+    /** @type {(data: CozyDataEnvelope) => void} */ (
+      requireEnvFunction(env, 'setLocalTemporaryData', 'temporary state setter')
+    );
+  const name = getPlayerName(scoped, input);
+  const state = getPlayerState(scoped);
+
+  return {
+    name,
+    state,
+    lowerInput: input.trim().toLowerCase(),
+    inventory: [...getStoredList(scoped.inventory)],
+    progress: [...getStoredList(scoped.progress)],
+    getCurrentTime,
+    getRandomNumber,
+    setLocalTemporaryData,
+  };
+}
+
+/**
+ * Resolve a player name using saved state and command input.
+ * @param {CozyScopedState} scoped Saved toy state.
+ * @param {string} input Raw player input.
+ * @returns {string} Resolved player name.
+ */
+function getPlayerName(scoped, input) {
+  return scoped.name || getInputName(input);
+}
+
+/**
+ * Resolve a player name directly from command input with fallback.
+ * @param {string} input Raw player input.
+ * @returns {string} Name resolved from input.
+ */
+function getInputName(input) {
+  const trimmed = input.trim();
+  if (trimmed) {
+    return trimmed;
+  }
+
+  return 'Builder';
+}
+
+/**
+ * Resolve the active player state.
+ * @param {CozyScopedState} scoped Saved toy state.
+ * @returns {CozyState} Active state value.
+ */
+function getPlayerState(scoped) {
+  if (!scoped.state) {
+    return 'intro';
+  }
+
+  return scoped.state;
+}
+
+/**
+ * Return a safe stored string list.
+ * @param {string[] | undefined} items Optional saved list.
+ * @returns {string[]} Normalized array value.
+ */
+function getStoredList(items) {
+  if (!items) {
+    return [];
+  }
+
+  return items;
+}
+
+/**
+ * Persist the toy runtime context after a transition.
+ * @param {CozyRuntimeContext} context Runtime context.
+ * @param {{state: CozyState, inventory: string[], progress: string[]}} result Transition result to save.
+ * @returns {void}
+ */
+function persistTransition(context, result) {
+  context.setLocalTemporaryData({
+    temporary: {
+      [COZY_KEY]: {
+        name: context.name,
+        state: result.state,
+        inventory: result.inventory,
+        progress: result.progress,
+      },
+    },
+  });
+}
+
+/**
+ * Persist first-visit state and return intro text.
+ * @param {CozyRuntimeContext} context Runtime context.
+ * @returns {string} Intro message.
+ */
+function handleFirstVisit(context) {
+  persistTransition(context, {
+    state: 'intro',
+    inventory: context.inventory,
+    progress: context.progress,
+  });
+
+  return introMessage(context.name);
+}
+
+/**
+ * Handle commands while state is `intro`.
+ * @param {CozyRuntimeContext} context Runtime context.
+ * @returns {string} Intro state response text.
+ */
+function handleIntroState(context) {
+  if (!context.lowerInput.includes('build')) {
+    return "> When you're ready, type 'build' to begin your house project.";
+  }
+
+  persistTransition(context, {
+    state: 'yard',
+    inventory: ['tea thermos'],
+    progress: context.progress,
+  });
+  return yardMessage(context.getCurrentTime());
+}
+
+/**
+ * Select a state handler for the active state.
+ * @param {CozyState} state Active state.
+ * @returns {(context: CozyRuntimeContext) => {output: string, state: CozyState, inventory: string[], progress: string[]}} Handler function.
+ */
+function getStateHandler(state) {
+  const handlers = {
+    yard: handleYard,
+    foundation: context => handleBuildStage(context, 'foundation'),
+    materials: context => handleBuildStage(context, 'materials'),
+    roof: context => handleBuildStage(context, 'roof'),
+    garden: context => handleBuildStage(context, 'garden'),
+    intro: handleYard,
+  };
+
+  return handlers[state] || handleYard;
+}
+
+/**
+ * Build optional random flavor text.
+ * @param {number} randomValue Value from random provider.
+ * @returns {string} Flavor suffix text.
+ */
+function getBonusText(randomValue) {
+  if (randomValue > 0.8) {
+    return '\n> A robin lands nearby and approves of your craftsmanship.';
+  }
+
+  return '';
+}
+
+/**
+ * Run non-intro state transition and persist results.
+ * @param {CozyRuntimeContext} context Runtime context.
+ * @returns {string} Transition output text.
+ */
+function runStateTransition(context) {
+  const handler = getStateHandler(context.state);
+  const result = handler(context);
+  persistTransition(context, result);
+
+  const bonus = getBonusText(context.getRandomNumber());
+  return `${result.output}${bonus}`;
+}
+
+/**
+ * Process one command with already-known player state.
+ * @param {CozyRuntimeContext} context Runtime context.
+ * @returns {string} Output text.
+ */
+function processKnownPlayer(context) {
+  if (context.state === 'intro') {
+    return handleIntroState(context);
+  }
+
+  return runStateTransition(context);
+}
+
+/**
+ * Core adventure processor.
+ * @param {string} input Raw player command.
+ * @param {CozyEnvironment} env Environment helper map.
+ * @returns {string} Output narrative.
+ */
+function runAdventure(input, env) {
+  const getData = /** @type {() => CozyDataEnvelope} */ (
+    requireEnvFunction(env, 'getData', 'state accessor')
+  );
+  const scoped = getScopedState(getData());
+  const context = createRuntimeContext(input, scoped, env);
+
+  if (!scoped.name) {
+    return handleFirstVisit(context);
+  }
+
+  return processKnownPlayer(context);
+}
+
+/**
+ * Cozy house construction themed text adventure toy.
+ * @param {string} input Player command.
+ * @param {CozyEnvironment} env Environment helper map.
+ * @returns {string} Narrative response text.
+ */
+export function cozyHouseAdventure(input, env) {
+  try {
+    return runAdventure(input, env);
+  } catch {
+    return '> SYSTEM ERROR: fireplace smoke in the command line';
+  }
+}

--- a/test/toys/2026-04-19/cozyHouseAdventure.test.js
+++ b/test/toys/2026-04-19/cozyHouseAdventure.test.js
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, test } from '@jest/globals';
+import { cozyHouseAdventure } from '../../../src/core/browser/toys/2026-04-19/cozyHouseAdventure.js';
+
+describe('cozyHouseAdventure', () => {
+  let tempData;
+  let env;
+
+  beforeEach(() => {
+    tempData = {};
+    env = new Map([
+      ['getRandomNumber', () => 0.1],
+      ['getCurrentTime', () => '07:15'],
+      ['getData', () => ({ temporary: { COZY1: tempData } })],
+      [
+        'setLocalTemporaryData',
+        data => {
+          tempData = { ...tempData, ...data.temporary?.COZY1 };
+        },
+      ],
+    ]);
+  });
+
+  test('welcomes player and prompts to begin build', () => {
+    const result = cozyHouseAdventure('Rowan', env);
+
+    expect(result).toMatch(/Welcome home, Rowan/);
+    expect(tempData.name).toBe('Rowan');
+    expect(tempData.state).toBe('intro');
+  });
+
+  test('starts build loop and visits a construction station', () => {
+    cozyHouseAdventure('Rowan', env);
+
+    const yard = cozyHouseAdventure('build', env);
+    const station = cozyHouseAdventure('foundation', env);
+
+    expect(yard).toMatch(
+      /Next tasks: foundation \/ materials \/ roof \/ garden/
+    );
+    expect(station).toMatch(/Type `level soil`/);
+    expect(tempData.state).toBe('foundation');
+    expect(tempData.inventory).toContain('tea thermos');
+  });
+
+  test('completes all build stages and records progress', () => {
+    cozyHouseAdventure('Rowan', env);
+    cozyHouseAdventure('build', env);
+
+    cozyHouseAdventure('foundation', env);
+    cozyHouseAdventure('level soil', env);
+
+    cozyHouseAdventure('materials', env);
+    cozyHouseAdventure('pack insulation', env);
+
+    cozyHouseAdventure('roof', env);
+    cozyHouseAdventure('lay shingles', env);
+
+    cozyHouseAdventure('garden', env);
+    const ending = cozyHouseAdventure('plant herbs', env);
+
+    expect(ending).toMatch(/You built a peaceful home/);
+    expect(tempData.progress).toEqual([
+      'foundation',
+      'materials',
+      'roof',
+      'garden',
+    ]);
+    expect(tempData.inventory).toEqual(
+      expect.arrayContaining(['foundation', 'materials', 'roof', 'garden'])
+    );
+    expect(tempData.state).toBe('yard');
+  });
+
+  test('adds random cozy bonus line when random check passes', () => {
+    cozyHouseAdventure('Rowan', env);
+    cozyHouseAdventure('build', env);
+    env.set('getRandomNumber', () => 0.95);
+
+    const result = cozyHouseAdventure('materials', env);
+
+    expect(result).toMatch(/A robin lands nearby/);
+  });
+
+  test('returns system error when dependencies fail', () => {
+    env.delete('getData');
+
+    const result = cozyHouseAdventure('anything', env);
+
+    expect(result).toMatch(/SYSTEM ERROR: fireplace smoke in the command line/);
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide a cozy, house-construction themed text-adventure toy (text-in / text-out) that follows the existing toy contract and complements the existing Cyberpunk adventure with new commands and state.
- Ship the toy as a published blog toy (so it appears on the site) and include full local docs/harness so future loops can reproduce and extend the work.
- Ensure the repository quality gates pass (`npm run check`) by keeping the implementation distinct (to avoid duplication flags) and resolving any lint/audit warnings.

### Description
- Added a new toy implementation at `src/core/browser/toys/2026-04-19/cozyHouseAdventure.js` that implements a small state machine (intro → yard → foundation/materials/roof/garden), persists temporary state under `temporary.COZY1`, and returns narrative strings; exported `cozyHouseAdventure` as the toy entry function.
- Published the toy in `public/blog.json` with key `COZY1` and appropriate metadata so it is discoverable by the site loader.
- Added focused Jest tests at `test/toys/2026-04-19/cozyHouseAdventure.test.js` covering naming/intro, stage navigation, full completion, random bonus branch, and dependency-failure behavior.
- Added the per-toy docs copied from the template under `docs/toys/cozy-house-adventure/` (`spec.md`, `acceptance.md`, `failure-modes.md`, `harness.md`) and an agent retrospective note at `notes/agents/2026-04-19-cozy-house-adventure.md`.
- Performed small refactors (extracted helpers, trimmed complexity and parameter counts, added small JSDoc clarifications) to resolve lint warnings and ran `npm audit fix` to bump a transient dependency in `package-lock.json` so the `check` script reports no outstanding issues.

### Testing
- Ran the unit/test and quality command suite and all steps passed:
  - `npm test -- --watchman=false --runInBand` — full Jest suite (all tests passed).
  - `npm run lint` — ESLint run with `--fix` produced no outstanding warnings for the changes.
  - `npm run depcruise` — dependency cruiser reported no violations.
  - `npm run duplication` — duplication scan completed and generated reports with no blocking issues for the toy.
  - `npm audit fix` — fixed the protobufjs advisory and removed the audit warning.
  - `npm run check` — ran the composed check (`test`, `lint`, `depcruise`, `duplication`, `audit`) and completed successfully.
- Evidence and artifacts: new files (`src/core/browser/toys/2026-04-19/cozyHouseAdventure.js`, `test/toys/2026-04-19/cozyHouseAdventure.test.js`, `docs/toys/cozy-house-adventure/*`, `notes/agents/2026-04-19-cozy-house-adventure.md`, `public/blog.json`) and the updated `package-lock.json` with the `protobufjs` bump.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4a0b3f6b8832eb6b6a29c563cce54)