### PR TITLE
Reduce lint warnings in local runtime and state store

### DIFF
--- a/notes/agents/2026-05-26-lint-warnings.md
+++ b/notes/agents/2026-05-26-lint-warnings.md
@@ -1,0 +1,6 @@
+# Lint warning reduction loop
+
+- **Unexpected hurdle:** The project enforces a cyclomatic complexity maximum of 2 plus strict JSDoc completeness, so straightforward refactors still left many warnings.
+- **Diagnosis path:** Ran `npm run lint`, inspected `reports/lint/lint.txt`, and focused on the two highest-warning files under `src/core/local`.
+- **Chosen fix:** Reduced warning count by extracting state-store read/write helpers, simplifying guard logic, and adding targeted JSDoc in `stateStore.js` and `run.js`.
+- **Next-time guidance / open questions:** Consider relaxing complexity/JSDoc thresholds for internal utility modules or adding shared helper utilities to avoid repetitive guard/JSDoc boilerplate.

--- a/src/core/local/notion-codex/stateStore.js
+++ b/src/core/local/notion-codex/stateStore.js
@@ -6,11 +6,7 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises';
  * @returns {Record<string, unknown> | null} Active run object or null.
  */
 export function normalizeActiveRun(value) {
-  if (!value) {
-    return null;
-  }
-
-  if (typeof value !== 'object') {
+  if (typeof value !== 'object' || !value) {
     return null;
   }
 
@@ -22,11 +18,7 @@ export function normalizeActiveRun(value) {
  * @returns {Record<string, unknown>} Source object or empty object.
  */
 function toSourceObject(value) {
-  if (!value) {
-    return {};
-  }
-
-  if (typeof value !== 'object') {
+  if (typeof value !== 'object' || !value) {
     return {};
   }
 
@@ -102,11 +94,23 @@ export function normalizeNotionCodexState(value) {
 }
 
 /**
+ * @param {unknown} error Candidate filesystem error.
+ * @returns {boolean} True when the error is a missing-file read.
+ */
+function isMissingStateError(error) {
+  return readErrorCode(error) === 'ENOENT';
+}
+
+/**
  *
  * @param error
  */
-function isMissingStateError(error) {
-  return Boolean(error && typeof error === 'object' && error.code === 'ENOENT');
+function readErrorCode(error) {
+  if (typeof error !== 'object' || !error) {
+    return null;
+  }
+
+  return error.code;
 }
 
 /**
@@ -122,31 +126,71 @@ function isMissingStateError(error) {
  * }} JSON state store.
  */
 export function createNotionCodexStateStore(options) {
-  const mkdirImpl = options.mkdirImpl ?? mkdir;
-  const readFileImpl = options.readFileImpl ?? readFile;
-  const writeFileImpl = options.writeFileImpl ?? writeFile;
+  const { mkdirImpl, readFileImpl, writeFileImpl, readStatePath } =
+    resolveStoreDeps(options);
+
+  /**
+   * @returns {Promise<Record<string, unknown>>} Parsed state or defaults.
+   */
+  const readState = createReadState({ readFileImpl, readStatePath });
+  const writeState = createWriteState({
+    mkdirImpl,
+    writeFileImpl,
+    readStatePath,
+  });
 
   return {
-    async readState() {
-      try {
-        const rawState = await readFileImpl(options.statePath, 'utf8');
-        return normalizeNotionCodexState(JSON.parse(rawState));
-      } catch (error) {
-        if (isMissingStateError(error)) {
-          return normalizeNotionCodexState(null);
-        }
+    readState,
+    writeState,
+  };
+}
 
+/**
+ *
+ * @param options
+ */
+function resolveStoreDeps(options) {
+  return {
+    mkdirImpl: options.mkdirImpl ?? mkdir,
+    readFileImpl: options.readFileImpl ?? readFile,
+    writeFileImpl: options.writeFileImpl ?? writeFile,
+    readStatePath: options.statePath,
+  };
+}
+
+/**
+ *
+ * @param root0
+ * @param root0.readFileImpl
+ * @param root0.readStatePath
+ */
+function createReadState({ readFileImpl, readStatePath }) {
+  return async () => {
+    try {
+      const rawState = await readFileImpl(readStatePath, 'utf8');
+      return normalizeNotionCodexState(JSON.parse(rawState));
+    } catch (error) {
+      if (!isMissingStateError(error)) {
         throw error;
       }
-    },
 
-    async writeState(state) {
-      await mkdirImpl(path.dirname(options.statePath), { recursive: true });
-      await writeFileImpl(
-        options.statePath,
-        JSON.stringify(normalizeNotionCodexState(state), null, 2),
-        'utf8'
-      );
-    },
+      return normalizeNotionCodexState(null);
+    }
+  };
+}
+
+/**
+ *
+ * @param root0
+ * @param root0.mkdirImpl
+ * @param root0.writeFileImpl
+ * @param root0.readStatePath
+ */
+function createWriteState({ mkdirImpl, writeFileImpl, readStatePath }) {
+  return async state => {
+    await mkdirImpl(path.dirname(readStatePath), { recursive: true });
+    const normalizedState = normalizeNotionCodexState(state);
+    const serializedState = JSON.stringify(normalizedState, null, 2);
+    await writeFileImpl(readStatePath, serializedState, 'utf8');
   };
 }

--- a/src/core/local/run.js
+++ b/src/core/local/run.js
@@ -12,8 +12,7 @@
  * @returns {{ runLocalServer: (config: { env: Record<string, string | undefined>, port: number, store: unknown, publicDir: string, writerDir: string, exchangeRealtimeCallSdp: (body: unknown) => Promise<unknown>, getNonCoreThinStatus: () => unknown, renderNonCoreThinDashboard: (status: unknown) => string }) => void }} Local server runner.
  */
 export function createLocalServerRuntime(deps) {
-  const log = deps.consoleLog ?? console.log;
-  const errorLog = deps.consoleError ?? console.error;
+  const { log, errorLog } = createLoggers(deps);
 
   /**
    * @param {{ env: Record<string, string | undefined>, port: number, store: unknown, publicDir: string, writerDir: string, exchangeRealtimeCallSdp: (body: unknown) => Promise<unknown>, getNonCoreThinStatus: () => unknown, renderNonCoreThinDashboard: (status: unknown) => string }} config Runtime config.
@@ -32,8 +31,25 @@ export function createLocalServerRuntime(deps) {
 }
 
 /**
- *
- * @param host
+ * @param {{
+ *   consoleLog?: (message: string) => void,
+ *   consoleError?: (message: string) => void
+ * }} deps Runtime dependencies.
+ * @returns {{ log: (message: string) => void, errorLog: (message: string) => void }} Normalized loggers.
+ */
+function createLoggers(deps) {
+  const log = deps.consoleLog || console.log;
+  const errorLog = deps.consoleError || console.error;
+
+  return {
+    log,
+    errorLog,
+  };
+}
+
+/**
+ * @param {string | undefined} host Raw host value.
+ * @returns {string} Trimmed host or empty string.
  */
 function normalizeHost(host) {
   if (!host) {
@@ -44,10 +60,10 @@ function normalizeHost(host) {
 }
 
 /**
- *
- * @param config
- * @param deps
- * @param log
+ * @param {{ env: Record<string, string | undefined>, store: unknown, publicDir: string, writerDir: string, exchangeRealtimeCallSdp: (body: unknown) => Promise<unknown>, getNonCoreThinStatus: () => unknown, renderNonCoreThinDashboard: (status: unknown) => string }} config Runtime config.
+ * @param {{ isWriterRequestLogEnabled: (env: Record<string, string | undefined>) => boolean }} deps Runtime dependencies.
+ * @param {(message: string) => void} log Request logger destination.
+ * @returns {{ store: unknown, publicDir: string, writerDir: string, exchangeRealtimeCallSdp: (body: unknown) => Promise<unknown>, getNonCoreThinStatus: () => unknown, renderNonCoreThinDashboard: (status: unknown) => string, requestLogger?: (message: string) => void }} Local app config.
  */
 function buildLocalAppConfig(config, deps, log) {
   return {
@@ -62,10 +78,10 @@ function buildLocalAppConfig(config, deps, log) {
 }
 
 /**
- *
- * @param env
- * @param deps
- * @param log
+ * @param {Record<string, string | undefined>} env Runtime environment variables.
+ * @param {{ isWriterRequestLogEnabled: (env: Record<string, string | undefined>) => boolean }} deps Runtime dependencies.
+ * @param {(message: string) => void} log Request logger destination.
+ * @returns {((message: string) => void) | undefined} Request logger when enabled.
  */
 function getRequestLogger(env, deps, log) {
   if (!deps.isWriterRequestLogEnabled(env)) {
@@ -76,14 +92,15 @@ function getRequestLogger(env, deps, log) {
 }
 
 /**
- *
- * @param root0
- * @param root0.server
- * @param root0.host
- * @param root0.port
- * @param root0.env
- * @param root0.deps
- * @param root0.log
+ * @param {{
+ *   server: { listen: (...args: Array<unknown>) => void },
+ *   host: string,
+ *   port: number,
+ *   env: Record<string, string | undefined>,
+ *   deps: { getWriterUrl: (port: number, env: Record<string, string | undefined>) => string },
+ *   log: (message: string) => void
+ * }} options Server startup options.
+ * @returns {void} Nothing.
  */
 function startServer({ server, host, port, env, deps, log }) {
   const writerUrl = deps.getWriterUrl(port, env);
@@ -104,11 +121,12 @@ function startServer({ server, host, port, env, deps, log }) {
 }
 
 /**
- *
- * @param root0
- * @param root0.port
- * @param root0.deps
- * @param root0.errorLog
+ * @param {{
+ *   port: number,
+ *   deps: { formatListenErrorMessage: (port: number) => string },
+ *   errorLog: (message: string) => void
+ * }} options Error handler dependencies.
+ * @returns {(error: unknown) => void} Server error callback.
  */
 function createServerErrorHandler({ port, deps, errorLog }) {
   return error => {
@@ -122,13 +140,26 @@ function createServerErrorHandler({ port, deps, errorLog }) {
 }
 
 /**
+ * @param {unknown} error Candidate server listen error.
+ * @returns {boolean} True when the error is a permission issue.
+ */
+function isPermissionError(error) {
+  const errorCode = getErrorCode(error);
+  return errorCode === 'EPERM' || errorCode === 'EACCES';
+}
+
+/**
  *
  * @param error
  */
-function isPermissionError(error) {
-  if (!error?.code) {
-    return false;
+function getErrorCode(error) {
+  if (typeof error !== 'object' || !error) {
+    return null;
   }
 
-  return error.code === 'EPERM' || error.code === 'EACCES';
+  if (!('code' in error)) {
+    return null;
+  }
+
+  return error.code;
 }


### PR DESCRIPTION
### Motivation
- Reduce ESLint warnings in the local runtime and notion-codex state store modules while preserving existing behavior and test coverage.

### Description
- Refactored `src/core/local/notion-codex/stateStore.js` by extracting dependency resolution and factory helpers (`resolveStoreDeps`, `createReadState`, `createWriteState`) and centralized error-code reading to simplify guard logic and lower function complexity.
- Simplified small guards in `normalizeActiveRun` and `toSourceObject`, and added targeted JSDoc for clearer types and return values.
- Refactored `src/core/local/run.js` to normalize logger construction via `createLoggers`, isolated error-code parsing into `getErrorCode`, and updated `isPermissionError` to use it, plus added JSDoc on touched helpers.
- Added an agent retrospective note at `notes/agents/2026-05-26-lint-warnings.md` documenting the loop, diagnosis, and next steps.

### Testing
- Ran `npm run lint`, which still fails due to remaining warnings but reduced the reported warnings in the touched scope (from 53 down to 32 in the lint output).;
- Ran `npm test`, where all test suites passed but the overall command exits non-zero because global coverage thresholds were not met (global statements 99.97%, branches 99.93%, lines 99.97%), so the test step reported a coverage failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15cd3b9c5c832ebd3b641065cf7bf5)