### PR TITLE
Export normalizeActiveRun and add targeted tests to improve coverage

### DIFF
--- a/notes/agents/2026-05-26-coverage-loop.md
+++ b/notes/agents/2026-05-26-coverage-loop.md
@@ -1,0 +1,6 @@
+# Coverage loop note (2026-05-26)
+
+- **Unexpected hurdle:** Full `npm test -- --watchman=false` still fails global 100% coverage thresholds despite all suites passing.
+- **Diagnosis path:** Used Jest coverage output to identify uncovered branches and lines, then added focused tests for `textUtils` underflow pluralization and `stateStore` normalization/read branches.
+- **Chosen fix:** Added targeted assertions that execute previously missed branches in `generateFeedback` and `normalizeNotionCodexState`/`readState` paths.
+- **Next-time guidance:** Keep iterating on remaining uncovered branch paths reported by global coverage summary; run focused `jest` on impacted suites first before full `npm test`.

--- a/src/core/local/notion-codex/stateStore.js
+++ b/src/core/local/notion-codex/stateStore.js
@@ -5,7 +5,7 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises';
  * @param {unknown} value Candidate run object.
  * @returns {Record<string, unknown> | null} Active run object or null.
  */
-function normalizeActiveRun(value) {
+export function normalizeActiveRun(value) {
   if (!value || typeof value !== 'object') {
     return null;
   }

--- a/test/core/analyzePost.test.js
+++ b/test/core/analyzePost.test.js
@@ -1,0 +1,69 @@
+import { jest } from '@jest/globals';
+import { getInput, runAnalyzePost } from '../../src/core/build/analyzePost.js';
+
+describe('analyzePost', () => {
+  test('getInput returns argv text when provided', async () => {
+    const input = await getInput(
+      { argv: ['node', 'script', 'hello', 'world'], stdin: [] },
+      Buffer
+    );
+    expect(input).toBe('hello world');
+  });
+
+  test('getInput reads from stdin when argv is empty', async () => {
+    async function* makeChunks() {
+      yield Buffer.from('hello ');
+      yield Buffer.from('stdin');
+    }
+
+    const input = await getInput(
+      { argv: ['node', 'script'], stdin: makeChunks() },
+      Buffer
+    );
+    expect(input).toBe('hello stdin');
+  });
+
+  test('runAnalyzePost exits when input is blank', async () => {
+    const log = jest.fn();
+    const exit = jest.fn();
+
+    await runAnalyzePost({
+      process: { argv: ['node', 'script', '   '], stdin: [], exit },
+      Buffer,
+      console: { log },
+    });
+
+    expect(log).toHaveBeenCalledWith('No text provided.');
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  test('runAnalyzePost prints analysis and feedback for non-100-word text', async () => {
+    const log = jest.fn();
+
+    await runAnalyzePost({
+      process: { argv: ['node', 'script', 'One two three.'], stdin: [], exit: jest.fn() },
+      Buffer,
+      console: { log },
+    });
+
+    expect(log).toHaveBeenCalledWith('--- Post Analysis ---');
+    expect(log).toHaveBeenCalledWith('Words: 3 / 100');
+    expect(log).toHaveBeenCalledWith('Delta: -97');
+    expect(log).toHaveBeenCalledWith('--- Feedback ---');
+    expect(log).not.toHaveBeenCalledWith('Ready for title suggestions!');
+  });
+
+  test('runAnalyzePost prints ready message for exactly 100 words', async () => {
+    const words = Array.from({ length: 100 }, (_, i) => `w${String(i)}`).join(' ');
+    const log = jest.fn();
+
+    await runAnalyzePost({
+      process: { argv: ['node', 'script', words], stdin: [], exit: jest.fn() },
+      Buffer,
+      console: { log },
+    });
+
+    expect(log).toHaveBeenCalledWith('Delta: +0');
+    expect(log).toHaveBeenCalledWith('Ready for title suggestions!');
+  });
+});

--- a/test/core/build/textUtils.test.js
+++ b/test/core/build/textUtils.test.js
@@ -125,6 +125,17 @@ describe('textUtils', () => {
           longestSentence: { sentence: 'x', wordCount: 1 },
         })
       ).toEqual(['1 words under. Add 1 word.']);
+
+
+      expect(
+        generateFeedback({
+          isExactly100: false,
+          delta: -2,
+          avgWordsPerSentence: 10,
+          sentenceCount: 2,
+          longestSentence: { sentence: 'x', wordCount: 1 },
+        })
+      ).toEqual(['2 words under. Add 2 words.']);
     });
   });
 

--- a/test/core/local/notion-codex/stateStore.test.js
+++ b/test/core/local/notion-codex/stateStore.test.js
@@ -1,6 +1,7 @@
 import { jest } from '@jest/globals';
 import {
   createNotionCodexStateStore,
+  normalizeActiveRun,
   normalizeNotionCodexState,
 } from '../../../../src/core/local/notion-codex/stateStore.js';
 
@@ -35,11 +36,90 @@ describe('notion codex state store core', () => {
     expect(normalized.eventLog).toHaveLength(20);
   });
 
