### PR TITLE
Fix cloud build EISDIR by routing preserved tree copies as directories

### DIFF
--- a/notes/agents/2026-04-24-copy-cloud-eisdir.md
+++ b/notes/agents/2026-04-24-copy-cloud-eisdir.md
@@ -1,0 +1,6 @@
+# 2026-04-24 copy-cloud EISDIR fix
+
+- **Unexpected hurdle:** `npm run build:cloud` failed with `EISDIR` because a directory copy plan was routed through `individualFileCopies` (which uses `fs.copyFile`).
+- **Diagnosis path:** Confirmed `preservedCloudTreeCopies` entries were directory-shaped (`source: .../assign-moderation-job`) and were spread into `individualFileCopies` in `src/build/copy-cloud.js`.
+- **Chosen fix:** Removed `preservedCloudTreeCopies` from `individualFileCopies` and appended it to `directoryCopies` in the `runCopyToInfra` call.
+- **Next-time guidance:** Keep directory plans and file plans separated at call boundaries; if adding a new plan array, validate `source` type (`file` vs `directory`) before merging.

--- a/src/build/copy-cloud.js
+++ b/src/build/copy-cloud.js
@@ -1099,7 +1099,6 @@ const individualFileCopies = [
   ...functionSpecificCommonCoreCopies,
   ...sharedUtilityCopies,
   ...preservedSharedUtilityCopies,
-  ...preservedCloudTreeCopies,
   ...packageFileCopies,
 ];
 
@@ -1157,7 +1156,7 @@ async function rewriteImport(filePath, from, to) {
 }
 
 await runCopyToInfra({
-  directoryCopies,
+  directoryCopies: [...directoryCopies, ...preservedCloudTreeCopies],
   individualFileCopies,
   io,
   messageLogger: logger,


### PR DESCRIPTION
### Motivation
- The cloud build failed with `EISDIR` because directory-shaped copy plans (from `preservedCloudTreeCopies`) were ending up in the per-file copy list and `fs.copyFile` was called on a directory.
- Keep the staging/copy step robust by ensuring directory copy plans are handled by the directory copy path, not the individual-file path.

### Description
- Removed `preservedCloudTreeCopies` from the `individualFileCopies` merge so directory-shaped entries are no longer treated as individual file copies in `src/build/copy-cloud.js`.
- Added `preservedCloudTreeCopies` into the `directoryCopies` passed to `runCopyToInfra` (`directoryCopies: [...directoryCopies, ...preservedCloudTreeCopies]`) so those entries are handled as directories.
- Added a short agent retrospective note under `notes/agents/2026-04-24-copy-cloud-eisdir.md` describing the diagnosis and fix.

### Testing
- Ran `npm run build:cloud` and verified the copy step completes without `EISDIR` errors (build succeeded).
- Ran `npm run check` which executes the full test and quality pipeline; the test suites ran and all tests passed (493 test suites, 2494 tests) and the check completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb06b46080832e9166f9fcafeff2d5)