### PR TITLE
Guard Codex VM provisioning when the admin secret is unset

### DIFF
--- a/.github/workflows/gcp-prod.yml
+++ b/.github/workflows/gcp-prod.yml
@@ -25,7 +25,7 @@ jobs:
       TF_VAR_openai_api_key: ${{ secrets.OPENAI_API_KEY }}
       TF_VAR_production_alert_email: ${{ secrets.PRODUCTION_ALERT_EMAIL }}
       TF_VAR_create_default_firestore_database: 'false'
-      TF_VAR_codex_vm_enabled: 'true'
+      TF_VAR_codex_vm_enabled: ${{ secrets.CODEX_ADMIN_MEMBER != '' }}
       TF_VAR_codex_admin_member: ${{ secrets.CODEX_ADMIN_MEMBER }}
 
     steps:

--- a/infra/codex-vm.tf
+++ b/infra/codex-vm.tf
@@ -1,5 +1,5 @@
 locals {
-  codex_vm_enabled = var.codex_vm_enabled && var.environment == "prod"
+  codex_vm_enabled = var.codex_vm_enabled && var.environment == "prod" && var.codex_admin_member != ""
   codex_vm_tag     = "codex-vm"
 }
 
@@ -129,13 +129,6 @@ resource "google_compute_instance" "codex_vm" {
     enable_secure_boot          = true
     enable_vtpm                 = true
     enable_integrity_monitoring = true
-  }
-
-  lifecycle {
-    precondition {
-      condition     = var.codex_admin_member != ""
-      error_message = "codex_admin_member must be configured when the Codex VM is enabled in production."
-    }
   }
 
   depends_on = [

--- a/notes/agents/codex-vm-empty-admin-member.md
+++ b/notes/agents/codex-vm-empty-admin-member.md
@@ -1,0 +1,6 @@
+# Codex VM empty administrator member
+
+- **Unexpected hurdle:** GitHub Actions supplies an unset repository secret as an empty string, while the production workflow unconditionally enabled the Codex VM.
+- **Diagnosis path:** The Terraform error pointed to the project IAM member. Tracing `codex_admin_member` showed that the variable deliberately permits an empty default for non-VM environments, but the production workflow still set `codex_vm_enabled` to `true`.
+- **Chosen fix:** Derive the workflow's VM-enabled flag from the presence of `CODEX_ADMIN_MEMBER`, and include the non-empty member in Terraform's shared enablement condition so every VM and IAM resource uses the same guard.
+- **Next-time guidance:** Optional infrastructure that requires a secret should use the secret's presence to gate the whole resource group; do not rely on a resource precondition that Terraform may evaluate after provider argument validation.

--- a/test/infra/codexVmTerraform.test.js
+++ b/test/infra/codexVmTerraform.test.js
@@ -20,12 +20,20 @@ describe('Codex VM Terraform policy', () => {
     expect(codexVm).not.toMatch(/for_each\s*=\s*var\.codex_vm_enabled/);
 
     const workflow = readFileSync('.github/workflows/gcp-prod.yml', 'utf8');
-    expect(workflow).toContain("TF_VAR_codex_vm_enabled: 'true'");
+    expect(workflow).toContain(
+      "TF_VAR_codex_vm_enabled: ${{ secrets.CODEX_ADMIN_MEMBER != '' }}"
+    );
     expect(workflow).toContain(
       'TF_VAR_codex_admin_member: ${{ secrets.CODEX_ADMIN_MEMBER }}'
     );
     expect(readFileSync('infra/prod.auto.tfvars', 'utf8')).not.toContain(
       'codex_vm_enabled'
+    );
+  });
+
+  it('does not create IAM resources without an administrator member', () => {
+    expect(codexVm).toContain(
+      'var.environment == "prod" && var.codex_admin_member != ""'
     );
   });
 


### PR DESCRIPTION
### Motivation

- Prevent Terraform from receiving an empty IAM `member` value when the GitHub secret for the Codex VM administrator is unset, which previously caused `terraform apply` to fail.
- Ensure the production workflow only enables the Codex VM when an administrator member is actually provided so IAM resources are never created with an invalid empty member.

### Description

- Change the production workflow to set `TF_VAR_codex_vm_enabled` based on the presence of the `CODEX_ADMIN_MEMBER` secret instead of unconditionally enabling it (`.github/workflows/gcp-prod.yml`).
- Tighten the Terraform enablement guard by requiring `var.codex_admin_member != ""` in the shared `codex_vm_enabled` local so the VM and all related IAM resources are omitted when the administrator member is empty (`infra/codex-vm.tf`).
- Remove the lifecycle precondition that attempted to validate the member inside the VM resource and instead gate resource creation via the shared enablement condition.
- Add regression assertions to `test/infra/codexVmTerraform.test.js` that validate the workflow-level guard and the Terraform-level guard, and add an agent retrospective note under `notes/agents/codex-vm-empty-admin-member.md` documenting the diagnosis and guidance.

### Testing

- `npx jest test/infra/codexVmTerraform.test.js --runInBand` — ran the infra tests for the change and they passed (6 tests passed).
- `npm run check` — ran the repository aggregate checks where the updated infra policy and many subsystems passed, but the aggregate gate reported existing dependency `npm audit` advisories and two unrelated `gcp-simulator/payment-webhook-route` Jest tests timed out and left open handles, which prevented a clean full-pass of the aggregate gate.
- `terraform` checks such as `terraform fmt -check` / `terraform validate` were not executed here because Terraform is not installed in the execution environment, so those formatting/validate steps were skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a60e7c87c5c832e927aabe74b9f6a40)