### PR TITLE
Add MEMO3: memoryScalarVectorWrite toy (write scalar/vector into memory)

### DIFF
--- a/docs/toys/memory-scalar-vector-write/acceptance.md
+++ b/docs/toys/memory-scalar-vector-write/acceptance.md
@@ -1,0 +1,23 @@
+# Acceptance: Memory Scalar/Vector Write
+
+## Machine-Checkable Criteria
+- [ ] The toy appears in Dadeto blog metadata as `MEMO3`.
+- [ ] JSON input can write a scalar to a missing nested temporary path.
+- [ ] JSON input can write a vector to permanent memory.
+- [ ] Missing nested containers are constructed, including numeric path segments that imply arrays.
+- [ ] `MEMO2` can read back values written by `MEMO3`.
+- [ ] Malformed requests and unsupported memory locations return structured JSON errors.
+- [ ] `node --experimental-vm-modules ./node_modules/.bin/jest --watchman=false --runTestsByPath test/toys/2026-05-28/memoryScalarVectorWrite.test.js` exits with status 0.
+- [ ] `npm test` exits with status 0 before closure.
+
+## Evidence Collection
+- Command log path: PR/testing notes and terminal output.
+- Generated artifacts:
+  - `public/blog.json`
+  - `public/index.html`
+  - `public/core/browser/toys/2026-05-28/memoryScalarVectorWrite.js`
+- Test report path (if applicable): Jest terminal output and coverage artifacts from `npm test`.
+
+## Pass/Fail Rules
+- Pass when the targeted MEMO3 test passes, full `npm test` passes, and generated blog metadata includes `MEMO3`.
+- Fail when any command exits non-zero, read-back via `MEMO2` is not covered by tests, or generated metadata omits `MEMO3`.

--- a/docs/toys/memory-scalar-vector-write/failure-modes.md
+++ b/docs/toys/memory-scalar-vector-write/failure-modes.md
@@ -1,0 +1,42 @@
+# Failure Modes: Memory Scalar/Vector Write
+
+## Initial Predicted Failure Classes
+- Setup/configuration mismatch:
+  - Blog metadata points at the wrong module path or function name.
+- Invalid or missing inputs:
+  - Non-object JSON, blank path, missing `value`, unsupported `memoryLocation`, or object leaf values.
+- Dependency/service unavailable:
+  - Missing `setLocalTemporaryData` or `setLocalPermanentData` helper in the toy environment.
+- Non-deterministic timing or ordering:
+  - Read-back assertions must use the same in-memory env instance immediately after the write.
+- Environment-specific behavior:
+  - Sparse arrays serialize `undefined` slots as `null` in JSON, so tests should validate read-back through `MEMO2` rather than relying only on raw JSON string shape.
+
+## Detection Signals
+- Error signatures/log lines:
+  - `Input must be a JSON object write request.`
+  - `A non-empty path or key is required.`
+  - `A value property is required.`
+  - `Value must be a scalar or vector array.`
+  - `Unsupported memoryLocation`
+  - `Missing toy helper`
+- Observable symptoms:
+  - `MEMO2` cannot find the path after a reported successful write.
+  - Sibling memory entries disappear after an update.
+- Failing command(s):
+  - `node --experimental-vm-modules ./node_modules/.bin/jest --watchman=false --runTestsByPath test/toys/2026-05-28/memoryScalarVectorWrite.test.js`
+  - `npm test`
+
+## First-Response Playbook
+1. Capture failing command and full output.
+2. Confirm the normalized request (`memoryLocation`, `path`, `value`) in the failing test.
+3. Inspect whether the writer selected the expected persistence helper for `temporary`, `permanent`, or `envelope`.
+4. Re-run `MEMO2` against the written path in the same env fixture to separate write failure from read-back failure.
+5. Add or adjust a focused Jest case before changing production logic.
+
+## Promoted from Real Failures
+- Date: 2026-05-30
+- Failure observed: Numeric path construction created an object at `matrix.0` rather than an array for `matrix.0.1`.
+- Root cause: Parent-container creation looked only at sliced parent segments, so the final leaf segment was not visible when choosing the container shape.
+- Fix implemented: Parent resolution now passes the next segment from the complete path segment list.
+- Guardrail added: Targeted Jest coverage for `matrix.0.1` construction plus `MEMO2` read-back.

--- a/docs/toys/memory-scalar-vector-write/harness.md
+++ b/docs/toys/memory-scalar-vector-write/harness.md
@@ -1,0 +1,24 @@
+# Harness: Memory Scalar/Vector Write
+
+## Local Run Instructions
+1. Install prerequisites: `npm install`
+2. Prepare fixtures/config: no external fixtures required; tests create in-memory toy env maps.
+3. Run harness command: `node --experimental-vm-modules ./node_modules/.bin/jest --watchman=false --runTestsByPath test/toys/2026-05-28/memoryScalarVectorWrite.test.js`
+4. Run full closure check: `npm test`
+5. Regenerate static output: `npm run build`
+
+## Expected Observable Outputs
+- Terminal output should include:
+  - `PASS test/toys/2026-05-28/memoryScalarVectorWrite.test.js`
+  - `MEMO3` in generated blog metadata after build
+- Artifacts written to:
+  - `public/blog.json`
+  - `public/index.html`
+  - `public/core/browser/toys/2026-05-28/memoryScalarVectorWrite.js`
+- Exit code:
+  - `0`
+
+## Troubleshooting Hooks
+- Verbose mode command: `node --experimental-vm-modules ./node_modules/.bin/jest --watchman=false --runTestsByPath test/toys/2026-05-28/memoryScalarVectorWrite.test.js --verbose`
+- Log location: terminal output and Jest coverage artifacts from `npm test`.
+- Cleanup command: restore generated `public/` files with `git checkout -- public/` only if abandoning the change.

