### PR TITLE
Add COZY1 toy metadata to blog.json

### DIFF
--- a/notes/agents/2026-04-19-cozy1-blog-entry.md
+++ b/notes/agents/2026-04-19-cozy1-blog-entry.md
@@ -1,0 +1,6 @@
+# COZY1 blog.json registration
+
+- **Unexpected hurdle:** The repo workflow references `bd`, but the `bd` CLI is not installed in this container.
+- **Diagnosis path:** Ran `bd prime` first to follow loop workflow; shell returned `bd: command not found`.
+- **Chosen fix:** Proceeded with the bounded content update by adding the COZY1 post metadata directly to `src/build/blog.json`.
+- **Next-time guidance:** Install or document `bd` bootstrap steps in repo setup so loop evidence can be recorded consistently in bead comments.

--- a/src/build/blog.json
+++ b/src/build/blog.json
@@ -1,6 +1,22 @@
 {
   "posts": [
     {
+      "key": "COZY1",
+      "title": "Cozy House Adventure",
+      "publicationDate": "2026-04-19",
+      "content": [
+        "A stateful text adventure where you build a tiny cozy home by completing foundation, materials, roof, and garden milestones.",
+        "The toy saves progress in temporary local storage so each command continues from your current construction step.",
+        "Play by entering simple commands like build, foundation, and level soil; the response returns narrative output plus completion updates."
+      ],
+      "toy": {
+        "modulePath": "/core/browser/toys/2026-04-19/cozyHouseAdventure.js",
+        "functionName": "cozyHouseAdventure",
+        "defaultInputMethod": "textarea"
+      },
+      "tags": ["toy", "game", "text-adventure", "stateful", "storage"]
+    },
+    {
       "key": "REAL1",
       "title": "Real Hourly Wage",
       "publicationDate": "2026-04-03",


### PR DESCRIPTION
### Motivation
- Register the Cozy House Adventure toy in the blog/toys feed so the interactive toy is discoverable and linked to its runtime module and input method.
- Record an agent retrospective about a local environment limitation encountered while making the change.

### Description
- Add a `COZY1` post entry to `src/build/blog.json` containing `key`, `title`, `publicationDate`, descriptive `content`, `toy.modulePath`, `toy.functionName`, `toy.defaultInputMethod`, and `tags`.
- Add `notes/agents/2026-04-19-cozy1-blog-entry.md` documenting the missing `bd` CLI in this environment and the chosen workaround.

### Testing
- Ran `npm test` and all automated test suites passed (493 suites, 2494 tests) and coverage was generated successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5112421e4832ea3b5079edf523f0f)