### PR TITLE
Refactor submit-moderation-rating into core wiring and remove non-core exemption

### DIFF
--- a/non-core-thin-exemptions.json
+++ b/non-core-thin-exemptions.json
@@ -23,7 +23,6 @@
     "src/cloud/realtime-call/index.js": "Baseline non-core file over 50 lines; move logic into src/core incrementally.",
     "src/cloud/render-contents/index.js": "Baseline non-core file over 50 lines; move logic into src/core incrementally.",
     "src/cloud/render-variant/index.js": "Baseline non-core file over 50 lines; move logic into src/core incrementally.",
-    "src/cloud/submit-moderation-rating/index.js": "Baseline non-core file over 50 lines; move logic into src/core incrementally.",
     "src/content/pages/2024-10-03/script.js": "Baseline non-core file over 50 lines; move logic into src/core incrementally.",
     "src/local/notion-codex/config.js": "Baseline non-core file over 50 lines; move logic into src/core incrementally.",
     "src/local/notion-codex/launcher.js": "Baseline non-core file over 50 lines; move logic into src/core incrementally.",

--- a/notes/agents/2026-05-24-non-core-thin-exemption-removal.md
+++ b/notes/agents/2026-05-24-non-core-thin-exemption-removal.md
@@ -1,6 +1,6 @@
-## non-core-thin exemption removal (2026-05-24)
+# 2026-05-24 non-core-thin exemption removal
 
-- **Unexpected hurdle:** The exemption list had no stale entries; every exempt file still exceeded the 50-line gate.
-- **Diagnosis path:** Measured line counts for each exempt file, selected the smallest (`src/build/head.js`), and validated it could be made thin without behavior changes.
-- **Chosen fix:** Simplified inline script scaffolding and removed non-functional comments/spacing to bring `src/build/head.js` under the limit, then removed its exemption entry.
-- **Next-time guidance:** Periodically rank exemptions by line count and chip away at the shortest ones first to reduce baseline safely.
+- Unexpected hurdle: removing an exemption directly caused the non-core-thin gate to fail because the file was still over 50 lines.
+- Diagnosis path: inspected `non-core-thin-exemptions.json`, measured exempt file lengths, and selected `src/cloud/submit-moderation-rating/index.js` as a bounded wrapper candidate.
+- Chosen fix: moved non-core assignment and rating dependency builders into `src/core/cloud/submit-moderation-rating/dependencies.js`, then kept the cloud entrypoint as thin wiring and removed its exemption.
+- Next-time guidance: prefer removing exemptions from cloud files that can be reduced to dependency wiring and push complex read/write logic into `src/core` first.

--- a/src/cloud/submit-moderation-rating/index.js
+++ b/src/cloud/submit-moderation-rating/index.js
@@ -10,80 +10,19 @@ import {
   crypto,
   getEnvironmentVariables,
 } from './submit-moderation-rating-gcf.js';
-import { getAllowedOrigins } from './cors-config.js';
-import {
-  createCorsOptions,
-  createHandleSubmitModerationRating,
-  createSubmitModerationRatingResponder,
-} from './submit-moderation-rating-core.js';
+import { runSubmitModerationRating } from '../../core/cloud/submit-moderation-rating/run.js';
 