+
+  test('exports normalizeActiveRun for direct branch testing', () => {
+    expect(normalizeActiveRun(null)).toBeNull();
+    expect(normalizeActiveRun(9)).toBeNull();
+    const run = { id: 'run-2' };
+    expect(normalizeActiveRun(run)).toBe(run);
+  });
+
+  test('preserves valid scalar fields during normalization', () => {
+    const normalized = normalizeNotionCodexState({
+      lastPollAt: '2026-05-26T00:00:00.000Z',
+      lastOutcome: 'success',
+      lastSummary: 'ok',
+      idleBackoffExponent: 4,
+      nextPollAfter: '2026-05-26T00:05:00.000Z',
+      activeRun: { id: 'run-3' },
+      eventLog: [{ step: 1 }],
+    });
+
+    expect(normalized).toEqual(
+      expect.objectContaining({
+        lastPollAt: '2026-05-26T00:00:00.000Z',
+        lastOutcome: 'success',
+        lastSummary: 'ok',
+        idleBackoffExponent: 4,
+        nextPollAfter: '2026-05-26T00:05:00.000Z',
+        activeRun: { id: 'run-3' },
+        eventLog: [{ step: 1 }],
+      })
+    );
+  });
+
+  test('keeps object activeRun values and normalizes parsed read state', async () => {
+    const store = createNotionCodexStateStore({
+      statePath: '/tmp/state.json',
+      readFileImpl: jest.fn(async () => JSON.stringify({
+        activeRun: { id: 'run-1' },
+        eventLog: [{ ok: true }],
+      })),
+    });
+
+    await expect(store.readState()).resolves.toEqual(
+      expect.objectContaining({
+        activeRun: { id: 'run-1' },
+        eventLog: [{ ok: true }],
+      })
+    );
+  });
+
+  test('normalizes optional scalar fields when types are invalid', () => {
+    const normalized = normalizeNotionCodexState({
+      lastPollAt: 123,
+      lastOutcome: null,
+      lastSummary: false,
+      idleBackoffExponent: 1.5,
+      nextPollAfter: {},
+      eventLog: 'bad',
+    });
+
+    expect(normalized).toEqual(
+      expect.objectContaining({
+        lastPollAt: null,
+        lastOutcome: 'idle',
+        lastSummary: '',
+        idleBackoffExponent: null,
+        nextPollAfter: null,
+        eventLog: [],
+      })
+    );
+  });
+
+  test('uses node fs defaults when dependency implementations are omitted', () => {
+    const store = createNotionCodexStateStore({ statePath: '/tmp/state.json' });
+    expect(typeof store.readState).toBe('function');
+    expect(typeof store.writeState).toBe('function');
+  });
+
   test('reads ENOENT as empty state and rethrows other errors', async () => {
     const notFound = Object.assign(new Error('missing'), { code: 'ENOENT' });
     const store = createNotionCodexStateStore({
       statePath: '/tmp/state.json',
-      readFileImpl: jest.fn(async () => { throw notFound; }),
+      readFileImpl: jest.fn(async () => {
+        throw notFound;
+      }),
     });
     await expect(store.readState()).resolves.toEqual(
       expect.objectContaining({ lastOutcome: 'idle' })
@@ -48,7 +128,9 @@ describe('notion codex state store core', () => {
     const fatal = new Error('fatal');
     const badStore = createNotionCodexStateStore({
       statePath: '/tmp/state.json',
-      readFileImpl: jest.fn(async () => { throw fatal; }),
+      readFileImpl: jest.fn(async () => {
+        throw fatal;
+      }),
     });
     await expect(badStore.readState()).rejects.toThrow('fatal');
   });

--- a/test/core/runCore.test.js
+++ b/test/core/runCore.test.js
@@ -1,0 +1,20 @@
+import { jest } from '@jest/globals';
+
+const runCopyWorkflow = jest.fn();
+const createCopyCoreMock = jest.fn(() => ({ runCopyWorkflow }));
+
+jest.unstable_mockModule('../../src/core/build/blog.js', () => ({
+  createCopyCore: createCopyCoreMock,
+}));
+
+const { runCore } = await import('../../src/core/build/runCore.js');
+
+describe('runCore', () => {
+  test('creates copy core and runs workflow', () => {
+    const deps = { now: Date.now };
+    runCore(deps);
+
+    expect(createCopyCoreMock).toHaveBeenCalledWith(deps);
+    expect(runCopyWorkflow).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
### Motivation

- Address uncovered branches reported by Jest coverage for `generateFeedback` pluralization and `stateStore` normalization/read paths.  
- Make internal normalization logic testable by exposing `normalizeActiveRun`.  
- Add focused unit tests to exercise edge cases in CLI input handling and core workflows to raise coverage on problematic branches.

### Description

- Exported `normalizeActiveRun` from `src/core/local/notion-codex/stateStore.js` to enable direct branch testing.  
- Expanded `normalizeNotionCodexState` test coverage and added tests for scalar field normalization, `activeRun` handling, trimming `eventLog`, ENOENT read behaviour, and default fs implementations in `test/core/local/notion-codex/stateStore.test.js`.  
- Added `test/core/build/textUtils.test.js` assertions to cover underflow pluralization in `generateFeedback`.  
- Added `test/core/analyzePost.test.js` to cover `getInput` behavior for argv and stdin and `runAnalyzePost` exit/log paths.  
- Added `test/core/runCore.test.js` to mock `createCopyCore` and assert `runCore` triggers the workflow.  
- Added a notes file `notes/agents/2026-05-26-coverage-loop.md` documenting the coverage diagnosis and next steps.

### Testing

- Ran the new and updated Jest suites for the modified modules (focused runs on `test/core/*`) and the new tests passed.  
- Used Jest coverage output to identify missed branches and iterate on tests with targeted assertions.  
- A full `npm test -- --watchman=false` run still fails the global 100% coverage threshold despite all suites passing, so further branch tests remain to be added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a159a205434832eb4033948b568f40d)