### PR TITLE
Add missing infra cloud wrapper for load-static-config-core

### DIFF
--- a/infra/load-static-config-core.js
+++ b/infra/load-static-config-core.js
@@ -1,0 +1,1 @@
+export * from '../core/browser/load-static-config-core.js';

--- a/notes/agents/2026-05-23-gcp-wrapper-entrypoint-fix.md
+++ b/notes/agents/2026-05-23-gcp-wrapper-entrypoint-fix.md
@@ -1,0 +1,4 @@
+- unexpected hurdle: `npm test` failed on `test/infra/cloudBrowserEntrypoints.test.js` because `infra/load-static-config-core.js` was missing while Terraform/test expectations still referenced it.
+- diagnosis path: ran full `npm test`, isolated the failure to ENOENT in the entrypoint wrapper assertion, then validated expected wrapper contents in the test file.
+- chosen fix: added `infra/load-static-config-core.js` as a root wrapper exporting `../core/browser/load-static-config-core.js` to match the existing root-wrapper upload pattern.
+- next-time guidance or open questions: when adding or renaming cloud browser entrypoints, update wrappers and infra upload manifests together and keep a small infra-focused Jest run in the loop before full suite.


### PR DESCRIPTION
### Motivation
- Fix an ENOENT failure in infra entrypoint tests by providing the expected root cloud-browser wrapper so infra upload and Terraform/test expectations align.

### Description
- Add `infra/load-static-config-core.js` that re-exports `../core/browser/load-static-config-core.js`, and add an agent retrospective note at `notes/agents/2026-05-23-gcp-wrapper-entrypoint-fix.md` documenting the diagnosis and fix.

### Testing
- Ran `node --experimental-vm-modules ./node_modules/.bin/jest --watchman=false test/infra/cloudBrowserEntrypoints.test.js`, which passed; ran `npm test`, which executed all test suites (518 suites, 2627 tests) and all tests passed but the overall `npm test` process exits non-zero due to global coverage thresholds not meeting 100% (branches 99.65%, lines 99.61%, functions 99.91%).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11a2f98400832eb28ec2dfac9e6f20)