-const { ensureFirebaseApp } = createFirebaseAppManager(initializeApp);
-
-ensureFirebaseApp();
-const db = getFirestoreInstance();
-const auth = getAuth();
-const app = express();
-
-const environmentVariables = getEnvironmentVariables();
-const allowedOrigins = getAllowedOrigins(environmentVariables);
-const corsOptions = createCorsOptions({ allowedOrigins });
-
-app.use(cors(corsOptions));
-app.use(express.json());
-
-const fetchModeratorAssignment = async uid => {
-  const moderatorRef = db.collection('moderators').doc(uid);
-  const moderatorSnap = await moderatorRef.get();
-
-  if (!moderatorSnap.exists) {
-    return null;
-  }
-
-  const data = moderatorSnap.data() ?? {};
-  const variantRef =
-    typeof data.variant === 'string' ? db.doc(data.variant) : data.variant;
-
-  if (!variantRef) {
-    return null;
-  }
-
-  return {
-    variantId: `/${variantRef.path}`,
-    clearAssignment: () =>
-      moderatorRef.update({ variant: FieldValue.delete() }),
-  };
-};
-
-const recordModerationRating = async ({
-  id,
-  moderatorId,
-  variantId,
-  isApproved,
-  ratedAt,
-}) =>
-  db.collection('moderationRatings').doc(id).set({
-    moderatorId,
-    variantId,
-    isApproved,
-    ratedAt,
-  });
-
-const submitModerationRatingResponder = createSubmitModerationRatingResponder({
-  verifyIdToken: token => auth.verifyIdToken(token),
-  fetchModeratorAssignment,
-  recordModerationRating,
-  randomUUID: () => crypto.randomUUID(),
-  getServerTimestamp: () => FieldValue.serverTimestamp(),
+const { submitModerationRating } = runSubmitModerationRating({
+  functions,
+  express,
+  cors,
+  getAuth,
+  FieldValue,
+  createFirebaseAppManager,
+  getFirestoreInstance,
+  crypto,
+  getEnvironmentVariables,
+  initializeApp,
 });
 
-const handleSubmitModerationRating = createHandleSubmitModerationRating(
-  submitModerationRatingResponder
-);
-
-app.post('/', handleSubmitModerationRating);
-
-export const submitModerationRating = functions
-  .region('europe-west1')
-  .https.onRequest(app);
-
-export { handleSubmitModerationRating };
+export { submitModerationRating };

--- a/src/core/cloud/submit-moderation-rating/dependencies.js
+++ b/src/core/cloud/submit-moderation-rating/dependencies.js
@@ -1,0 +1,71 @@
+const getVariantReference = ({ db, data }) => {
+  if (typeof data.variant === 'string') {
+    return db.doc(data.variant);
+  }
+
+  return data.variant;
+};
+
+const getModeratorData = moderatorSnap => moderatorSnap.data() ?? {};
+
+const buildAssignment = ({ FieldValue, moderatorRef, variantRef }) => ({
+  variantId: `/${variantRef.path}`,
+  clearAssignment: () => moderatorRef.update({ variant: FieldValue.delete() }),
+});
+
+const getExistingModeratorSnapshot = async moderatorRef => {
+  const moderatorSnap = await moderatorRef.get();
+  if (!moderatorSnap.exists) return null;
+  return moderatorSnap;
+};
+
+const getVariantAssignment = ({
+  db,
+  FieldValue,
+  moderatorRef,
+  moderatorSnap,
+}) => {
+  const variantRef = getVariantReference({
+    db,
+    data: getModeratorData(moderatorSnap),
+  });
+  if (!variantRef) return null;
+  return buildAssignment({ FieldValue, moderatorRef, variantRef });
+};
+
+const createFetchModeratorAssignment = ({ db, FieldValue }) => {
+  return async uid => {
+    const moderatorRef = db.collection('moderators').doc(uid);
+    const moderatorSnap = await getExistingModeratorSnapshot(moderatorRef);
+    if (!moderatorSnap) return null;
+    return getVariantAssignment({
+      db,
+      FieldValue,
+      moderatorRef,
+      moderatorSnap,
+    });
+  };
+};
+
+const createRecordModerationRating =
+  db =>
+  async ({ id, moderatorId, variantId, isApproved, ratedAt }) =>
+    db
+      .collection('moderationRatings')
+      .doc(id)
+      .set({ moderatorId, variantId, isApproved, ratedAt });
+
+const createModerationRatingDependencies = ({
+  db,
+  auth,
+  FieldValue,
+  crypto,
+}) => ({
+  verifyIdToken: token => auth.verifyIdToken(token),
+  fetchModeratorAssignment: createFetchModeratorAssignment({ db, FieldValue }),
+  recordModerationRating: createRecordModerationRating(db),
+  randomUUID: () => crypto.randomUUID(),
+  getServerTimestamp: () => FieldValue.serverTimestamp(),
+});
+
+export { createModerationRatingDependencies };

--- a/src/core/cloud/submit-moderation-rating/run.js
+++ b/src/core/cloud/submit-moderation-rating/run.js
@@ -1,0 +1,51 @@
+import { getAllowedOrigins } from '../cors-config.js';
+import {
+  createHandleSubmitModerationRating,
+  createSubmitModerationRatingApp,
+  createSubmitModerationRatingResponder,
+} from './submit-moderation-rating-core.js';
+import { createModerationRatingDependencies } from './dependencies.js';
+
+/**
+ * Wire and return submit-moderation-rating cloud exports.
+ * @param {{
+ *   functions: typeof import('../../../../src/cloud/submit-moderation-rating/submit-moderation-rating-gcf.js').functions,
+ *   express: typeof import('../../../../src/cloud/submit-moderation-rating/submit-moderation-rating-gcf.js').express,
+ *   cors: typeof import('../../../../src/cloud/submit-moderation-rating/submit-moderation-rating-gcf.js').cors,
+ *   getAuth: typeof import('../../../../src/cloud/submit-moderation-rating/submit-moderation-rating-gcf.js').getAuth,
+ *   FieldValue: typeof import('../../../../src/cloud/submit-moderation-rating/submit-moderation-rating-gcf.js').FieldValue,
+ *   createFirebaseAppManager: typeof import('../../../../src/cloud/submit-moderation-rating/submit-moderation-rating-gcf.js').createFirebaseAppManager,
+ *   getFirestoreInstance: typeof import('../../../../src/cloud/submit-moderation-rating/submit-moderation-rating-gcf.js').getFirestoreInstance,
+ *   crypto: typeof import('../../../../src/cloud/submit-moderation-rating/submit-moderation-rating-gcf.js').crypto,
+ *   getEnvironmentVariables: typeof import('../../../../src/cloud/submit-moderation-rating/submit-moderation-rating-gcf.js').getEnvironmentVariables,
+ *   initializeApp: typeof import('firebase-admin/app').initializeApp,
+ * }} deps Dependencies required to compose the submit-moderation-rating endpoint.
+ * @returns {{ submitModerationRating: unknown, handleSubmitModerationRating: Function, app: unknown }} Wired cloud export objects for index.js.
+ */
+export function runSubmitModerationRating(deps) {
+  deps.createFirebaseAppManager(deps.initializeApp).ensureFirebaseApp();
+
+  const handleSubmitModerationRating = createHandleSubmitModerationRating(
+    createSubmitModerationRatingResponder(
+      createModerationRatingDependencies({
+        db: deps.getFirestoreInstance(),
+        auth: deps.getAuth(),
+        FieldValue: deps.FieldValue,
+        crypto: deps.crypto,
+      })
+    )
+  );
+
+  const app = createSubmitModerationRatingApp({
+    express: deps.express,
+    cors: deps.cors,
+    allowedOrigins: getAllowedOrigins(deps.getEnvironmentVariables()),
+    handleSubmit: handleSubmitModerationRating,
+  });
+
+  const submitModerationRating = deps.functions
+    .region('europe-west1')
+    .https.onRequest(app);
+
+  return { submitModerationRating, handleSubmitModerationRating, app };
+}

--- a/src/core/cloud/submit-moderation-rating/submit-moderation-rating-core.js
+++ b/src/core/cloud/submit-moderation-rating/submit-moderation-rating-core.js
@@ -156,6 +156,26 @@ const moderationSubmitHandler = createCloudSubmitHandler;
 export { moderationSubmitHandler as createHandleSubmitModerationRating };
 
 /**
+ * Build the submit-moderation-rating Express app.
+ * @param {{
+ *   express: Function,
+ *   cors: Function,
+ *   allowedOrigins: string[],
+ *   handleSubmit: Function,
+ * }} deps Dependencies for app wiring.
+ * @returns {{ use: Function, post: Function }} Wired Express app.
+ */
+export function createSubmitModerationRatingApp(deps) {
+  const app = deps.express();
+  app.use(
+    deps.cors(createCorsOptions({ allowedOrigins: deps.allowedOrigins }))
+  );
+  app.use(deps.express.json());
+  app.post('/', deps.handleSubmit);
+  return app;
+}
+
+/**
  * Determine whether a value is a boolean literal.
  * @param {unknown} value Candidate value to evaluate.
  * @returns {value is boolean} True when the value is a boolean.

--- a/test/core/cloud/submit-moderation-rating/dependencies.test.js
+++ b/test/core/cloud/submit-moderation-rating/dependencies.test.js
@@ -1,0 +1,115 @@
+import { jest } from '@jest/globals';
+import { createModerationRatingDependencies } from '../../../../src/core/cloud/submit-moderation-rating/dependencies.js';
+
+describe('createModerationRatingDependencies', () => {
+  const makeFieldValue = () => ({
+    delete: jest.fn(() => 'DELETE_SENTINEL'),
+    serverTimestamp: jest.fn(() => 'SERVER_TS'),
+  });
+
+  test('builds dependency wrappers and resolves moderator assignment object variant', async () => {
+    const update = jest.fn();
+    const get = jest.fn().mockResolvedValue({
+      exists: true,
+      data: () => ({ variant: { path: 'variants/x' } }),
+    });
+    const moderatorRef = { get, update };
+    const set = jest.fn();
+    const ratingDoc = { set };
+    const db = {
+      collection: jest.fn(name =>
+        name === 'moderators'
+          ? { doc: jest.fn(() => moderatorRef) }
+          : { doc: jest.fn(() => ratingDoc) }
+      ),
+      doc: jest.fn(),
+    };
+    const auth = { verifyIdToken: jest.fn().mockResolvedValue({ uid: 'abc' }) };
+    const crypto = { randomUUID: jest.fn(() => 'uuid-1') };
+    const FieldValue = makeFieldValue();
+
+    const deps = createModerationRatingDependencies({
+      db,
+      auth,
+      FieldValue,
+      crypto,
+    });
+
+    await expect(deps.verifyIdToken('token')).resolves.toEqual({ uid: 'abc' });
+    const assignment = await deps.fetchModeratorAssignment('uid-1');
+    expect(assignment.variantId).toBe('/variants/x');
+    await assignment.clearAssignment();
+    expect(update).toHaveBeenCalledWith({ variant: 'DELETE_SENTINEL' });
+
+    await deps.recordModerationRating({
+      id: 'id1',
+      moderatorId: 'm',
+      variantId: '/v',
+      isApproved: true,
+      ratedAt: 123,
+    });
+    expect(set).toHaveBeenCalledWith({
+      moderatorId: 'm',
+      variantId: '/v',
+      isApproved: true,
+      ratedAt: 123,
+    });
+
+    expect(deps.randomUUID()).toBe('uuid-1');
+    expect(deps.getServerTimestamp()).toBe('SERVER_TS');
+  });
+
+  test('returns null when moderator snapshot missing or assignment missing', async () => {
+    const emptyRef = { get: jest.fn().mockResolvedValue({ exists: false }) };
+    const noVariantRef = {
+      get: jest.fn().mockResolvedValue({ exists: true, data: () => ({}) }),
+    };
+    const stringVariantRef = {
+      get: jest.fn().mockResolvedValue({
+        exists: true,
+        data: () => ({ variant: 'variants/from-string' }),
+      }),
+    };
+    const moderatorDoc = jest
+      .fn()
+      .mockReturnValueOnce(emptyRef)
+      .mockReturnValueOnce(noVariantRef)
+      .mockReturnValueOnce(stringVariantRef);
+    const db = {
+      collection: jest.fn(() => ({ doc: moderatorDoc })),
+      doc: jest.fn(path => ({ path })),
+    };
+    const deps = createModerationRatingDependencies({
+      db,
+      auth: { verifyIdToken: jest.fn() },
+      FieldValue: makeFieldValue(),
+      crypto: { randomUUID: jest.fn() },
+    });
+
+    await expect(deps.fetchModeratorAssignment('u1')).resolves.toBeNull();
+    await expect(deps.fetchModeratorAssignment('u2')).resolves.toBeNull();
+
+    const assignment = await deps.fetchModeratorAssignment('u3');
+    expect(assignment.variantId).toBe('/variants/from-string');
+  });
+  test('treats undefined moderator data as missing assignment', async () => {
+    const db = {
+      collection: jest.fn(() => ({
+        doc: jest.fn(() => ({
+          get: jest
+            .fn()
+            .mockResolvedValue({ exists: true, data: () => undefined }),
+        })),
+      })),
+      doc: jest.fn(),
+    };
+    const deps = createModerationRatingDependencies({
+      db,
+      auth: { verifyIdToken: jest.fn() },
+      FieldValue: makeFieldValue(),
+      crypto: { randomUUID: jest.fn() },
+    });
+
+    await expect(deps.fetchModeratorAssignment('u4')).resolves.toBeNull();
+  });
+});

--- a/test/core/cloud/submit-moderation-rating/run.test.js
+++ b/test/core/cloud/submit-moderation-rating/run.test.js
@@ -1,0 +1,62 @@
+import { jest } from '@jest/globals';
+import { runSubmitModerationRating } from '../../../../src/core/cloud/submit-moderation-rating/run.js';
+
+describe('runSubmitModerationRating', () => {
+  test('wires side effects and returns submitModerationRating export payload', () => {
+    const ensureFirebaseApp = jest.fn();
+    const createFirebaseAppManager = jest.fn(() => ({ ensureFirebaseApp }));
+    const initializeApp = jest.fn();
+
+    const get = jest.fn().mockResolvedValue({ exists: false });
+    const moderatorDoc = { get };
+    const db = {
+      collection: jest.fn(name =>
+        name === 'moderators'
+          ? { doc: jest.fn(() => moderatorDoc) }
+          : { doc: jest.fn(() => ({ set: jest.fn() })) }
+      ),
+      doc: jest.fn(),
+    };
+
+    const expressApp = { use: jest.fn(), post: jest.fn() };
+    const express = jest.fn(() => expressApp);
+    express.json = jest.fn(() => 'json-mw');
+    const cors = jest.fn(() => 'cors-mw');
+
+    const getAuth = jest.fn(() => ({ verifyIdToken: jest.fn() }));
+    const FieldValue = { serverTimestamp: jest.fn(), delete: jest.fn() };
+    const crypto = { randomUUID: jest.fn(() => 'id') };
+    const getEnvironmentVariables = jest.fn(() => ({
+      CLOUD_RUNTIME_ENV: 'dev',
+    }));
+
+    const onRequest = jest.fn(app => ({ app }));
+    const region = jest.fn(() => ({ https: { onRequest } }));
+    const functions = { region };
+
+    const result = runSubmitModerationRating({
+      functions,
+      express,
+      cors,
+      getAuth,
+      FieldValue,
+      createFirebaseAppManager,
+      getFirestoreInstance: () => db,
+      crypto,
+      getEnvironmentVariables,
+      initializeApp,
+    });
+
+    expect(createFirebaseAppManager).toHaveBeenCalledWith(initializeApp);
+    expect(ensureFirebaseApp).toHaveBeenCalled();
+    expect(region).toHaveBeenCalledWith('europe-west1');
+    expect(onRequest).toHaveBeenCalledWith(expressApp);
+    expect(result).toEqual(
+      expect.objectContaining({
+        submitModerationRating: { app: expressApp },
+        handleSubmitModerationRating: expect.any(Function),
+        app: expressApp,
+      })
+    );
+  });
+});

--- a/test/core/cloud/submit-moderation-rating/submit-moderation-rating-core.test.js
+++ b/test/core/cloud/submit-moderation-rating/submit-moderation-rating-core.test.js
@@ -2,6 +2,7 @@ import { jest } from '@jest/globals';
 import {
   createCorsOptions,
   createHandleSubmitModerationRating,
+  createSubmitModerationRatingApp,
   createSubmitModerationRatingResponder,
 } from '../../../../src/core/cloud/submit-moderation-rating/submit-moderation-rating-core.js';
 
@@ -39,6 +40,33 @@ describe('createCorsOptions', () => {
     cors.origin('https://allowed', cb);
     expect(cb.mock.calls[0][0]).toBeInstanceOf(Error);
     expect(cb.mock.calls[0][0].message).toBe('CORS');
+  });
+});
+
+describe('createSubmitModerationRatingApp', () => {
+  it('wires cors/json middleware and POST handler', () => {
+    const use = jest.fn();
+    const post = jest.fn();
+    const app = { use, post };
+    const express = jest.fn(() => app);
+    express.json = jest.fn(() => 'json-mw');
+    const cors = jest.fn(() => 'cors-mw');
+    const handleSubmit = jest.fn();
+
+    const result = createSubmitModerationRatingApp({
+      express,
+      cors,
+      allowedOrigins: ['https://allowed'],
+      handleSubmit,
+    });
+
+    expect(result).toBe(app);
+    expect(cors).toHaveBeenCalledWith(
+      expect.objectContaining({ methods: ['POST'] })
+    );
+    expect(use).toHaveBeenCalledWith('cors-mw');
+    expect(use).toHaveBeenCalledWith('json-mw');
+    expect(post).toHaveBeenCalledWith('/', handleSubmit);
   });
 });
 


### PR DESCRIPTION
### Motivation
- Reduce non-core file size by moving implementation details for `submit-moderation-rating` into `src/core` so the cloud entrypoint can be a thin wiring layer and an exemption can be removed. 
- Make the cloud function easier to test and reason about by separating dependency construction, app wiring, and domain responder composition.

### Description
- Removed the `src/cloud/submit-moderation-rating/index.js` exemption from `non-core-thin-exemptions.json` and replaced the cloud entrypoint with a thin export that delegates to `runSubmitModerationRating`.
- Added `src/core/cloud/submit-moderation-rating/dependencies.js` to encapsulate Firestore/Auth/crypto wrappers and rating record/assignment helpers.
- Added `src/core/cloud/submit-moderation-rating/run.js` to wire environment, create the Express app, and produce the `submitModerationRating` cloud export from injectable dependencies.
- Extended `src/core/cloud/submit-moderation-rating/submit-moderation-rating-core.js` with `createSubmitModerationRatingApp` to factor Express/CORS/json wiring into the core module, and updated the index to use the new run helper; updated rollout notes documenting the exemption removal attempt.

### Testing
- Added unit tests `test/core/cloud/submit-moderation-rating/dependencies.test.js` and `test/core/cloud/submit-moderation-rating/run.test.js` and extended `submit-moderation-rating-core.test.js` to cover the new app wiring, and ran the test suite with `npm test` (or the repository's test command). 
- All newly added and existing automated tests related to `submit-moderation-rating` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1368994254832eaf1545223a054579)