--- a/docs/toys/memory-scalar-vector-write/spec.md
+++ b/docs/toys/memory-scalar-vector-write/spec.md
@@ -1,0 +1,48 @@
+# Toy Spec: Memory Scalar/Vector Write
+
+## Summary
+- Toy name: Memory Scalar/Vector Write (`MEMO3`)
+- Owner: Dadeto toy loop
+- Last updated: 2026-05-30
+
+## Problem Statement
+- Provide a small write toy that can insert or update a JSON scalar or vector at an arbitrary dot-path key in the existing Dadeto memory locations.
+- Keep the write behavior easy to verify by reading the same memory location and path with `MEMO2`.
+
+## Boundary
+- Exercises the browser toy contract for stateful memory mutation while keeping inspection in the existing read-only `MEMO2` toy.
+
+## Scope
+- In scope:
+  - Accept JSON object requests with `memoryLocation`, `path` or `key`, and `value`.
+  - Default to temporary memory when `memoryLocation` is omitted.
+  - Support `temporary`, `permanent`, and full `envelope` memory locations.
+  - Permit scalar values (`null`, string, number, boolean) and vector values (JSON arrays).
+  - Create missing nested object or array containers along the requested dot path.
+  - Return structured JSON with write status, normalized location, path, and value or error.
+- Out of scope:
+  - Writing arbitrary object payloads as leaf values; object values are reserved for constructed containers.
+  - Escaped-dot path syntax for keys that literally contain `.`.
+  - Direct DOM mutation or output rendering customization.
+
+## Actors and Interfaces
+- Primary actor(s): Browser toy user, automated Jest harness.
+- Inputs: JSON object such as `{ "memoryLocation": "temporary", "path": "profile.name", "value": "Ada" }`.
+- Outputs: JSON write result; persisted memory state observable through `MEMO2`.
+
+## Assumptions and Constraints
+- Assumptions:
+  - `MEMO2` remains the canonical read-side validator for memory vector projections.
+  - The runtime provides the same storage helpers used by `MEMO1`/`MEMO2` for temporary, permanent, and envelope memory.
+- Constraints:
+  - Temporary and envelope writes must preserve an object with a `temporary` property so the existing persistence helper accepts the update.
+  - Permanent writes persist through `setLocalPermanentData`, whose public contract requires an object root.
+
+## Dependencies
+- Internal dependencies:
+  - `src/core/browser/toys/2026-05-28/memoryScalarVectorWrite.js`
+  - `src/core/browser/toys/2026-05-28/memoryVectorPairs.js`
+  - `src/build/blog.json`
+  - `test/toys/2026-05-28/memoryScalarVectorWrite.test.js`
+- External dependencies:
+  - Jest local unit-test runner.

--- a/notes/agents/2026-05-30-memo3-memory-write.md
+++ b/notes/agents/2026-05-30-memo3-memory-write.md
@@ -1,0 +1,6 @@
+# MEMO3 Memory Scalar/Vector Write
+
+- Unexpected hurdle: `bd` is required by repo workflow, but the command is not installed in this container (`/bin/bash: bd: command not found`), so loop evidence had to be retained in docs/tests/PR notes instead of bead comments.
+- Diagnosis path: started from existing `MEMO1`/`MEMO2` implementations and used `MEMO2` read-back tests to keep the new writer compatible with existing memory inspection behavior.
+- Chosen fix: added `memoryScalarVectorWrite` (`MEMO3`) as a JSON write toy for temporary, permanent, and envelope locations, with scalar/vector leaf validation and automatic object/array container construction.
+- Next-time guidance: when adding write-side memory behavior, include read-back assertions through the read-side toy in the same env fixture so persistence-helper mistakes show up as user-visible failures.

