### PR TITLE
[codex] Fix GCP test bundle imports

### DIFF
--- a/infra/dendrite-firestore.tf
+++ b/infra/dendrite-firestore.tf
@@ -56,23 +56,6 @@ resource "google_firestore_index" "variants_moderation_rand" {
   depends_on = [google_firestore_database.database]
 }
 
-resource "google_firestore_field" "pages_all" {
-  provider   = google-beta
-  project    = var.project_id
-  database   = var.database_id
-  collection = "pages"
-  field      = "__name__"
-
-  index_config {
-    indexes {
-      order       = "ASCENDING"
-      query_scope = "COLLECTION_GROUP"
-    }
-  }
-
-  depends_on = [google_firestore_database.database]
-}
-
 # Supports: querying variants by moderatorReputationSum alone
 resource "google_firestore_field" "variants_moderation" {
   provider   = google-beta

--- a/src/core/cloud/copy.js
+++ b/src/core/cloud/copy.js
@@ -144,7 +144,7 @@ export function createCopyToInfraCore({
   }
 
   /**
-   * Copy every supported file from a directory into the target path.
+   * Copy every supported file from a directory tree into the target path.
    * @param {{ source: string, target: string }} copyPlan - Absolute source and target paths.
    * @param {{
    *   ensureDirectory: (target: string) => Promise<void>,
@@ -152,7 +152,7 @@ export function createCopyToInfraCore({
    *   copyFile: (source: string, destination: string) => Promise<void>,
    * }} io - Filesystem adapters.
    * @param {{ info: (message: string) => void }} messageLogger - Logger to report progress.
-   * @returns {Promise<void>} Resolves when the directory has been processed.
+   * @returns {Promise<void>} Resolves when the directory tree has been processed.
    */
   async function copyDirectory(copyPlan, io, messageLogger) {
     const { source, target } = copyPlan;
@@ -160,6 +160,7 @@ export function createCopyToInfraCore({
     const fileNames = sourceEntries
       .filter(isCopyableFile)
       .map(entry => entry.name);
+
     await copyFiles({
       files: fileNames,
       sourceDir: source,
@@ -167,6 +168,20 @@ export function createCopyToInfraCore({
       io,
       messageLogger,
     });
+
+    const directoryEntries = sourceEntries.filter(entry => entry.isDirectory());
+    await Promise.all(
+      directoryEntries.map(entry =>
+        copyDirectory(
+          {
+            source: join(source, entry.name),
+            target: join(target, entry.name),
+          },
+          io,
+          messageLogger
+        )
+      )
+    );
   }
 
   /**

--- a/test/core/cloud/copy.test.js
+++ b/test/core/cloud/copy.test.js
@@ -73,7 +73,13 @@ describe('createCopyToInfraCore', () => {
       ];
       const io = {
         ensureDirectory: jest.fn().mockResolvedValue(undefined),
-        readDirEntries: jest.fn().mockResolvedValue(entries),
+        readDirEntries: jest.fn(dir =>
+          Promise.resolve(
+            dir.endsWith('/nested')
+              ? [createDirent('child.js'), createDirent('skip.txt')]
+              : entries
+          )
+        ),
         copyFile: jest.fn().mockResolvedValue(undefined),
       };
       const logger = { info: jest.fn() };
@@ -93,12 +99,15 @@ describe('createCopyToInfraCore', () => {
       expect(io.readDirEntries).toHaveBeenCalledWith(
         posix.join(projectRoot, 'functions')
       );
-      expect(io.copyFile).toHaveBeenCalledTimes(2);
+      expect(io.copyFile).toHaveBeenCalledTimes(3);
       expect(logger.info).toHaveBeenCalledWith(
         'Copied: functions/index.js -> infra/functions/index.js'
       );
       expect(logger.info).toHaveBeenCalledWith(
         'Copied: functions/config.json -> infra/functions/config.json'
+      );
+      expect(logger.info).toHaveBeenCalledWith(
+        'Copied: functions/nested/child.js -> infra/functions/nested/child.js'
       );
     });
 


### PR DESCRIPTION
## Summary

- remove the invalid Firestore `pages_all` field config for reserved `__name__`
- route preserved Cloud Function source-tree copies as directory copies
- make the Cloud Function copy helper recurse into nested source directories
- add test coverage for nested copy behavior

## Root Cause

`gcp-test` failed during Terraform apply because Firestore rejected the reserved `__name__` field config and several generated Cloud Function bundles omitted nested source-tree dependencies used by cross-function imports.

## Validation

- `npm run build:cloud`
- generated bundle import checks for `get-api-key-credit`, `process-new-story`, and `mark-variant-dirty`
- `git diff --check`
- `terraform -chdir=infra fmt -check -diff dendrite-firestore.tf`
- `node --experimental-vm-modules ./node_modules/.bin/jest --runTestsByPath test/core/cloud/copy.test.js test/core/cloud/copy-core.branch.test.js --runInBand`
- full Jest suite: 494 suites, 2,499 tests passed
