### PR TITLE
Add production-gated Codex administration VM and infra tests

### DIFF
--- a/.github/workflows/gcp-prod.yml
+++ b/.github/workflows/gcp-prod.yml
@@ -25,6 +25,8 @@ jobs:
       TF_VAR_openai_api_key: ${{ secrets.OPENAI_API_KEY }}
       TF_VAR_production_alert_email: ${{ secrets.PRODUCTION_ALERT_EMAIL }}
       TF_VAR_create_default_firestore_database: 'false'
+      TF_VAR_codex_vm_enabled: 'true'
+      TF_VAR_codex_admin_member: ${{ secrets.CODEX_ADMIN_MEMBER }}
 
     steps:
       - name: Checkout repo

--- a/infra/codex-vm.tf
+++ b/infra/codex-vm.tf
@@ -1,0 +1,147 @@
+locals {
+  codex_vm_enabled = var.codex_vm_enabled && var.environment == "prod"
+  codex_vm_tag     = "codex-vm"
+}
+
+resource "google_project_service" "iap" {
+  count = local.codex_vm_enabled ? 1 : 0
+
+  project            = var.project_id
+  service            = "iap.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "oslogin" {
+  count = local.codex_vm_enabled ? 1 : 0
+
+  project            = var.project_id
+  service            = "oslogin.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_compute_network" "codex" {
+  count = local.codex_vm_enabled ? 1 : 0
+
+  name                    = "codex"
+  auto_create_subnetworks = false
+
+  depends_on = [google_project_service.compute]
+}
+
+resource "google_compute_subnetwork" "codex" {
+  count = local.codex_vm_enabled ? 1 : 0
+
+  name          = "codex"
+  region        = var.region
+  network       = google_compute_network.codex[0].id
+  ip_cidr_range = "10.20.0.0/28"
+}
+
+resource "google_compute_firewall" "codex_iap_ssh" {
+  count = local.codex_vm_enabled ? 1 : 0
+
+  name          = "codex-iap-ssh"
+  network       = google_compute_network.codex[0].name
+  direction     = "INGRESS"
+  source_ranges = ["35.235.240.0/20"]
+  target_tags   = [local.codex_vm_tag]
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+}
+
+resource "google_service_account" "codex_vm" {
+  count = local.codex_vm_enabled ? 1 : 0
+
+  account_id   = "codex-vm"
+  display_name = "Codex VM"
+  description  = "Identity for the production Codex administration VM; intentionally has no project-level roles"
+}
+
+resource "google_service_account_iam_member" "terraform_can_use_codex_vm" {
+  count = local.codex_vm_enabled ? 1 : 0
+
+  service_account_id = google_service_account.codex_vm[0].name
+  role               = "roles/iam.serviceAccountUser"
+  member             = local.terraform_service_account_member
+}
+
+resource "google_service_account_iam_member" "administrator_can_use_codex_vm" {
+  count = local.codex_vm_enabled ? 1 : 0
+
+  service_account_id = google_service_account.codex_vm[0].name
+  role               = "roles/iam.serviceAccountUser"
+  member             = var.codex_admin_member
+}
+
+locals {
+  codex_administrator_roles = toset([
+    "roles/compute.instanceAdmin.v1",
+    "roles/compute.osAdminLogin",
+    "roles/iap.tunnelResourceAccessor",
+  ])
+}
+
+resource "google_project_iam_member" "codex_administrator" {
+  for_each = local.codex_vm_enabled ? local.codex_administrator_roles : toset([])
+
+  project = var.project_id
+  role    = each.value
+  member  = var.codex_admin_member
+}
+
+resource "google_compute_instance" "codex_vm" {
+  count = local.codex_vm_enabled ? 1 : 0
+
+  name         = "codex-vm"
+  zone         = var.codex_vm_zone
+  machine_type = var.codex_vm_machine_type
+  tags         = [local.codex_vm_tag]
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-12"
+      size  = var.codex_vm_disk_size_gb
+      type  = "pd-balanced"
+    }
+  }
+
+  network_interface {
+    subnetwork = google_compute_subnetwork.codex[0].id
+
+    # The address is outbound-only and deliberately omitted from Terraform outputs.
+    access_config {}
+  }
+
+  metadata = {
+    enable-oslogin         = "TRUE"
+    block-project-ssh-keys = "TRUE"
+  }
+
+  service_account {
+    email  = google_service_account.codex_vm[0].email
+    scopes = ["cloud-platform"]
+  }
+
+  shielded_instance_config {
+    enable_secure_boot          = true
+    enable_vtpm                 = true
+    enable_integrity_monitoring = true
+  }
+
+  lifecycle {
+    precondition {
+      condition     = var.codex_admin_member != ""
+      error_message = "codex_admin_member must be configured when the Codex VM is enabled in production."
+    }
+  }
+
+  depends_on = [
+    google_project_service.iap,
+    google_project_service.oslogin,
+    google_service_account_iam_member.terraform_can_use_codex_vm,
+    google_service_account_iam_member.administrator_can_use_codex_vm,
+  ]
+}

