### PR TITLE
Refactor Notion prompt helpers and add test JSDoc

### DIFF
--- a/src/core/local/notion-codex/prompt.js
+++ b/src/core/local/notion-codex/prompt.js
@@ -22,9 +22,10 @@
  */
 export function buildNotionCodexPrompt(options) {
   const { notion } = options.config;
-  const inboxPageList = notion.inboxPageIds.length
-    ? notion.inboxPageIds.map(pageId => `- ${pageId}`).join('\n')
-    : '- none configured';
+  let inboxPageList = '- none configured';
+  if (notion.inboxPageIds.length > 0) {
+    inboxPageList = notion.inboxPageIds.map(pageId => `- ${pageId}`).join('\n');
+  }
 
   return [
     'You are Codex running as the Dadeto Notion polling worker on lorandil.',
@@ -72,11 +73,19 @@ export function buildNotionCodexPrompt(options) {
 }
 
 /**
- *
- * @param tokenEnvNames
+ * @param {unknown} tokenEnvNames Environment variable names that may store a Notion API token.
+ * @returns {string} Token environment names joined by "or", or default names when none are configured.
+ */
+function hasTokenEnvNames(tokenEnvNames) {
+  return Array.isArray(tokenEnvNames) && tokenEnvNames.length > 0;
+}
+
+/**
+ * @param {unknown} tokenEnvNames Environment variable names that may store a Notion API token.
+ * @returns {string} Token environment names joined by "or", or default names when none are configured.
  */
 function formatTokenEnvNames(tokenEnvNames) {
-  if (!Array.isArray(tokenEnvNames) || tokenEnvNames.length === 0) {
+  if (!hasTokenEnvNames(tokenEnvNames)) {
     return 'NOTION_API_KEY or NOTION_TOKEN';
   }
 

--- a/test/core/analyzePost.test.js
+++ b/test/core/analyzePost.test.js
@@ -12,7 +12,7 @@ describe('analyzePost', () => {
 
   test('getInput reads from stdin when argv is empty', async () => {
     /**
-     *
+     * @yields {Buffer} Stdin chunks for test input.
      */
     async function* makeChunks() {
       yield Buffer.from('hello ');


### PR DESCRIPTION
### Motivation
- Improve robustness and clarity of the Notion Codex prompt generation and provide clearer test documentation for the analyzePost input generator.

### Description
- Refactored `src/core/local/notion-codex/prompt.js` to use a clearer initialization for the inbox list, added a `hasTokenEnvNames` helper, and updated `formatTokenEnvNames` with a stronger JSDoc signature and logic; also updated `test/core/analyzePost.test.js` to include an `@yields {Buffer}` JSDoc for the test stdin generator.

### Testing
- Ran the unit test suite with `npm test` (Jest) and the modified tests executed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15af36edc4832eade16f0ecd73b07d)