--- a/public/blog.json
+++ b/public/blog.json
@@ -1,6 +1,22 @@
 {
   "posts": [
     {
+      "key": "MEMO3",
+      "title": "Memory Scalar/Vector Write",
+      "publicationDate": "2026-05-30",
+      "content": [
+        "Writes a scalar or vector value into temporary, permanent, or full-envelope memory at a chosen dot path.",
+        "Missing intermediate containers are constructed automatically, including arrays when numeric path segments imply indexed storage.",
+        "Use MEMO2 after a write to inspect the target path and confirm the stored value is visible as a vector or key-value pair projection."
+      ],
+      "toy": {
+        "modulePath": "/core/browser/toys/2026-05-28/memoryScalarVectorWrite.js",
+        "functionName": "memoryScalarVectorWrite",
+        "defaultInputMethod": "textarea"
+      },
+      "tags": ["toy", "memory", "vector", "write", "json", "storage"]
+    },
+    {
       "key": "MEMO2",
       "title": "Memory Vector",
       "publicationDate": "2026-05-28",

--- a/public/index.html
+++ b/public/index.html
@@ -588,6 +588,99 @@
         </p>
       </div>
       <article
+        class="entry tag-toy tag-memory tag-vector tag-write tag-json tag-storage"
+        id="MEMO3"
+      >
+        <div class="key full-width">▄▄▄▄▄▄▄▄▄▄</div>
+        <div class="value full-width">
+          ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+        </div>
+        <div class="key article-title">MEMO3</div>
+        <div class="value">
+          <h2><a href="#MEMO3">Memory Scalar/Vector Write</a></h2>
+        </div>
+        <div class="key">pubAt</div>
+        <p class="value metadata">30 May 2026</p>
+        <div class="key">tags</div>
+        <p class="value metadata">
+          <a class="tag-toy">toy</a>, <a class="tag-memory">memory</a>,
+          <a class="tag-vector">vector</a>, <a class="tag-write">write</a>,
+          <a class="tag-json">json</a>, <a class="tag-storage">storage</a>
+        </p>
+        <div class="key">text</div>
+        <p class="value">
+          Writes a scalar or vector value into temporary, permanent, or
+          full-envelope memory at a chosen dot path.
+        </p>
+        <div class="key"></div>
+        <p class="value">
+          Missing intermediate containers are constructed automatically,
+          including arrays when numeric path segments imply indexed storage.
+        </p>
+        <div class="key"></div>
+        <p class="value">
+          Use MEMO2 after a write to inspect the target path and confirm the
+          stored value is visible as a vector or key-value pair projection.
+        </p>
+        <div class="key">in</div>
+        <div class="value">
+          <select class="input">
+            <option value="text">text</option>
+            <option value="textarea" selected>textarea</option>
+            <option value="file">file</option>
+            <option value="number">number</option>
+            <option value="real-hourly-wage">real-hourly-wage</option>
+            <option value="kv">kv</option>
+            <option value="blog-key">blog-key</option>
+            <option value="dendrite-story">dendrite-story</option>
+            <option value="dendrite-page">dendrite-page</option>
+            <option value="moderator-ratings">moderator-ratings</option>
+            <option value="keyboard-capture">keyboard-capture</option>
+            <option value="gamepad-capture">gamepad-capture</option>
+            <option value="gamepad-button-mapper">
+              gamepad-button-mapper
+            </option></select
+          ><input type="text" disabled />
+        </div>
+        <div class="key"></div>
+        <div class="value">
+          <button type="submit" disabled>Submit</button
+          ><label class="auto-submit-label"
+            ><input type="checkbox" class="auto-submit-checkbox" disabled />
+            Auto</label
+          >
+        </div>
+        <div class="key">out</div>
+        <div class="value">
+          <select class="output">
+            <option value="text">text</option>
+            <option value="pre">pre</option>
+            <option value="copy-to-clipboard">copy-to-clipboard</option>
+            <option value="ledger-ingest">ledger-ingest</option>
+            <option value="real-hourly-wage">real-hourly-wage</option>
+            <option value="joycon-mapping">joycon-mapping</option>
+            <option value="realtime-voice">realtime-voice</option>
+            <option value="tic-tac-toe">tic-tac-toe</option>
+            <option value="battleship-solitaire-fleet">
+              battleship-solitaire-fleet
+            </option>
+            <option value="battleship-solitaire-clues-presenter">
+              battleship-solitaire-clues-presenter
+            </option>
+          </select>
+          <div class="output warning">
+            <p>This toy requires Javascript to run.</p>
+          </div>
+        </div>
+        <script type="module">
+          window.addComponent(
+            'MEMO3',
+            '/core/browser/toys/2026-05-28/memoryScalarVectorWrite.js',
+            'memoryScalarVectorWrite'
+          );
+        </script>
+      </article>
+      <article
         class="entry tag-toy tag-memory tag-vector tag-pairs tag-json tag-inspection"
         id="MEMO2"
       >

--- a/src/build/blog.json
+++ b/src/build/blog.json
@@ -1,6 +1,22 @@
 {
   "posts": [
     {
+      "key": "MEMO3",
+      "title": "Memory Scalar/Vector Write",
+      "publicationDate": "2026-05-30",
+      "content": [
+        "Writes a scalar or vector value into temporary, permanent, or full-envelope memory at a chosen dot path.",
+        "Missing intermediate containers are constructed automatically, including arrays when numeric path segments imply indexed storage.",
+        "Use MEMO2 after a write to inspect the target path and confirm the stored value is visible as a vector or key-value pair projection."
+      ],
+      "toy": {
+        "modulePath": "/core/browser/toys/2026-05-28/memoryScalarVectorWrite.js",
+        "functionName": "memoryScalarVectorWrite",
+        "defaultInputMethod": "textarea"
+      },
+      "tags": ["toy", "memory", "vector", "write", "json", "storage"]
+    },
+    {
       "key": "MEMO2",
       "title": "Memory Vector",
       "publicationDate": "2026-05-28",

--- a/src/core/browser/toys/2026-05-28/memoryScalarVectorWrite.js
+++ b/src/core/browser/toys/2026-05-28/memoryScalarVectorWrite.js
@@ -1,0 +1,584 @@
+import { deepClone } from '../../browser-core.js';
+import {
+  normalizeMemoryLocation,
+  normalizeMemoryPath,
+} from './memoryVector.js';
+
+const SUPPORTED_WRITE_LOCATIONS = ['temporary', 'permanent', 'envelope'];
+
+/**
+ * Insert or update a scalar or vector value at a nested memory key.
+ * Missing intermediate containers are created as objects or arrays.
+ * @param {string} input JSON write request.
+ * @param {import('../browserToysCore.js').ToyEnv} env Environment helpers.
+ * @returns {string} JSON write result.
+ */
+export function memoryScalarVectorWrite(input, env) {
+  const request = parseMemoryWriteRequest(input);
+  if (request.error) {
+    return JSON.stringify(buildMemoryWriteError(request, request.error));
+  }
+
+  return JSON.stringify(writeMemoryValue(request, env));
+}
+
+/**
+ * Parse and normalize a MEMO3 write request.
+ * @param {string} input JSON write request.
+ * @returns {{ memoryLocation: string, path: string, value?: unknown, error?: string }} Normalized write request.
+ */
+function parseMemoryWriteRequest(input) {
+  const parsed = parseJsonObject(input);
+  if (!parsed.ok) {
+    return createMemoryWriteRequest('temporary', '', undefined, parsed.error);
+  }
+
+  return normalizeMemoryWriteRequest(parsed.value);
+}
+
+/**
+ * Normalize parsed JSON into the write request shape.
+ * @param {Record<string, unknown>} parsed Parsed request object.
+ * @returns {{ memoryLocation: string, path: string, value?: unknown, error?: string }} Normalized write request.
+ */
+function normalizeMemoryWriteRequest(parsed) {
+  const request = createMemoryWriteRequest(
+    normalizeMemoryLocation(parsed.memoryLocation),
+    normalizeMemoryPath(getPathCandidate(parsed)),
+    parsed.value
+  );
+
+  return validateMemoryWriteRequest(request, hasValueProperty(parsed));
+}
+
+/**
+ * Write the requested value into the selected memory location.
+ * @param {{ memoryLocation: string, path: string, value: unknown }} request Normalized write request.
+ * @param {import('../browserToysCore.js').ToyEnv} env Environment helpers.
+ * @returns {{ memoryLocation: string, path: string, written: boolean, value?: unknown, error?: string }} Write result.
+ */
+function writeMemoryValue(request, env) {
+  const writer = getMemoryWriter(request.memoryLocation);
+  if (!writer) {
+    return buildUnsupportedLocationError(request);
+  }
+
+  return runWriteAction(request, () => writer(request, env));
+}
+
+/**
+ * Execute a memory write and convert thrown errors into structured output.
+ * @param {{ memoryLocation: string, path: string, value: unknown }} request Normalized write request.
+ * @param {() => unknown} action Write action.
+ * @returns {{ memoryLocation: string, path: string, written: boolean, value?: unknown, error?: string }} Write result.
+ */
+function runWriteAction(request, action) {
+  try {
+    action();
+    return buildMemoryWriteSuccess(request);
+  } catch (error) {
+    return buildMemoryWriteError(request, formatThrownError(error));
+  }
+}
+
+/**
+ * Write into temporary memory.
+ * @param {{ path: string, value: unknown }} request Normalized write request.
+ * @param {import('../browserToysCore.js').ToyEnv} env Environment helpers.
+ */
+function writeTemporaryMemory(request, env) {
+  const envelope = readEnvelopeForWriting(env);
+  envelope.temporary = writePathValue(
+    getContainerRoot(envelope.temporary),
+    request
+  );
+  getRequiredEnvHelper(env, 'setLocalTemporaryData')(envelope);
+}
+
+/**
+ * Write into permanent memory.
+ * @param {{ path: string, value: unknown }} request Normalized write request.
+ * @param {import('../browserToysCore.js').ToyEnv} env Environment helpers.
+ */
+function writePermanentMemory(request, env) {
+  const permanent = readPermanentForWriting(env);
+  const updated = writePathValue(permanent, request);
+  getRequiredEnvHelper(env, 'setLocalPermanentData')(updated);
+}
+
+/**
+ * Write into the full memory envelope.
+ * @param {{ path: string, value: unknown }} request Normalized write request.
+ * @param {import('../browserToysCore.js').ToyEnv} env Environment helpers.
+ */
+function writeEnvelopeMemory(request, env) {
+  const envelope = readEnvelopeForWriting(env);
+  const updated = writePathValue(envelope, request);
+  ensureEnvelopeCanBePersisted(updated);
+  getRequiredEnvHelper(env, 'setLocalTemporaryData')(updated);
+}
+
+/**
+ * Return the writer for a supported memory location.
+ * @param {string} memoryLocation Memory location name.
+ * @returns {((request: { path: string, value: unknown }, env: import('../browserToysCore.js').ToyEnv) => void) | null} Writer function.
+ */
+function getMemoryWriter(memoryLocation) {
+  const writers = {
+    temporary: writeTemporaryMemory,
+    permanent: writePermanentMemory,
+    envelope: writeEnvelopeMemory,
+  };
+
+  return writers[memoryLocation] ?? null;
+}
+
+/**
+ * Insert a value into a cloned root at the requested path.
+ * @param {unknown} root Current memory root.
+ * @param {{ path: string, value: unknown }} request Write request.
+ * @returns {Record<string, unknown> | unknown[]} Updated root.
+ */
+function writePathValue(root, request) {
+  const segments = getPathSegments(request.path);
+  const nextRoot = deepClone(root);
+  const writableRoot = getWritableRoot(nextRoot, segments);
+  assignNestedValue(writableRoot, segments, request.value);
+  return writableRoot;
+}
+
+/**
+ * Assign the value to the final path segment, creating intermediate containers.
+ * @param {Record<string, unknown> | unknown[]} root Writable root.
+ * @param {string[]} segments Path segments.
+ * @param {unknown} value Value to assign.
+ */
+function assignNestedValue(root, segments, value) {
+  const parent = resolveParentContainer(root, segments);
+  assignContainerValue(parent, getLastSegment(segments), value);
+}
+
+/**
+ * Resolve the parent container that owns the final path segment.
+ * @param {Record<string, unknown> | unknown[]} root Writable root.
+ * @param {string[]} segments Path segments.
+ * @returns {Record<string, unknown> | unknown[]} Parent container.
+ */
+function resolveParentContainer(root, segments) {
+  return segments
+    .slice(0, -1)
+    .reduce(
+      (current, segment, index) =>
+        createNextContainer(current, segment, segments[index + 1]),
+      root
+    );
+}
+
+/**
+ * Resolve or create the next path container.
+ * @param {Record<string, unknown> | unknown[]} current Current container.
+ * @param {string} segment Path segment to resolve.
+ * @param {string} nextSegment Next path segment.
+ * @returns {Record<string, unknown> | unknown[]} Next container.
+ */
+function createNextContainer(current, segment, nextSegment) {
+  const existing = getContainerValue(current, segment);
+  if (isContainer(existing)) {
+    return existing;
+  }
+
+  const nextContainer = createContainerForSegment(nextSegment);
+  assignContainerValue(current, segment, nextContainer);
+  return nextContainer;
+}
+
+/**
+ * Get a child value from a container.
+ * @param {Record<string, unknown> | unknown[]} container Container to read.
+ * @param {string} segment Path segment.
+ * @returns {unknown} Child value.
+ */
+function getContainerValue(container, segment) {
+  assertWritableContainerSegment(container, segment);
+  return container[segment];
+}
+
+/**
+ * Assign a child value to a container.
+ * @param {Record<string, unknown> | unknown[]} container Container to mutate.
+ * @param {string} segment Path segment.
+ * @param {unknown} value Value to assign.
+ */
+function assignContainerValue(container, segment, value) {
+  assertWritableContainerSegment(container, segment);
+  container[segment] = value;
+}
+
+/**
+ * Ensure a path segment is writable for the current container type.
+ * @param {Record<string, unknown> | unknown[]} container Container to inspect.
+ * @param {string} segment Path segment.
+ */
+function assertWritableContainerSegment(container, segment) {
+  if (Array.isArray(container) && !isArrayIndexSegment(segment)) {
+    throw new Error(
+      `Cannot write non-numeric segment "${segment}" into an array.`
+    );
+  }
+}
+
+/**
+ * Read the current state envelope, falling back to an empty temporary envelope.
+ * @param {import('../browserToysCore.js').ToyEnv} env Environment helpers.
+ * @returns {Record<string, unknown>} Writable state envelope.
+ */
+function readEnvelopeForWriting(env) {
+  const envelope = callOptionalEnvHelper(env, 'getData');
+  if (!isObjectRecord(envelope)) {
+    return { temporary: {} };
+  }
+
+  return deepClone(envelope);
+}
+
+/**
+ * Read current permanent memory, falling back to an empty object.
+ * @param {import('../browserToysCore.js').ToyEnv} env Environment helpers.
+ * @returns {Record<string, unknown>} Writable permanent root.
+ */
+function readPermanentForWriting(env) {
+  const permanent = callOptionalEnvHelper(env, 'getLocalPermanentData');
+  if (!isObjectRecord(permanent)) {
+    return {};
+  }
+
+  return deepClone(permanent);
+}
+
+/**
+ * Ensure the full envelope can pass the temporary-state persistence contract.
+ * @param {Record<string, unknown> | unknown[]} envelope Candidate envelope.
+ */
+function ensureEnvelopeCanBePersisted(envelope) {
+  if (!isObjectRecord(envelope) || !Object.hasOwn(envelope, 'temporary')) {
+    throw new Error(
+      'Envelope writes must preserve an object with a temporary property.'
+    );
+  }
+}
+
+/**
+ * Return an object/array root or an empty object for invalid root candidates.
+ * @param {unknown} root Memory root candidate.
+ * @returns {Record<string, unknown> | unknown[]} Container root.
+ */
+function getContainerRoot(root) {
+  if (isContainer(root)) {
+    return deepClone(root);
+  }
+
+  return {};
+}
+
+/**
+ * Choose the root container shape from the first path segment.
+ * @param {unknown} root Cloned root candidate.
+ * @param {string[]} segments Path segments.
+ * @returns {Record<string, unknown> | unknown[]} Writable root.
+ */
+function getWritableRoot(root, segments) {
+  if (isContainer(root)) {
+    return root;
+  }
+
+  return createContainerForSegment(segments[0]);
+}
+
+/**
+ * Create the container that should own a path segment.
+ * @param {string} segment Upcoming path segment.
+ * @returns {Record<string, unknown> | unknown[]} New container.
+ */
+function createContainerForSegment(segment) {
+  if (isArrayIndexSegment(segment)) {
+    return [];
+  }
+
+  return {};
+}
+
+/**
+ * Validate a normalized write request.
+ * @param {{ memoryLocation: string, path: string, value?: unknown, error?: string }} request Request candidate.
+ * @param {boolean} hasValue Whether the input declared a value field.
+ * @returns {{ memoryLocation: string, path: string, value?: unknown, error?: string }} Validated request.
+ */
+function validateMemoryWriteRequest(request, hasValue) {
+  if (request.path.length === 0) {
+    return addRequestError(request, 'A non-empty path or key is required.');
+  }
+  if (!hasValue) {
+    return addRequestError(request, 'A value property is required.');
+  }
+  if (!isScalarOrVector(request.value)) {
+    return addRequestError(request, 'Value must be a scalar or vector array.');
+  }
+
+  return request;
+}
+
+/**
+ * Determine whether parsed input supplied a value field.
+ * @param {Record<string, unknown>} parsed Parsed request object.
+ * @returns {boolean} True when the value field exists.
+ */
+function hasValueProperty(parsed) {
+  return Object.hasOwn(parsed, 'value');
+}
+
+/**
+ * Parse input as a JSON object.
+ * @param {string} input JSON candidate.
+ * @returns {{ ok: true, value: Record<string, unknown> } | { ok: false, error: string }} Parse result.
+ */
+function parseJsonObject(input) {
+  try {
+    return requireParsedObject(JSON.parse(input));
+  } catch {
+    return { ok: false, error: 'Input must be a JSON object write request.' };
+  }
+}
+
+/**
+ * Require parsed input to be a JSON object.
+ * @param {unknown} value Parsed value.
+ * @returns {{ ok: true, value: Record<string, unknown> } | { ok: false, error: string }} Parse result.
+ */
+function requireParsedObject(value) {
+  if (isObjectRecord(value)) {
+    return { ok: true, value };
+  }
+
+  return { ok: false, error: 'Input must be a JSON object write request.' };
+}
+
+/**
+ * Build a normalized request record.
+ * @param {string} memoryLocation Target memory location.
+ * @param {string} path Target path.
+ * @param {unknown} value Value to write.
+ * @param {string} [error] Optional validation error.
+ * @returns {{ memoryLocation: string, path: string, value?: unknown, error?: string }} Request record.
+ */
+function createMemoryWriteRequest(memoryLocation, path, value, error) {
+  const request = {
+    memoryLocation,
+    path,
+    value,
+  };
+  if (error) {
+    request.error = error;
+  }
+
+  return request;
+}
+
+/**
+ * Add an error message to a request.
+ * @param {{ memoryLocation: string, path: string, value?: unknown }} request Request record.
+ * @param {string} error Error message.
+ * @returns {{ memoryLocation: string, path: string, value?: unknown, error: string }} Error request.
+ */
+function addRequestError(request, error) {
+  return { ...request, error };
+}
+
+/**
+ * Build a successful write response.
+ * @param {{ memoryLocation: string, path: string, value: unknown }} request Request record.
+ * @returns {{ memoryLocation: string, path: string, written: true, value: unknown }} Success response.
+ */
+function buildMemoryWriteSuccess(request) {
+  return {
+    memoryLocation: request.memoryLocation,
+    path: request.path,
+    written: true,
+    value: request.value,
+  };
+}
+
+/**
+ * Build an error response.
+ * @param {{ memoryLocation: string, path: string, value?: unknown }} request Request record.
+ * @param {string} error Error message.
+ * @returns {{ memoryLocation: string, path: string, written: false, error: string }} Error response.
+ */
+function buildMemoryWriteError(request, error) {
+  return {
+    memoryLocation: request.memoryLocation,
+    path: request.path,
+    written: false,
+    error,
+  };
+}
+
+/**
+ * Build an unsupported-location error response.
+ * @param {{ memoryLocation: string, path: string }} request Request record.
+ * @returns {{ memoryLocation: string, path: string, written: false, error: string }} Error response.
+ */
+function buildUnsupportedLocationError(request) {
+  return buildMemoryWriteError(
+    request,
+    `Unsupported memoryLocation "${request.memoryLocation}". Supported locations: ${SUPPORTED_WRITE_LOCATIONS.join(', ')}.`
+  );
+}
+
+/**
+ * Pick the best path candidate from a parsed object.
+ * @param {Record<string, unknown>} parsed Parsed request object.
+ * @returns {unknown} Path candidate.
+ */
+function getPathCandidate(parsed) {
+  if (parsed.path !== undefined) {
+    return parsed.path;
+  }
+
+  return parsed.key;
+}
+
+/**
+ * Split a normalized dot path into segments.
+ * @param {string} path Dot path.
+ * @returns {string[]} Path segments.
+ */
+function getPathSegments(path) {
+  return path.split('.');
+}
+
+/**
+ * Return the final segment from a path segment list.
+ * @param {string[]} segments Path segments.
+ * @returns {string} Final segment.
+ */
+function getLastSegment(segments) {
+  return segments[segments.length - 1];
+}
+
+/**
+ * Call an optional environment helper if it exists.
+ * @param {import('../browserToysCore.js').ToyEnv} env Environment helpers.
+ * @param {string} helperName Helper name.
+ * @returns {unknown} Helper return value or undefined.
+ */
+function callOptionalEnvHelper(env, helperName) {
+  const helper = getOptionalEnvHelper(env, helperName);
+  if (!helper) {
+    return undefined;
+  }
+
+  return helper();
+}
+
+/**
+ * Get an optional environment helper.
+ * @param {import('../browserToysCore.js').ToyEnv} env Environment helpers.
+ * @param {string} helperName Helper name.
+ * @returns {Function | null} Helper function or null.
+ */
+function getOptionalEnvHelper(env, helperName) {
+  const helper = env.get(helperName);
+  if (typeof helper === 'function') {
+    return helper;
+  }
+
+  return null;
+}
+
+/**
+ * Get a required environment helper.
+ * @param {import('../browserToysCore.js').ToyEnv} env Environment helpers.
+ * @param {string} helperName Helper name.
+ * @returns {Function} Helper function.
+ */
+function getRequiredEnvHelper(env, helperName) {
+  const helper = getOptionalEnvHelper(env, helperName);
+  if (!helper) {
+    throw new Error(`Missing toy helper "${helperName}"`);
+  }
+
+  return helper;
+}
+
+/**
+ * Determine whether a value can be assigned by MEMO3.
+ * @param {unknown} value Candidate value.
+ * @returns {boolean} True when scalar or vector.
+ */
+function isScalarOrVector(value) {
+  return isScalar(value) || Array.isArray(value);
+}
+
+/**
+ * Determine whether a value is a JSON scalar.
+ * @param {unknown} value Candidate value.
+ * @returns {boolean} True when scalar.
+ */
+function isScalar(value) {
+  return (
+    value === null || ['string', 'number', 'boolean'].includes(typeof value)
+  );
+}
+
+/**
+ * Determine whether a value is a writable object or array container.
+ * @param {unknown} value Candidate value.
+ * @returns {value is Record<string, unknown> | unknown[]} True when object or array.
+ */
+function isContainer(value) {
+  return Array.isArray(value) || isObjectRecord(value);
+}
+
+/**
+ * Determine whether a value is a non-array object record.
+ * @param {unknown} value Candidate value.
+ * @returns {value is Record<string, unknown>} True when non-null object record.
+ */
+function isObjectRecord(value) {
+  return typeof value === 'object' && Boolean(value) && !Array.isArray(value);
+}
+
+/**
+ * Determine whether a path segment is a valid array index.
+ * @param {string} segment Path segment.
+ * @returns {boolean} True when segment can index an array.
+ */
+function isArrayIndexSegment(segment) {
+  const index = Number(segment);
+  return Number.isInteger(index) && index >= 0 && String(index) === segment;
+}
+
+/**
+ * Format a thrown value as a string.
+ * @param {unknown} error Thrown value.
+ * @returns {string} Error message.
+ */
+function formatThrownError(error) {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error);
+}
+
+export const memoryScalarVectorWriteTestOnly = {
+  assignNestedValue,
+  buildMemoryWriteError,
+  buildMemoryWriteSuccess,
+  createContainerForSegment,
+  getMemoryWriter,
+  ensureEnvelopeCanBePersisted,
+  isScalarOrVector,
+  parseMemoryWriteRequest,
+  writePathValue,
+};

--- a/test/toys/2026-05-28/memoryScalarVectorWrite.test.js
+++ b/test/toys/2026-05-28/memoryScalarVectorWrite.test.js
@@ -1,0 +1,402 @@
+import { describe, expect, test } from '@jest/globals';
+import {
+  memoryScalarVectorWrite,
+  memoryScalarVectorWriteTestOnly,
+} from '../../../src/core/browser/toys/2026-05-28/memoryScalarVectorWrite.js';
+import { memoryVectorPairs } from '../../../src/core/browser/toys/2026-05-28/memoryVectorPairs.js';
+
+/**
+ * Create a toy environment backed by a mutable temporary state object.
+ * @param {Record<string, unknown>} initialTemporary Initial temporary memory.
+ * @returns {{ env: Map<string, Function>, state: Record<string, unknown> }} Env and state.
+ */
+function createTemporaryEnv(initialTemporary = {}) {
+  const state = { temporary: initialTemporary };
+  return {
+    env: new Map([
+      ['getData', () => state],
+      ['setLocalTemporaryData', nextState => Object.assign(state, nextState)],
+    ]),
+    state,
+  };
+}
+
+/**
+ * Create a toy environment backed by mutable permanent memory.
+ * @param {Record<string, unknown>} initialPermanent Initial permanent memory.
+ * @returns {{ env: Map<string, Function>, getPermanent: () => Record<string, unknown> }} Env and getter.
+ */
+function createPermanentEnv(initialPermanent = {}) {
+  let permanent = initialPermanent;
+  return {
+    env: new Map([
+      ['getLocalPermanentData', () => permanent],
+      [
+        'setLocalPermanentData',
+        nextPermanent => {
+          permanent = nextPermanent;
+          return permanent;
+        },
+      ],
+    ]),
+    getPermanent: () => permanent,
+  };
+}
+
+/**
+ * Serialize a toy request as JSON.
+ * @param {Record<string, unknown>} request Request object.
+ * @returns {string} JSON request payload.
+ */
+function writeRequest(request) {
+  return JSON.stringify(request);
+}
+
+describe('memoryScalarVectorWrite', () => {
+  test('inserts a scalar into a missing nested temporary path', () => {
+    const { env, state } = createTemporaryEnv();
+
+    expect(
+      JSON.parse(
+        memoryScalarVectorWrite(
+          writeRequest({ path: 'profile.name', value: 'Ada' }),
+          env
+        )
+      )
+    ).toEqual({
+      memoryLocation: 'temporary',
+      path: 'profile.name',
+      written: true,
+      value: 'Ada',
+    });
+    expect(state.temporary).toEqual({ profile: { name: 'Ada' } });
+    expect(JSON.parse(memoryVectorPairs('profile', env))).toEqual({
+      memoryLocation: 'temporary',
+      path: 'profile',
+      found: true,
+      vector: [{ key: 'name', value: 'Ada' }],
+    });
+  });
+
+  test('updates an existing scalar without discarding sibling memory', () => {
+    const { env, state } = createTemporaryEnv({
+      profile: { name: 'Ada', city: 'London' },
+    });
+
+    expect(
+      JSON.parse(
+        memoryScalarVectorWrite(
+          writeRequest({ path: 'profile.name', value: 'Grace' }),
+          env
+        )
+      )
+    ).toEqual({
+      memoryLocation: 'temporary',
+      path: 'profile.name',
+      written: true,
+      value: 'Grace',
+    });
+    expect(state.temporary).toEqual({
+      profile: { name: 'Grace', city: 'London' },
+    });
+  });
+
+  test('inserts a vector into permanent memory and memo2 can read it', () => {
+    const { env, getPermanent } = createPermanentEnv({ inventory: {} });
+
+    expect(
+      JSON.parse(
+        memoryScalarVectorWrite(
+          writeRequest({
+            memoryLocation: 'permanent',
+            key: 'inventory.slots',
+            value: ['tea', 'book'],
+          }),
+          env
+        )
+      )
+    ).toEqual({
+      memoryLocation: 'permanent',
+      path: 'inventory.slots',
+      written: true,
+      value: ['tea', 'book'],
+    });
+    expect(getPermanent()).toEqual({ inventory: { slots: ['tea', 'book'] } });
+    expect(
+      JSON.parse(
+        memoryVectorPairs(
+          writeRequest({
+            memoryLocation: 'permanent',
+            path: 'inventory.slots',
+          }),
+          env
+        )
+      )
+    ).toEqual({
+      memoryLocation: 'permanent',
+      path: 'inventory.slots',
+      found: true,
+      vector: ['tea', 'book'],
+    });
+  });
+
+  test('creates nested arrays when numeric segments imply array containers', () => {
+    const { env, state } = createTemporaryEnv();
+
+    memoryScalarVectorWrite(
+      writeRequest({ path: 'matrix.0.1', value: 42 }),
+      env
+    );
+
+    expect(state.temporary).toEqual({ matrix: [[undefined, 42]] });
+    expect(JSON.parse(memoryVectorPairs('matrix.0.1', env))).toEqual({
+      memoryLocation: 'temporary',
+      path: 'matrix.0.1',
+      found: true,
+      vector: [42],
+    });
+  });
+
+  test('starts temporary memory when getData is unavailable', () => {
+    let savedState;
+    const env = new Map([
+      [
+        'setLocalTemporaryData',
+        nextState => {
+          savedState = nextState;
+        },
+      ],
+    ]);
+
+    expect(
+      JSON.parse(
+        memoryScalarVectorWrite(
+          writeRequest({ path: 'profile.name', value: 'Ada' }),
+          env
+        )
+      )
+    ).toEqual({
+      memoryLocation: 'temporary',
+      path: 'profile.name',
+      written: true,
+      value: 'Ada',
+    });
+    expect(savedState).toEqual({ temporary: { profile: { name: 'Ada' } } });
+  });
+
+  test('replaces invalid temporary roots with object containers', () => {
+    const { env, state } = createTemporaryEnv('not-an-object');
+
+    memoryScalarVectorWrite(
+      writeRequest({ path: 'profile.name', value: 'Ada' }),
+      env
+    );
+
+    expect(state.temporary).toEqual({ profile: { name: 'Ada' } });
+  });
+
+  test('formats non-error thrown values from persistence helpers', () => {
+    const env = new Map([
+      ['getData', () => ({ temporary: {} })],
+      [
+        'setLocalTemporaryData',
+        () => {
+          throw 'string failure';
+        },
+      ],
+    ]);
+
+    expect(
+      JSON.parse(
+        memoryScalarVectorWrite(
+          writeRequest({ path: 'profile.name', value: 'Ada' }),
+          env
+        )
+      )
+    ).toEqual({
+      memoryLocation: 'temporary',
+      path: 'profile.name',
+      written: false,
+      error: 'string failure',
+    });
+  });
+
+  test('writes into the full envelope when requested', () => {
+    const { env, state } = createTemporaryEnv({ existing: true });
+
+    memoryScalarVectorWrite(
+      writeRequest({
+        memoryLocation: 'envelope',
+        path: 'scratch.answer',
+        value: true,
+      }),
+      env
+    );
+
+    expect(state).toEqual({
+      temporary: { existing: true },
+      scratch: { answer: true },
+    });
+    expect(
+      JSON.parse(
+        memoryVectorPairs(
+          writeRequest({ memoryLocation: 'envelope', path: 'scratch' }),
+          env
+        )
+      )
+    ).toEqual({
+      memoryLocation: 'envelope',
+      path: 'scratch',
+      found: true,
+      vector: [{ key: 'answer', value: true }],
+    });
+  });
+
+  test('rejects malformed requests', () => {
+    const env = new Map();
+
+    expect(JSON.parse(memoryScalarVectorWrite('{', env))).toEqual({
+      memoryLocation: 'temporary',
+      path: '',
+      written: false,
+      error: 'Input must be a JSON object write request.',
+    });
+    expect(JSON.parse(memoryScalarVectorWrite('[]', env))).toEqual({
+      memoryLocation: 'temporary',
+      path: '',
+      written: false,
+      error: 'Input must be a JSON object write request.',
+    });
+    expect(
+      JSON.parse(memoryScalarVectorWrite(writeRequest({ value: 'Ada' }), env))
+    ).toEqual({
+      memoryLocation: 'temporary',
+      path: '',
+      written: false,
+      error: 'A non-empty path or key is required.',
+    });
+    expect(
+      JSON.parse(memoryScalarVectorWrite(writeRequest({ path: 'a' }), env))
+    ).toEqual({
+      memoryLocation: 'temporary',
+      path: 'a',
+      written: false,
+      error: 'A value property is required.',
+    });
+    expect(
+      JSON.parse(
+        memoryScalarVectorWrite(
+          writeRequest({ path: 'a', value: { nested: true } }),
+          env
+        )
+      )
+    ).toEqual({
+      memoryLocation: 'temporary',
+      path: 'a',
+      written: false,
+      error: 'Value must be a scalar or vector array.',
+    });
+  });
+
+  test('returns structured errors for unsupported locations and missing helpers', () => {
+    expect(
+      JSON.parse(
+        memoryScalarVectorWrite(
+          writeRequest({ memoryLocation: 'moon', path: 'a', value: 1 }),
+          new Map()
+        )
+      )
+    ).toEqual({
+      memoryLocation: 'moon',
+      path: 'a',
+      written: false,
+      error:
+        'Unsupported memoryLocation "moon". Supported locations: temporary, permanent, envelope.',
+    });
+    expect(
+      JSON.parse(
+        memoryScalarVectorWrite(
+          writeRequest({ memoryLocation: 'permanent', path: 'a', value: 1 }),
+          new Map()
+        )
+      )
+    ).toEqual({
+      memoryLocation: 'permanent',
+      path: 'a',
+      written: false,
+      error: 'Missing toy helper "setLocalPermanentData"',
+    });
+  });
+
+  test('reports array segment type mismatches', () => {
+    const { env } = createTemporaryEnv({ matrix: [] });
+
+    expect(
+      JSON.parse(
+        memoryScalarVectorWrite(
+          writeRequest({ path: 'matrix.left', value: 1 }),
+          env
+        )
+      )
+    ).toEqual({
+      memoryLocation: 'temporary',
+      path: 'matrix.left',
+      written: false,
+      error: 'Cannot write non-numeric segment "left" into an array.',
+    });
+  });
+});
+
+describe('memoryScalarVectorWrite helpers', () => {
+  test('parses JSON object requests', () => {
+    expect(
+      memoryScalarVectorWriteTestOnly.parseMemoryWriteRequest(
+        writeRequest({ memoryLocation: ' permanent ', key: ' a.b ', value: 1 })
+      )
+    ).toEqual({ memoryLocation: 'permanent', path: 'a.b', value: 1 });
+  });
+
+  test('recognizes scalar and vector values', () => {
+    expect(memoryScalarVectorWriteTestOnly.isScalarOrVector(null)).toBe(true);
+    expect(memoryScalarVectorWriteTestOnly.isScalarOrVector('Ada')).toBe(true);
+    expect(memoryScalarVectorWriteTestOnly.isScalarOrVector([1, 2])).toBe(true);
+    expect(memoryScalarVectorWriteTestOnly.isScalarOrVector({ a: 1 })).toBe(
+      false
+    );
+  });
+
+  test('writes through primitive intermediate values by replacing containers', () => {
+    expect(
+      memoryScalarVectorWriteTestOnly.writePathValue(
+        { profile: 'Ada' },
+        { path: 'profile.name', value: 'Grace' }
+      )
+    ).toEqual({ profile: { name: 'Grace' } });
+  });
+
+  test('guards envelope persistence shape', () => {
+    expect(() =>
+      memoryScalarVectorWriteTestOnly.ensureEnvelopeCanBePersisted([])
+    ).toThrow(
+      'Envelope writes must preserve an object with a temporary property.'
+    );
+  });
+
+  test('creates a writable root when an existing root is primitive', () => {
+    expect(
+      memoryScalarVectorWriteTestOnly.writePathValue('Ada', {
+        path: '0.name',
+        value: 'Grace',
+      })
+    ).toEqual([{ name: 'Grace' }]);
+  });
+
+  test('creates array or object containers from upcoming path segments', () => {
+    expect(
+      memoryScalarVectorWriteTestOnly.createContainerForSegment('0')
+    ).toEqual([]);
+    expect(
+      memoryScalarVectorWriteTestOnly.createContainerForSegment('name')
+    ).toEqual({});
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide a writable counterpart to the existing MEMO read toys so callers can insert or update a scalar or vector at any arbitrary dot-path inside temporary, permanent, or envelope memory.  
- Ensure writes are inspectable with the existing MEMO2 read tool and that missing intermediate containers (objects or arrays) are constructed automatically.

### Description
- Add `src/core/browser/toys/2026-05-28/memoryScalarVectorWrite.js` implementing `memoryScalarVectorWrite(input, env)` which accepts a JSON write request and writes a scalar or vector at a normalized dot-path across `temporary`, `permanent`, and `envelope` memory locations.  
- Implement robust validation and error payloads for malformed JSON, blank paths, missing `value`, unsupported `memoryLocation`, and non-scalar/object leaf values, plus protective shape checks for envelope/persistent writes.  
- Add comprehensive Jest tests at `test/toys/2026-05-28/memoryScalarVectorWrite.test.js` covering insertion, updates, array construction from numeric segments, envelope writes, error cases, and helper branch coverage; export `memoryScalarVectorWriteTestOnly` helpers for focused assertions.  
- Ship toy docs under `docs/toys/memory-scalar-vector-write/` (`spec.md`, `acceptance.md`, `harness.md`, `failure-modes.md`) and register the toy in blog metadata so it appears as `MEMO3` in generated `public/blog.json`/`public/index.html`.

### Testing
- Ran the focused toy test: `node --experimental-vm-modules ./node_modules/.bin/jest --watchman=false --runTestsByPath test/toys/2026-05-28/memoryScalarVectorWrite.test.js` — all tests passed.  
- Ran full suite: `npm test` — all test suites passed (no regressions).  
- Verified build/output generation: `npm run build` completed and `MEMO3` appears in generated `public/index.html`/`public/blog.json`.  
- Linting: `npx eslint . --fix --max-warnings=0 --no-color` completed with fixes applied and no remaining warnings for the added files.  
- Note: repository helper `bd` was not available in this environment so bead comments/sync could not be recorded; the loop evidence is preserved in the toy tests, docs under `docs/toys/memory-scalar-vector-write/`, and `notes/agents/2026-05-30-memo3-memory-write.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a8e58f320832eaeea39054800587e)