--- a/infra/load-balancer.tf
+++ b/infra/load-balancer.tf
@@ -11,7 +11,7 @@ variable "lb_cert_domains" {
 }
 
 resource "google_project_service" "compute" {
-  count              = local.enable_lb || local.playwright_enabled ? 1 : 0
+  count              = local.enable_lb || local.playwright_enabled || local.codex_vm_enabled ? 1 : 0
   project            = var.project_id
   service            = "compute.googleapis.com"
   disable_on_destroy = false

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -68,17 +68,18 @@ locals {
     terraform_network_admin  = "roles/compute.networkAdmin"
   }
   terraform_service_account_roles = {
-    firestore_access                = "roles/datastore.user"
-    cloudfunctions_access           = "roles/cloudfunctions.developer"
-    terraform_cloudfunctions_viewer = "roles/cloudfunctions.viewer"
-    terraform_set_iam_policy        = "roles/cloudfunctions.admin"
-    terraform_create_sa             = "roles/iam.serviceAccountAdmin"
-    terraform_cloudscheduler_admin  = "roles/cloudscheduler.admin"
-    monitoring_editor               = "roles/monitoring.editor"
-    monitoring_channel_editor       = "roles/monitoring.notificationChannelEditor"
-    logging_config_writer           = "roles/logging.configWriter"
-    ci_firebaserules_admin          = "roles/firebaserules.admin"
-    terraform_loadbalancer_admin    = "roles/compute.loadBalancerAdmin"
+    firestore_access                 = "roles/datastore.user"
+    cloudfunctions_access            = "roles/cloudfunctions.developer"
+    terraform_cloudfunctions_viewer  = "roles/cloudfunctions.viewer"
+    terraform_set_iam_policy         = "roles/cloudfunctions.admin"
+    terraform_create_sa              = "roles/iam.serviceAccountAdmin"
+    terraform_cloudscheduler_admin   = "roles/cloudscheduler.admin"
+    monitoring_editor                = "roles/monitoring.editor"
+    monitoring_channel_editor        = "roles/monitoring.notificationChannelEditor"
+    logging_config_writer            = "roles/logging.configWriter"
+    ci_firebaserules_admin           = "roles/firebaserules.admin"
+    terraform_loadbalancer_admin     = "roles/compute.loadBalancerAdmin"
+    terraform_compute_instance_admin = "roles/compute.instanceAdmin.v1"
   }
   cloud_function_service_keys = [
     "cloudfunctions",

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -44,3 +44,18 @@ output "lb_ip" {
   description = "Global LB IPv4"
   value       = local.enable_lb ? google_compute_global_address.dendrite[0].address : null
 }
+
+output "codex_vm_name" {
+  description = "Name of the production Codex administration VM"
+  value       = local.codex_vm_enabled ? google_compute_instance.codex_vm[0].name : null
+}
+
+output "codex_vm_zone" {
+  description = "Zone of the production Codex administration VM"
+  value       = local.codex_vm_enabled ? google_compute_instance.codex_vm[0].zone : null
+}
+
+output "codex_vm_internal_ip" {
+  description = "Internal IP address of the production Codex administration VM"
+  value       = local.codex_vm_enabled ? google_compute_instance.codex_vm[0].network_interface[0].network_ip : null
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -96,6 +96,46 @@ variable "enable_lb" {
   default     = true
 }
 
+variable "codex_vm_enabled" {
+  description = "Whether to provision the production Codex administration VM"
+  type        = bool
+  default     = false
+}
+
+variable "codex_vm_zone" {
+  description = "Compute Engine zone for the Codex administration VM"
+  type        = string
+  default     = "europe-west1-b"
+}
+
+variable "codex_vm_machine_type" {
+  description = "Machine type for the Codex administration VM"
+  type        = string
+  default     = "e2-small"
+}
+
+variable "codex_vm_disk_size_gb" {
+  description = "Boot disk size in GiB for the Codex administration VM"
+  type        = number
+  default     = 20
+
+  validation {
+    condition     = var.codex_vm_disk_size_gb >= 10
+    error_message = "codex_vm_disk_size_gb must be at least 10 GiB."
+  }
+}
+
+variable "codex_admin_member" {
+  description = "IAM user or group permitted to administer the Codex VM"
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = var.codex_admin_member == "" || can(regex("^(user|group):[^@\\s]+@[^@\\s]+$", var.codex_admin_member))
+    error_message = "codex_admin_member must be empty or an IAM member beginning with user: or group:."
+  }
+}
+
 variable "project_level_environment" {
   description = "Environment that manages project-level singleton resources"
   type        = string

--- a/notes/agents/2026-07-22-codex-vm-terraform.md
+++ b/notes/agents/2026-07-22-codex-vm-terraform.md
@@ -1,0 +1,9 @@
+# Codex VM Terraform loop
+
+- **Loop contract:** If every Codex VM resource is gated by an explicit production-only local, static policy tests should prove that test environments remain unchanged while production can opt in through the deployment workflow.
+- **Acceptance evidence:** `terraform fmt -check -recursive infra`, the focused Codex VM Jest test, and `npm run check`.
+- **Unexpected hurdle:** The repository's required `bd` executable was unavailable, and the user explicitly asked to continue without it.
+- **Diagnosis:** Existing infrastructure tests characterize Terraform as source text, which provides deterministic coverage without requiring GCP credentials or a remote backend.
+- **Fix:** Added a dedicated production-gated Terraform module and static policy tests for the security boundaries that must not regress.
+- **Evidence:** `npx jest test/infra/codexVmTerraform.test.js test/scripts/gcp-prod-workflow.test.js --runInBand --coverage=false` passed (2 suites, 6 tests); `/tmp/terraform-bin/terraform init -backend=false -input=false && /tmp/terraform-bin/terraform validate` passed with Terraform 1.13.3; `npm run check` reached passing lint, dependency, parse, duplication, entrypoint, thin-file, export, and TSDoc checks but could not pass because the pre-existing dependency audit reports eight high-severity transitive advisories and `test/core/local/gcp-simulator/payment-webhook-route.test.js` times out under the repository's Node 24 runtime. The focused simulator rerun reproduced both timeouts independently of this Terraform-only change.
+- **Next time:** Keep the external address intentionally output-free and add any future VM permissions to administrator bindings, not to the VM service account.

--- a/test/infra/codexVmTerraform.test.js
+++ b/test/infra/codexVmTerraform.test.js
@@ -1,0 +1,54 @@
+import { readFileSync } from 'node:fs';
+
+const CODEX_VM_PATH = 'infra/codex-vm.tf';
+
+describe('Codex VM Terraform policy', () => {
+  const codexVm = readFileSync(CODEX_VM_PATH, 'utf8');
+  const allInfra = [
+    codexVm,
+    readFileSync('infra/main.tf', 'utf8'),
+    readFileSync('infra/load-balancer.tf', 'utf8'),
+    readFileSync('infra/outputs.tf', 'utf8'),
+    readFileSync('infra/variables.tf', 'utf8'),
+  ].join('\n');
+
+  it('creates resources only when explicitly enabled in production', () => {
+    expect(codexVm).toContain(
+      'codex_vm_enabled = var.codex_vm_enabled && var.environment == "prod"'
+    );
+    expect(codexVm).not.toMatch(/count\s*=\s*var\.codex_vm_enabled/);
+    expect(codexVm).not.toMatch(/for_each\s*=\s*var\.codex_vm_enabled/);
+
+    const workflow = readFileSync('.github/workflows/gcp-prod.yml', 'utf8');
+    expect(workflow).toContain("TF_VAR_codex_vm_enabled: 'true'");
+    expect(workflow).toContain(
+      'TF_VAR_codex_admin_member: ${{ secrets.CODEX_ADMIN_MEMBER }}'
+    );
+    expect(readFileSync('infra/prod.auto.tfvars', 'utf8')).not.toContain(
+      'codex_vm_enabled'
+    );
+  });
+
+  it('limits inbound SSH to IAP and the VM network tag', () => {
+    expect(codexVm).toContain('source_ranges = ["35.235.240.0/20"]');
+    expect(codexVm).toContain('ports    = ["22"]');
+    expect(codexVm).toContain('target_tags   = [local.codex_vm_tag]');
+  });
+
+  it('requires OS Login and blocks project SSH keys', () => {
+    expect(codexVm).toContain('enable-oslogin         = "TRUE"');
+    expect(codexVm).toContain('block-project-ssh-keys = "TRUE"');
+  });
+
+  it('does not grant project roles to the VM service account', () => {
+    expect(allInfra).not.toMatch(
+      /google_project_iam_member[\s\S]{0,500}member\s*=\s*"serviceAccount:\$\{google_service_account\.codex_vm/
+    );
+  });
+
+  it('does not expose the ephemeral external address as an output', () => {
+    expect(readFileSync('infra/outputs.tf', 'utf8')).not.toMatch(
+      /output\s+"codex_vm_external_ip"/
+    );
+  });
+});


### PR DESCRIPTION
### Motivation

- Provide a provisioned, secure administration VM for Codex in production that is opt-in via the deployment workflow and gated to prevent accidental creation in test environments.
- Enforce security boundaries (IAP-only SSH, OS Login, no project-level roles on the VM service account) via Terraform and static policy checks.
- Make the deployment reproducible from CI by wiring the GH Actions prod workflow to set the necessary TF vars for opt-in provisioning.

### Description

- Added a new Terraform module `infra/codex-vm.tf` that provisions network, subnetwork, firewall, service account, IAM bindings, and a hardened `google_compute_instance` for the Codex VM gated by `local.codex_vm_enabled = var.codex_vm_enabled && var.environment == "prod"`.
- Introduced variables in `infra/variables.tf` for `codex_vm_enabled`, `codex_vm_zone`, `codex_vm_machine_type`, `codex_vm_disk_size_gb`, and `codex_admin_member` with validations, and added `terraform_compute_instance_admin` to `locals.terraform_service_account_roles` in `infra/main.tf`.
- Updated `infra/load-balancer.tf` to include `local.codex_vm_enabled` in the `google_project_service.compute` creation condition and added outputs in `infra/outputs.tf` for `codex_vm_name`, `codex_vm_zone`, and `codex_vm_internal_ip` while intentionally not exposing an external IP output.
- Updated the GitHub Actions prod workflow `.github/workflows/gcp-prod.yml` to set `TF_VAR_codex_vm_enabled: 'true'` and `TF_VAR_codex_admin_member: ${{ secrets.CODEX_ADMIN_MEMBER }}` for the production deployment path.
- Added a focused static test `test/infra/codexVmTerraform.test.js` that asserts the production-only gating, IAP-only SSH, OS Login enforcement, no project roles for the VM SA, and absence of an external IP output, and included rollout notes at `notes/agents/2026-07-22-codex-vm-terraform.md`.

### Testing

- Ran the focused Jest tests with `npx jest test/infra/codexVmTerraform.test.js test/scripts/gcp-prod-workflow.test.js --runInBand --coverage=false` and they passed (2 suites, 6 tests).
- Performed a local Terraform smoke check with `/tmp/terraform-bin/terraform init -backend=false -input=false && /tmp/terraform-bin/terraform validate` using Terraform 1.13.3 and it passed.
- Executed `npm run check` which advanced through linting and many repository checks but could not fully complete due to unrelated pre-existing issues: a dependency audit reporting transitive advisories and a flaky simulator test timing out, so the full suite was not completed in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a60c343ccf0832ea111152aa07f05d0)