### PR TITLE
Raise Jest global coverage thresholds to 100%

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -42,9 +42,10 @@ const config = {
   coverageDirectory: 'reports/coverage',
   coverageThreshold: {
     global: {
-      branches: 99.68,
-      functions: 99.91,
-      lines: 99.62,
+      branches: 100,
+      functions: 100,
+      lines: 100,
+      statements: 100,
     },
   },
   // Ensure coverage is collected for all files, including those not tested

--- a/notes/agents/2026-05-26-coverage-threshold-100.md
+++ b/notes/agents/2026-05-26-coverage-threshold-100.md
@@ -1,0 +1,4 @@
+- Unexpected hurdle: raising Jest global coverage thresholds to 100% immediately fails the suite even though all tests pass.
+- Diagnosis path: ran `npm test` after editing `jest.config.mjs` and checked the coverage summary output for unmet global percentages.
+- Chosen fix: kept the threshold bump in config so the requirement is explicit and enforceable.
+- Next-time guidance: add focused tests (especially under `src/core/local/notion-codex/stateStore.js`) before expecting `npm test` to pass with 100% global thresholds.


### PR DESCRIPTION
### Motivation
- Make the repository's test-quality gate explicit by requiring 100% global coverage for statements, branches, lines, and functions.

### Description
- Updated `coverageThreshold.global` in `jest.config.mjs` to require `branches: 100`, `functions: 100`, `lines: 100`, and `statements: 100` and added a short agent retrospective note at `notes/agents/2026-05-26-coverage-threshold-100.md` documenting the change and next steps.

### Testing
- Ran `npm test`; all test suites passed but the new global coverage gate failed (statements 99.61%, branches 99.45%, lines 99.60%, functions 99.91%), so the configuration change is in place and enforceable while focused coverage work remains to reach 100%.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a159661a96c832e976ff1a467a67252)